### PR TITLE
Reverts the medbay changes between Tegu and mainstream Bay

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -515,11 +515,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
 "abf" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/pager/robotics{
 	pixel_y = 30
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
@@ -553,6 +553,7 @@
 /area/medical/counselor)
 "abl" = (
 /obj/machinery/chemical_dispenser/full,
+/obj/effect/floor_decal/corner/beige/mono,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -560,7 +561,6 @@
 /obj/structure/sign/warning/nosmoking_1{
 	pixel_y = 24
 	},
-/obj/effect/floor_decal/corner/yellow/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "abm" = (
@@ -571,13 +571,14 @@
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/glass/beaker/insulated/large,
 /obj/item/reagent_containers/glass/beaker/large,
+/obj/effect/floor_decal/corner/beige/mono,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/yellow/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "abn" = (
+/obj/effect/floor_decal/corner/beige/mono,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "Pill Cabinet";
 	pixel_x = 0;
@@ -585,7 +586,6 @@
 	},
 /obj/machinery/reagentgrinder,
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/effect/floor_decal/corner/yellow/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "abo" = (
@@ -607,28 +607,31 @@
 /area/medical/morgue/autopsy)
 "abr" = (
 /obj/machinery/chem_master,
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/floor_decal/corner/yellow/mono,
+/obj/effect/floor_decal/corner/beige/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "abs" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 5;
+	icon_state = "corner_white"
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 10
+	},
 /obj/structure/bed/chair/comfy/blue{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/yellow/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "abt" = (
+/obj/effect/floor_decal/corner/beige/mono,
 /obj/structure/table/standard,
 /obj/machinery/reagent_temperature/cooler,
-/obj/effect/floor_decal/corner/yellow/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "abu" = (
 /obj/structure/table/standard,
+/obj/effect/floor_decal/corner/beige/mono,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -640,14 +643,19 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/reagent_temperature,
-/obj/effect/floor_decal/corner/yellow/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "abv" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/effect/floor_decal/corner/beige{
+	dir = 5;
+	icon_state = "corner_white"
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "abw" = (
@@ -695,7 +703,6 @@
 /obj/machinery/door/airlock/glass/medical{
 	name = "Chemistry"
 	},
-/obj/effect/floor_decal/corner/yellow/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "abz" = (
@@ -711,6 +718,10 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head/aux)
 "abA" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 5;
+	icon_state = "corner_white"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -722,10 +733,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/yellow/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "abB" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 5;
+	icon_state = "corner_white"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -737,10 +751,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/yellow/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "abC" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 5;
+	icon_state = "corner_white"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -752,10 +769,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/yellow/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "abD" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 5;
+	icon_state = "corner_white"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -764,7 +787,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/corner/yellow/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "abE" = (
@@ -775,10 +797,16 @@
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/firstdeck/forestarboard)
 "abG" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 5;
+	icon_state = "corner_white"
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/yellow/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "abH" = (
@@ -820,6 +848,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/development)
 "abK" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 10
+	},
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -827,12 +858,7 @@
 /obj/machinery/light_switch{
 	pixel_y = -22
 	},
-/obj/effect/floor_decal/corner/yellow/mono,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "abL" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -863,11 +889,9 @@
 /area/maintenance/firstdeck/centralstarboard)
 "abQ" = (
 /obj/machinery/disposal,
-/obj/effect/floor_decal/corner/yellow/mono,
+/obj/effect/floor_decal/corner/beige/mono,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "abR" = (
@@ -896,16 +920,24 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head/aux)
 "abT" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 10
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/structure/table/standard,
-/obj/effect/floor_decal/corner/yellow/mono,
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "abU" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 5;
+	icon_state = "corner_white"
+	},
 /obj/structure/bed/chair/padded,
-/obj/effect/floor_decal/corner/yellow/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "abV" = (
@@ -961,13 +993,13 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/firstdeck)
 "abZ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 6
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -997,21 +1029,25 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "ace" = (
-/obj/structure/table/rack{
+/obj/structure/closet/secure_closet/chemical,
+/obj/item/storage/box/pillbottles,
+/obj/item/device/radio/headset/headset_med,
+/obj/item/book/manual/chemistry_recipes,
+/obj/item/clothing/glasses/science,
+/obj/effect/floor_decal/corner/beige/mono,
+/obj/machinery/button/blast_door{
+	id_tag = "chemcounter";
+	name = "Chemistry Counter Lockdown Control";
+	pixel_x = -6;
+	pixel_y = -24
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "Infirmary - Chemistry";
 	dir = 8
 	},
-/obj/item/device/scanner/spectrometer,
-/obj/item/storage/box/freezer,
-/obj/item/storage/box/beakers/insulated,
-/obj/item/reagent_containers/dropper,
-/obj/item/storage/box/beakers,
-/obj/item/hand_labeler,
-/obj/item/stack/package_wrap/twenty_five,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
-	name = "Chemistry Cleaner"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
 	},
-/obj/effect/floor_decal/corner/yellow/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "acf" = (
@@ -1040,6 +1076,18 @@
 	dir = 4;
 	target_pressure = 15000
 	},
+/turf/simulated/floor/plating,
+/area/thruster/d1starboard)
+"aci" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/thruster/d1starboard)
 "acj" = (
@@ -1171,10 +1219,10 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 2
 	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
 "acv" = (
@@ -1204,6 +1252,9 @@
 /turf/simulated/floor/reinforced,
 /area/thruster/d1port)
 "acy" = (
+/obj/effect/floor_decal/corner/pink{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -1215,12 +1266,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 5
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
+"acz" = (
+/turf/simulated/wall/prepainted,
+/area/medical/medicalhallway)
 "acB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/steel_reinforced,
@@ -1337,7 +1387,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/freezer,
-/area/medical/washroom)
+/area/medical/medicalhallway)
 "acJ" = (
 /obj/structure/closet/crate/freezer,
 /obj/random/firstaid,
@@ -1372,6 +1422,7 @@
 /area/maintenance/firstdeck/aftstarboard)
 "acO" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -1379,10 +1430,6 @@
 	id_tag = "chemcounter";
 	name = "Chemistry Counter Shutters";
 	opacity = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/medical/chemistry)
@@ -1414,6 +1461,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
 "acU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -1422,10 +1473,6 @@
 	id_tag = "chemcounter";
 	name = "Chemistry Counter Shutters";
 	opacity = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/medical/chemistry)
@@ -1510,12 +1557,22 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/thruster/d1starboard)
+"add" = (
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 4;
+	target_pressure = 15000
+	},
+/obj/effect/floor_decal/industrial/outline/orange,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/thruster/d1starboard)
 "ade" = (
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
 "adf" = (
@@ -1577,18 +1634,21 @@
 	opacity = 0
 	},
 /obj/item/material/bell,
-/obj/effect/floor_decal/corner/yellow/mono,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "adj" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/firealarm{
 	dir = 2;
 	pixel_y = 24
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/medicalhallway)
 "adk" = (
@@ -1611,6 +1671,10 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head/aux)
 "adl" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/structure/bed/chair/padded/blue,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -1621,10 +1685,12 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "adm" = (
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -1635,17 +1701,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "adn" = (
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/computer/guestpass{
 	pixel_y = 32
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/medical/medicalhallway)
 "ado" = (
 /obj/machinery/light/small{
@@ -1673,11 +1734,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head/aux)
 "ads" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 9
-	},
+/obj/effect/floor_decal/corner/paleblue,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "adt" = (
@@ -1700,6 +1757,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "adu" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -1710,14 +1770,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10;
-	icon_state = "corner_white"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -1814,6 +1866,9 @@
 /turf/space,
 /area/space)
 "adB" = (
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1824,13 +1879,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	icon_state = "borderfloorcorner_white";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -1870,9 +1918,11 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
 "adH" = (
+/obj/effect/floor_decal/corner/paleblue/three_quarters,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 2
 	},
@@ -1891,19 +1941,19 @@
 	dir = 5;
 	icon_state = "intact"
 	},
-/obj/effect/floor_decal/corner/blue/three_quarters,
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	icon_state = "borderfloorcorner_white";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "adI" = (
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 4;
+	max_pressure_setting = 35000;
+	regulate_mode = 2;
+	target_pressure = 35000;
+	use_power = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
@@ -1918,6 +1968,9 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/safe_room/firstdeck)
 "adL" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1931,14 +1984,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -1954,7 +1999,48 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/forestarboard)
 "adO" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/machinery/button/alternate/door{
+	id_tag = "ETC_hall";
+	name = "Treatment Center Exit";
+	pixel_x = 7;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
+"adP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/obj/structure/railing/mapped,
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/forestarboard)
+"adQ" = (
+/obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/door/firedoor,
+/obj/structure/sign/directions/infm{
+	pixel_y = 32
+	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 4;
@@ -1977,53 +2063,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/firstaid/fulltile,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
-"adP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/obj/structure/railing/mapped,
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard)
-"adQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/sign/directions/infm{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medicalhallway)
 "adR" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10;
@@ -2114,6 +2155,82 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
 "aed" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medicalhallway)
+"aee" = (
+/obj/structure/hygiene/shower{
+	dir = 4;
+	icon_state = "shower"
+	},
+/obj/item/soap,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/head/aux)
+"aef" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/solgov,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/firstdeck/centralstarboard)
+"aeg" = (
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/centralstarboard)
+"aeh" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/dispenser{
+	oxygentanks = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/firstdeck/centralstarboard)
+"aei" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/item/reagent_containers/ivbag,
+/obj/item/reagent_containers/ivbag,
+/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "IV Equipment Cabinet";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
+"aej" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
 	name = "Chemistry";
@@ -2143,49 +2260,39 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
-"aee" = (
-/obj/structure/hygiene/shower{
-	dir = 4;
-	icon_state = "shower"
+"aek" = (
+/obj/machinery/optable,
+/obj/effect/floor_decal/floordetail/edgedrain{
+	dir = 1;
+	icon_state = "edge"
 	},
-/obj/item/soap,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/head/aux)
-"aef" = (
-/obj/structure/table/rack,
-/obj/random/maintenance/solgov,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/centralstarboard)
-"aeg" = (
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/centralstarboard)
-"aeh" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/dispenser{
-	oxygentanks = 0
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/centralstarboard)
-"aei" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/oxygen_pump{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/obj/machinery/body_scan_display{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"aej" = (
+/area/medical/surgery)
+"ael" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/device/radio/beacon,
+/turf/simulated/floor/tiled/white,
+/area/medical/medicalhallway)
+"aem" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/structure/disposalpipe/junction{
 	dir = 2;
 	icon_state = "pipe-j2"
@@ -2204,108 +2311,38 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medicalhallway)
-"aek" = (
-/obj/machinery/optable,
-/obj/effect/floor_decal/floordetail/edgedrain{
-	dir = 1;
-	icon_state = "edge"
-	},
-/obj/machinery/oxygen_pump{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/obj/machinery/body_scan_display{
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"ael" = (
-/obj/item/modular_computer/telescreen/preset/medical{
-	pixel_x = 32
-	},
-/obj/structure/bed/chair/padded/blue{
-	dir = 8;
-	icon_state = "chair_preview"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medicalhallway)
-"aem" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "aen" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/structure/sign/chemistry{
 	pixel_y = 32
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "aeo" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/light/spot{
 	dir = 1
 	},
@@ -2329,17 +2366,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "aep" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -2357,14 +2389,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
@@ -2413,6 +2437,9 @@
 /turf/simulated/wall/ocp_wall,
 /area/thruster/d1starboard)
 "aeu" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -2437,14 +2464,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "aev" = (
@@ -2458,6 +2477,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/security/brig)
 "aew" = (
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 2
 	},
@@ -2474,15 +2496,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10;
-	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
@@ -2554,6 +2567,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/firstdeck)
 "aeB" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2567,17 +2586,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	icon_state = "borderfloorcorner_white";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
@@ -2929,6 +2937,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
 "afa" = (
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -2945,26 +2957,31 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "afb" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/glass/medical{
+	dir = 4;
+	id_tag = "ETC_hall";
+	name = "Treatment Center"
 	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id_tag = "infirm_pub";
+	name = "Infirmary Public Hallway Lockdown";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medicalhallway)
+/turf/simulated/floor/tiled/white/monotile,
+/area/medical/sleeper)
 "afc" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -2972,47 +2989,39 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/firstaid,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "afd" = (
-/obj/effect/floor_decal/industrial/firstaid/corner{
-	icon_state = "stripecorner";
-	dir = 8
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 9;
+	icon_state = "spline_plain"
 	},
+/obj/structure/bed/roller,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "afe" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medicalhallway)
+"aff" = (
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 8;
-	icon_state = "corner_white"
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	icon_state = "borderfloorcorner_white";
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction/mirrored{
-	icon_state = "pipe-j2";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
-"aff" = (
+"afg" = (
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
+	},
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 2;
 	name = "Medical Foyer";
@@ -3020,34 +3029,28 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue,
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/turf/simulated/floor/tiled/white,
-/area/medical/medicalhallway)
-"afg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "afh" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medicalhallway)
+"afi" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
 /obj/machinery/camera/network/medbay{
 	c_tag = "Infirmary - Lobby";
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
@@ -3057,6 +3060,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/wing)
 "afk" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3067,21 +3073,27 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "afl" = (
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 1
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
 /turf/simulated/floor/tiled/white,
+/area/medical/medicalhallway)
+"afm" = (
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/structure/bed/chair/padded/blue{
+	dir = 8;
+	icon_state = "chair_preview"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
 /area/medical/medicalhallway)
 "afn" = (
 /obj/structure/closet/l3closet/general,
@@ -3096,6 +3108,7 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
 "afo" = (
+/obj/effect/wallframe_spawn/no_grille,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3107,19 +3120,18 @@
 	name = "Infirmary Window Lockdown";
 	opacity = 0
 	},
-/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/medical/foyer)
 "afp" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
@@ -3183,10 +3195,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "afu" = (
-/obj/effect/floor_decal/corner/blue,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
 "afv" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "south bump";
@@ -3195,10 +3212,6 @@
 /obj/structure/cable/green,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
@@ -3212,6 +3225,9 @@
 /turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
 "afx" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -3222,13 +3238,14 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
 "afy" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/structure/closet/crate/secure/biohazard/alt,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
@@ -3248,21 +3265,17 @@
 /turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
 "afB" = (
+/obj/structure/bed/roller,
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 5;
+	icon_state = "spline_plain"
+	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/structure/table/rack,
-/obj/item/roller{
-	pixel_y = 8
-	},
-/obj/item/roller{
-	pixel_y = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "afC" = (
 /obj/effect/floor_decal/techfloor{
@@ -3276,10 +3289,18 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/firstdeck)
 "afD" = (
+/obj/item/modular_computer/telescreen/preset/medical{
+	pixel_y = -32
+	},
 /obj/machinery/light/spot,
 /obj/structure/table/standard,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "afE" = (
 /obj/machinery/hologram/holopad,
@@ -3299,14 +3320,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/firstdeck)
 "afH" = (
-/obj/structure/bed/chair/comfy/blue,
-/obj/machinery/light{
-	dir = 1
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/item/modular_computer/telescreen/preset/medical{
+	pixel_y = 32
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
 "afI" = (
 /turf/simulated/wall/prepainted,
@@ -3325,10 +3345,14 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/firstdeck/fore)
 "afK" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/structure/table/standard,
-/obj/item/defibrillator/loaded,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "afL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3498,6 +3522,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
 "afY" = (
+/obj/machinery/vending/medical/torch{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/mono,
+/turf/simulated/floor/tiled/white/monotile,
+/area/medical/sleeper)
+"afZ" = (
+/obj/effect/wallframe_spawn/no_grille,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 4;
@@ -3506,21 +3538,20 @@
 	name = "Infirmary Window Lockdown";
 	opacity = 0
 	},
-/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/medical/sleeper)
 "aga" = (
 /obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/door/airlock/multi_tile/glass/medical{
 	id_tag = "ETC_stage";
 	name = "Treatment Center"
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/firstaid/fulltile,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
 "agb" = (
 /obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -3528,21 +3559,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/firstaid/fulltile,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
 "agc" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 6
-	},
-/obj/effect/floor_decal/industrial/firstaid{
-	icon_state = "stripe";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
@@ -3553,15 +3574,17 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "agf" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
@@ -3582,12 +3605,20 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/medical)
 "agh" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "agi" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -3595,29 +3626,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/firstaid{
-	icon_state = "stripe";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "agj" = (
-/obj/effect/floor_decal/industrial/firstaid/corner{
-	icon_state = "stripecorner";
-	dir = 1
-	},
-/obj/item/stool/padded,
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/structure/bed/roller,
+/turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
 "agl" = (
 /obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
@@ -3634,6 +3648,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
 "ago" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3644,13 +3661,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
@@ -3688,6 +3698,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
 "ags" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -3698,13 +3712,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
@@ -3778,9 +3785,11 @@
 /turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
 "agx" = (
-/obj/structure/bed/roller,
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
@@ -3808,11 +3817,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/firstdeck)
 "agB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/effect/floor_decal/borderfloorwhite,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "agC" = (
@@ -3852,21 +3860,20 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/conference)
 "agH" = (
-/obj/structure/table/reinforced,
-/obj/item/defibrillator/loaded,
-/obj/item/auto_cpr,
-/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/structure/bed/chair/padded/blue,
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "agI" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/firstaid,
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "agJ" = (
@@ -3889,6 +3896,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
 "agK" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/button/alternate/door{
 	id_tag = "inf_stage";
 	name = "Infirmary Staging Exit";
@@ -3900,13 +3910,6 @@
 	},
 /obj/effect/floor_decal/sign/tr,
 /obj/machinery/light/spot,
-/obj/effect/floor_decal/industrial/firstaid/corner{
-	icon_state = "stripecorner";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "agM" = (
@@ -4000,14 +4003,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralstarboard)
 "agU" = (
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 1;
-	pixel_y = -28
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass/medical{
+	autoset_access = 0;
+	id_tag = "inf_recep";
+	name = "Infirmary Reception";
+	req_access = list("ACCESS_MEDICAL")
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
 "agV" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -4048,18 +4052,14 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/firstdeck/centralstarboard)
 "agY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/medical{
-	autoset_access = 0;
-	id_tag = "inf_recep";
-	name = "Infirmary Reception";
-	req_access = list("ACCESS_MEDICAL")
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "agZ" = (
 /obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/door/airlock/multi_tile/glass/medical{
 	id_tag = "inf_stage";
 	name = "Infirmary Staging"
@@ -4072,12 +4072,11 @@
 	name = "Infirmary Staging Lockdown";
 	opacity = 0
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/firstaid/fulltile,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
 "aha" = (
 /obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -4086,8 +4085,6 @@
 	name = "Infirmary Staging Lockdown";
 	opacity = 0
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/firstaid/fulltile,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
 "ahb" = (
@@ -4096,6 +4093,18 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
+"ahc" = (
+/obj/effect/wallframe_spawn/reinforced/no_grille,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "inf_recep_window";
+	name = "Infirmary Reception Window Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/medical/staging)
 "ahd" = (
 /turf/simulated/wall/prepainted,
 /area/medical/counselor/therapy)
@@ -4869,8 +4878,7 @@
 /area/maintenance/firstdeck/aftstarboard)
 "aiI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/sign/warning/hot_exhaust,
-/turf/simulated/wall/ocp_wall,
+/turf/simulated/wall/r_wall/hull,
 /area/thruster/d1starboard)
 "aiK" = (
 /obj/effect/floor_decal/techfloor{
@@ -5797,11 +5805,11 @@
 /obj/item/storage/box/gloves,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
 "alR" = (
@@ -6002,6 +6010,8 @@
 /area/maintenance/firstdeck/centralstarboard)
 "amP" = (
 /obj/structure/table/rack,
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Medbay";
@@ -6024,8 +6034,6 @@
 /obj/item/storage/box/autoinjectors,
 /obj/item/storage/box/beakers,
 /obj/item/storage/box/syringes,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
 "amZ" = (
@@ -6137,26 +6145,43 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
 "anH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id_tag = "inf_recep_window";
-	name = "Infirmary Reception Window Lockdown";
-	opacity = 0
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
 	},
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	dir = 4;
-	icon_state = "left";
-	name = "Medical Reception"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/machinery/button/alternate/door{
+	id_tag = "inf_stage";
+	name = "Infirmary Staging Exit";
+	pixel_x = -7;
+	pixel_y = 23
+	},
+/obj/machinery/button/alternate/door{
+	id_tag = "ETC_stage";
+	name = "Treatment to Staging";
+	pixel_x = -7;
+	pixel_y = 33
+	},
+/obj/machinery/button/alternate/door{
+	id_tag = "ETC_hall";
+	name = "Treatment Center Exit";
+	pixel_x = 8;
+	pixel_y = 33
+	},
+/obj/machinery/button/alternate/door{
+	id_tag = "inf_recep";
+	name = "Reception Doors";
+	pixel_x = 8;
+	pixel_y = 23
+	},
+/obj/structure/bed/chair/padded/blue,
+/turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "anL" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -6165,13 +6190,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "anM" = (
@@ -6339,13 +6357,19 @@
 /obj/random/medical,
 /obj/random/medical,
 /obj/random/medical,
-/obj/random/medical,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/medical/lite,
+/obj/random/medical/lite,
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
 "apR" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -6473,21 +6497,28 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/robotics_lift)
 "aqL" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/prepainted,
-/area/medical/exam_room)
-"aqM" = (
-/obj/structure/flora/pottedplant/flower,
+/obj/effect/floor_decal/corner/paleblue,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
+"aqM" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/prepainted,
+/area/medical/medicalhallway)
 "aqP" = (
-/obj/structure/bed/chair/padded/blue{
-	icon_state = "chair_preview";
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
 	dir = 4
+	},
+/obj/structure/table/standard,
+/obj/item/reagent_containers/food/drinks/glass2/coffeecup/one{
+	custom_desc = "A white coffee cup, prominently featuring a #1 Gorpsman. Someone has scratched the C into a G."
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "aqQ" = (
+/obj/effect/wallframe_spawn/no_grille,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 4;
@@ -6496,27 +6527,26 @@
 	name = "Infirmary Window Lockdown";
 	opacity = 0
 	},
-/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/medical/foyer)
 "aqR" = (
 /obj/machinery/disposal,
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/foyer)
 "aqS" = (
+/obj/effect/floor_decal/corner/paleblue/mono,
 /obj/structure/flora/pottedplant/orientaltree,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/foyer)
 "aqT" = (
@@ -6711,6 +6741,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
 "arT" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/effect/floor_decal/sign/ex,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -6718,10 +6752,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/sign/ex,
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "ase" = (
+/obj/effect/floor_decal/corner/paleblue/mono,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -6731,8 +6765,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/papershredder,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/medpaperworkoffice)
 "ask" = (
@@ -6858,21 +6890,28 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
 "ata" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/light_switch{
+	pixel_x = -22;
+	pixel_y = 24
+	},
+/obj/machinery/button/windowtint{
+	id = "exam_windows";
+	pixel_x = -30;
+	pixel_y = 24;
+	pixel_z = 0
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/b_green/mono,
-/obj/machinery/body_scanconsole{
-	icon_state = "body_scannerconsole";
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 6;
-	icon_state = "spline_plain"
-	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
 "atb" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -6881,9 +6920,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
@@ -6899,6 +6935,7 @@
 /obj/item/folder/white,
 /obj/item/folder/white,
 /obj/item/folder/white,
+/obj/effect/floor_decal/corner/paleblue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/medpaperworkoffice)
 "atg" = (
@@ -6906,18 +6943,21 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medpaperworkoffice)
 "atm" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /obj/item/device/radio/intercom/department/medbay{
 	dir = 8;
 	pixel_x = 24
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
@@ -7086,6 +7126,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/laboratory)
+"aua" = (
+/obj/structure/bed/padded,
+/obj/item/bedsheet/medical,
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room)
 "aub" = (
 /obj/machinery/vending/wallmed1{
 	dir = 8;
@@ -7097,21 +7142,26 @@
 /obj/structure/bed/chair/comfy/blue{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
 "auc" = (
+/obj/effect/floor_decal/corner/paleblue/mono,
 /obj/structure/table/standard,
 /obj/item/paper_bin,
-/obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/exam_room)
 "aug" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
@@ -7370,36 +7420,42 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
 "avl" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/medical,
-/obj/effect/floor_decal/corner/lime/mono,
-/obj/effect/floor_decal/spline/plain{
-	dir = 5;
-	icon_state = "spline_plain"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/closet/secure_closet/personal/patient,
+/turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
 "avo" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/camera/network/medbay{
 	c_tag = "Infirmary - Examination Room";
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 1;
+	pixel_y = -28
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
 "avq" = (
 /obj/item/stool/padded,
+/obj/effect/floor_decal/corner/paleblue/mono,
 /obj/machinery/light/small,
 /obj/random_multi/single_item/runtime,
+/obj/random_multi/single_item/skelestand,
 /obj/structure/curtain/open/bed,
-/obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/exam_room)
 "avs" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/computer/modular/preset/medical{
 	dir = 1
 	},
@@ -7408,12 +7464,15 @@
 	icon_state = "nosmoking";
 	pixel_x = -37
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/white,
 /area/medical/medpaperworkoffice)
 "avu" = (
-/obj/effect/floor_decal/corner/paleblue,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/computer/modular/preset/medical{
 	dir = 1
 	},
@@ -7421,9 +7480,7 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/white,
 /area/medical/medpaperworkoffice)
 "avx" = (
 /obj/structure/cable/green{
@@ -7463,10 +7520,10 @@
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "avO" = (
+/obj/effect/floor_decal/corner/pink/mono,
 /obj/machinery/body_scanconsole{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/b_green/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
 "avS" = (
@@ -7662,12 +7719,12 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/armoury/access)
 "awM" = (
-/obj/machinery/atm{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/corner/blue/half{
+/obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1;
 	icon_state = "bordercolorhalf"
+	},
+/obj/machinery/atm{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
@@ -7737,7 +7794,7 @@
 /area/hallway/primary/firstdeck/center)
 "axh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/corner/blue/half{
+/obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1;
 	icon_state = "bordercolorhalf"
 	},
@@ -7778,21 +7835,46 @@
 /turf/simulated/floor/plating,
 /area/security/bo)
 "axw" = (
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
-"axB" = (
-/obj/machinery/newscaster{
+"axy" = (
+/obj/structure/sign/directions/med{
 	pixel_y = 32
 	},
-/obj/effect/floor_decal/corner/blue/half{
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
+"axB" = (
+/obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1;
 	icon_state = "bordercolorhalf"
 	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/firstdeck/aft)
+"axD" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "axF" = (
 /obj/structure/cable/green{
@@ -8188,6 +8270,29 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
+"ayC" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/firstdeck/aft)
 "ayF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8370,13 +8475,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/center)
-"azu" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "azN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -9364,8 +9462,8 @@
 /obj/item/clothing/shoes/dutyboots,
 /obj/item/clothing/accessory/storage/holster/thigh,
 /obj/item/clothing/glasses/tacgoggles,
-/obj/item/clothing/suit/armor/pcarrier/medium/sol,
-/obj/item/clothing/head/helmet,
+/obj/item/clothing/suit/armor/pcarrier/blue/sol,
+/obj/item/clothing/head/helmet/solgov,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
 "aEH" = (
@@ -9788,17 +9886,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
-"aGp" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medicalhallway)
 "aGq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -9865,9 +9952,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
 "aGx" = (
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/item/stool/padded,
+/turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "aGE" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
@@ -10703,11 +10795,11 @@
 /turf/simulated/floor/plating,
 /area/security/bo)
 "aKG" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/structure/closet/hydrant{
 	pixel_y = 32
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
@@ -11771,11 +11863,7 @@
 /area/thruster/d1port)
 "aPs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/sign/warning/hot_exhaust{
-	dir = 1;
-	icon_state = "fire"
-	},
-/turf/simulated/wall/ocp_wall,
+/turf/simulated/wall/r_wall/hull,
 /area/thruster/d1port)
 "aPu" = (
 /turf/simulated/floor/tiled/dark/monotile,
@@ -13291,6 +13379,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
 "aTn" = (
@@ -13303,8 +13392,8 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
@@ -13313,9 +13402,14 @@
 	dir = 1;
 	icon_state = "warningcorner"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 4;
+	max_pressure_setting = 35000;
+	regulate_mode = 2;
+	target_pressure = 35000;
+	use_power = 1
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
 "aTp" = (
@@ -13543,12 +13637,22 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/thruster/d1port)
+"aTX" = (
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 4;
+	target_pressure = 15000
+	},
+/obj/effect/floor_decal/industrial/outline/orange,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/thruster/d1port)
 "aTY" = (
 /obj/machinery/meter,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
 "aTZ" = (
@@ -13823,14 +13927,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
 "aUy" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 5
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
@@ -14522,7 +14626,7 @@
 /area/hallway/primary/firstdeck/fore)
 "bbb" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
-	target_pressure = 3000
+	dir = 2
 	},
 /turf/simulated/wall/ocp_wall,
 /area/thruster/d1starboard)
@@ -14575,21 +14679,17 @@
 /turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
 "bhy" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/structure/iv_drip,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/item/device/radio/intercom/department/medbay{
 	pixel_y = 23
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
 "bhL" = (
@@ -14677,11 +14777,11 @@
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = -5
 	},
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/warning/nosmoking_1{
 	pixel_y = 24
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
 "bmb" = (
@@ -14838,6 +14938,18 @@
 "btE" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/questioning)
+"bvI" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/thruster/d1port)
 "bvY" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
@@ -14866,8 +14978,7 @@
 /area/assembly/chargebay)
 "byb" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
-	dir = 1;
-	target_pressure = 3000
+	dir = 1
 	},
 /turf/simulated/wall/ocp_wall,
 /area/thruster/d1port)
@@ -14965,10 +15076,18 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -15012,10 +15131,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -15088,19 +15203,13 @@
 /obj/item/pen/crayon,
 /obj/item/pen,
 /obj/item/sticky_pad/random,
+/obj/effect/floor_decal/corner/paleblue/mono,
 /obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/medpaperworkoffice)
 "bMb" = (
 /turf/simulated/wall/prepainted,
 /area/engineering/hardstorage/aux)
-"bMp" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/staging)
 "bMB" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 6;
@@ -15340,11 +15449,11 @@
 /area/security/detectives_office)
 "bWA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
@@ -15419,6 +15528,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod17/station)
 "cbj" = (
+/obj/effect/floor_decal/corner/paleblue/mono,
 /obj/machinery/computer/modular/preset/medical,
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -15427,7 +15537,6 @@
 	dir = 4;
 	pixel_x = 21
 	},
-/obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/exam_room)
 "ccb" = (
@@ -15492,10 +15601,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
-"cic" = (
-/obj/item/stool/padded,
-/turf/simulated/floor/tiled/white,
-/area/medical/staging)
 "cix" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9;
@@ -15551,6 +15656,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "cmY" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -15584,30 +15692,6 @@
 /obj/item/storage/box/bodybags,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
-"cqc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "csb" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/blue,
@@ -15625,6 +15709,10 @@
 	dir = 8;
 	icon_state = "edge"
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /obj/structure/hygiene/sink{
 	dir = 8;
 	icon_state = "sink";
@@ -15637,10 +15725,6 @@
 /obj/item/device/radio/intercom/department/medbay{
 	dir = 4;
 	pixel_x = -24
-	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
@@ -15986,6 +16070,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
 "cNb" = (
+/obj/item/usedcryobag,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -16010,12 +16095,12 @@
 	dir = 9;
 	icon_state = "edge"
 	},
+/obj/effect/floor_decal/corner/paleblue,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -21;
 	pixel_y = 0
 	},
-/obj/effect/floor_decal/corner/b_green,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "cOH" = (
@@ -16077,12 +16162,11 @@
 	dir = 1;
 	icon_state = "edge"
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
@@ -16350,16 +16434,15 @@
 	dir = 1;
 	icon_state = "edge"
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/oxygen_pump{
 	pixel_x = -32;
 	pixel_y = 32
 	},
 /obj/machinery/body_scan_display{
 	pixel_y = 24
-	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
@@ -16462,37 +16545,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/washroom)
-"dpZ" = (
-/obj/machinery/button/alternate/door{
-	id_tag = "ETC_hall";
-	name = "Treatment Center Exit";
-	pixel_x = 24;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "dqb" = (
 /obj/structure/hygiene/sink{
 	dir = 1;
@@ -16701,42 +16753,55 @@
 /obj/random/medical,
 /obj/random/medical,
 /obj/random/medical,
+/obj/random/medical/lite,
+/obj/random/medical/lite,
+/obj/random/medical/lite,
+/obj/random/medical/lite,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/item/defibrillator/loaded,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "Medical Equipment Cabinet";
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/glass/bottle/inaprovaline,
-/obj/item/reagent_containers/glass/bottle/inaprovaline,
-/obj/item/reagent_containers/glass/bottle/antitoxin,
-/obj/item/reagent_containers/glass/bottle/antitoxin,
-/obj/item/reagent_containers/glass/bottle/antitoxin,
-/obj/item/reagent_containers/glass/bottle/inaprovaline,
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 6;
-	icon_state = "spline_plain"
-	},
-/obj/random/medical/lite,
-/obj/random/medical/lite,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/glass/bottle/inaprovaline,
+/obj/item/reagent_containers/glass/bottle/inaprovaline,
+/obj/item/reagent_containers/glass/bottle/antitoxin,
+/obj/item/reagent_containers/glass/bottle/antitoxin,
+/obj/item/reagent_containers/glass/bottle/antitoxin,
+/obj/item/reagent_containers/glass/bottle/inaprovaline,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"dMe" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/structure/sign/directions/med{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "dNb" = (
+/obj/effect/floor_decal/corner/paleblue/mono,
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/unary/cryo_cell,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
 "dPA" = (
@@ -16764,16 +16829,16 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/random/medical,
+/obj/random/medical/lite,
 /obj/random/medical/lite,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
 "dRf" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/structure/closet/hydrant{
 	pixel_y = 32
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
@@ -16800,12 +16865,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 21
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medpaperworkoffice)
@@ -16840,11 +16905,10 @@
 /turf/simulated/wall/r_wall/hull,
 /area/command/armoury/tactical)
 "dWb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/effect/floor_decal/borderfloorwhite,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "dWA" = (
@@ -16865,7 +16929,27 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/firstdeck/forestarboard)
+"dXM" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medicalhallway)
 "dYb" = (
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -16876,16 +16960,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "dZb" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
@@ -16908,6 +16986,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/locker)
 "eab" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -16920,16 +17004,12 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "eaF" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16952,17 +17032,17 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/nuke_storage)
 "ebb" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
 	icon_state = "intact"
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/machinery/light/spot{
-	dir = 4
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -17129,7 +17209,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
@@ -17202,6 +17282,9 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
 "ewb" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17212,13 +17295,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -17232,6 +17308,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/center)
 "exb" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -17250,13 +17329,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "exc" = (
@@ -17350,8 +17422,7 @@
 	dir = 1;
 	icon_state = "body_scanner_0"
 	},
-/obj/effect/floor_decal/corner/b_green/mono,
-/obj/effect/floor_decal/industrial/outline,
+/obj/effect/floor_decal/corner/pink/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
 "eIb" = (
@@ -17436,8 +17507,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/firstaid/fulltile,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery)
 "eQK" = (
@@ -17525,11 +17595,14 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/corner/white/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery)
 "eXk" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/structure/iv_drip,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 24
 	},
@@ -17537,14 +17610,6 @@
 	c_tag = "Medical - Foyer";
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
 "eZQ" = (
@@ -17655,14 +17720,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/bed/chair/comfy/blue,
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medpaperworkoffice)
 "frA" = (
@@ -17684,31 +17748,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/locker)
-"fsX" = (
-/obj/machinery/light_switch{
-	pixel_x = -22;
-	pixel_y = 24
-	},
-/obj/machinery/button/windowtint{
-	id = "exam_windows";
-	pixel_x = -30;
-	pixel_y = 24;
-	pixel_z = 0
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/b_green/mono,
-/obj/machinery/bodyscanner{
-	icon_state = "body_scanner_0";
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain,
-/turf/simulated/floor/tiled/white/monotile,
-/area/medical/exam_room)
 "fuV" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 2;
@@ -17719,13 +17758,19 @@
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/thruster/d1starboard)
+"fvb" = (
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/medical/sleeper)
 "fxb" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
 "fxe" = (
-/obj/effect/floor_decal/corner/white/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery2)
 "fBb" = (
@@ -17736,10 +17781,6 @@
 /obj/item/device/integrated_circuit_printer,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
-"fBP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/wall/ocp_wall,
-/area/thruster/d1port)
 "fCb" = (
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/surgery,
@@ -17747,12 +17788,11 @@
 	dir = 1;
 	icon_state = "edge"
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
@@ -17774,12 +17814,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
 "fEb" = (
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -17863,6 +17899,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury)
 "fMr" = (
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -17871,7 +17908,6 @@
 	name = "Infirmary Window Lockdown";
 	opacity = 0
 	},
-/obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/staging)
 "fMI" = (
@@ -17881,6 +17917,13 @@
 /obj/random/material,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralstarboard)
+"fOb" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/structure/flora/pottedplant/flower,
+/turf/simulated/floor/tiled/white,
+/area/medical/medicalhallway)
 "fOr" = (
 /obj/structure/table/steel,
 /obj/random/maintenance/solgov/clean,
@@ -17906,15 +17949,14 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
 "fQf" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
@@ -17944,19 +17986,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/detectives_office)
 "fVb" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/structure/iv_drip,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/noticeboard{
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
 "fVw" = (
@@ -17982,16 +18020,18 @@
 /turf/simulated/floor/plating,
 /area/security/wing)
 "fWb" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
@@ -18008,7 +18048,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/exam_room)
 "fYv" = (
@@ -18051,13 +18090,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/hardstorage/aux)
-"gaB" = (
-/obj/effect/floor_decal/industrial/firstaid{
-	icon_state = "stripe";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
 "gbb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18103,6 +18135,10 @@
 	dir = 8;
 	icon_state = "edge"
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -18114,10 +18150,6 @@
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
@@ -18133,7 +18165,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/center)
 "gib" = (
-/obj/effect/floor_decal/corner/white/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery)
 "gig" = (
@@ -18167,9 +18198,9 @@
 	dir = 4;
 	icon_state = "edge"
 	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 9
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
@@ -18180,8 +18211,6 @@
 /turf/simulated/floor/plating,
 /area/medical/surgery)
 "glb" = (
-/obj/structure/bed/roller,
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/spline/plain/blue{
 	dir = 6;
 	icon_state = "spline_plain"
@@ -18245,10 +18274,10 @@
 	pixel_y = 5
 	},
 /obj/item/storage/firstaid/toxin,
-/obj/machinery/light,
-/obj/random/medical,
-/obj/effect/floor_decal/corner/blue/mono,
+/obj/random/medical/lite,
+/obj/effect/floor_decal/corner/paleblue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
 "gvC" = (
@@ -18309,12 +18338,33 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage/aux)
 "gyV" = (
-/obj/effect/wallframe_spawn/reinforced/no_grille,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/medical/sleeper)
 "gyY" = (
 /turf/simulated/wall/r_wall/hull,
 /area/crew_quarters/safe_room/firstdeck)
+"gzb" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id_tag = "inf_recep_window";
+	name = "Infirmary Reception Window Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/window/eastright{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Medical Reception"
+	},
+/obj/item/storage/medical_lolli_jar,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white/monotile,
+/area/medical/staging)
 "gzM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18344,6 +18394,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"gDb" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/structure/bed/chair/padded/blue{
+	dir = 8;
+	icon_state = "chair_preview"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medicalhallway)
 "gDm" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4;
@@ -18386,8 +18446,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
 "gFb" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -18413,15 +18472,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/hardstorage/aux)
-"gMF" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/item/modular_computer/telescreen/preset/medical{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/white/monotile,
-/area/medical/staging)
 "gQb" = (
 /obj/structure/dispenser{
 	oxygentanks = 0
@@ -18442,17 +18492,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/firstdeck)
-"gQx" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/firstaid,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "gQI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -18468,10 +18507,13 @@
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
 "gRb" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/item/stool/padded,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue/three_quarters,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
 "gVR" = (
@@ -18494,24 +18536,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "gWb" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
 	icon_state = "shutter0";
-	id_tag = "infirm_pub";
-	name = "Infirmary Public Hallway Lockdown";
+	id_tag = "infirm_windows";
+	name = "Infirmary Window Lockdown";
 	opacity = 0
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/firstaid/fulltile,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/plating,
 /area/medical/medicalhallway)
 "gWY" = (
 /obj/machinery/mech_recharger,
@@ -18562,11 +18596,10 @@
 /turf/simulated/wall/prepainted,
 /area/rnd/development)
 "haV" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
 "hbP" = (
@@ -18591,19 +18624,16 @@
 /obj/machinery/camera/network/first_deck{
 	c_tag = "First Deck Hallway - Ladders"
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "hdb" = (
-/obj/structure/sign/directions/med{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/corner/blue/half{
+/obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1;
 	icon_state = "bordercolorhalf"
 	},
@@ -18666,16 +18696,15 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
 "hgt" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
@@ -18685,12 +18714,12 @@
 	dir = 9;
 	icon_state = "edge"
 	},
+/obj/effect/floor_decal/corner/paleblue,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -21;
 	pixel_y = 0
 	},
-/obj/effect/floor_decal/corner/b_green,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "hhb" = (
@@ -18704,6 +18733,9 @@
 	name = "Research Equipment";
 	sort_type = "Research Equipment"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -18713,17 +18745,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
 "hhB" = (
@@ -18759,24 +18780,19 @@
 	dir = 4;
 	icon_state = "edge"
 	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 9
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
-"hkQ" = (
-/obj/structure/sign/warning/vent_port,
-/turf/simulated/wall/r_wall/hull,
-/area/thruster/d1starboard)
 "hlb" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "hml" = (
@@ -18851,18 +18867,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/opscheck)
-"hqs" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/thruster/d1port)
 "hrb" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -19019,12 +19023,8 @@
 /turf/simulated/wall/prepainted,
 /area/rnd/development)
 "hwx" = (
-/obj/effect/floor_decal/corner/blue/three_quarters{
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
 	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	icon_state = "borderfloorcorner_white";
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -19070,25 +19070,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/fore)
-"hyG" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medicalhallway)
 "hzb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19209,17 +19190,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
 "hEU" = (
-/obj/machinery/light/spot{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
 	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
-	},
-/obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "hFb" = (
@@ -19263,14 +19241,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
-"hGo" = (
-/obj/machinery/door/airlock/medical{
-	id_tag = "examdoor";
-	name = "Examination Room"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white/monotile,
-/area/medical/exam_room)
 "hGs" = (
 /turf/simulated/wall/prepainted,
 /area/security/locker)
@@ -19374,19 +19344,11 @@
 /obj/random_multi/single_item/runtime,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
-"hPp" = (
-/obj/structure/sign/warning/vent_port{
-	dir = 1
-	},
-/turf/simulated/wall/r_wall/hull,
-/area/thruster/d1port)
 "hPt" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/table/standard,
-/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "hQb" = (
@@ -19399,13 +19361,6 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/hardstorage/aux)
-"hQd" = (
-/obj/structure/sign/warning/hot_exhaust{
-	dir = 1;
-	icon_state = "fire"
-	},
-/turf/simulated/wall/ocp_wall,
-/area/thruster/d1starboard)
 "hUb" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -19529,27 +19484,6 @@
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/reinforced,
 /area/thruster/d1port)
-"ieS" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id_tag = "inf_recep_window";
-	name = "Infirmary Reception Window Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/window/eastright{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Medical Reception"
-	},
-/obj/item/storage/medical_lolli_jar,
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/white/monotile,
-/area/medical/staging)
 "igb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19562,22 +19496,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
-"igk" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
 "iib" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19685,10 +19603,10 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
+/obj/effect/floor_decal/corner/paleblue/mono,
 /obj/machinery/recharger,
 /obj/structure/table/glass,
 /obj/random/smokes,
-/obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/medpaperworkoffice)
 "iqb" = (
@@ -19824,7 +19742,7 @@
 /turf/simulated/wall/prepainted,
 /area/rnd/misc_lab)
 "ivT" = (
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
@@ -19847,6 +19765,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
 "ixf" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -19855,13 +19776,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "ixB" = (
@@ -19998,11 +19912,10 @@
 /area/security/detectives_office)
 "iGb" = (
 /obj/effect/floor_decal/floordetail/edgedrain,
-/obj/machinery/organ_printer/flesh/mapped,
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
+/obj/machinery/organ_printer/flesh/mapped,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "iHb" = (
@@ -20031,7 +19944,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "iKb" = (
@@ -20069,13 +19981,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
 "iMW" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
@@ -20318,7 +20230,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/corner/white/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery)
 "jcg" = (
@@ -20329,18 +20240,16 @@
 /turf/simulated/floor/tiled,
 /area/security/locker)
 "jcu" = (
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 5;
+	icon_state = "spline_plain"
+	},
 /obj/machinery/light/spot{
 	dir = 8
 	},
 /obj/machinery/camera/network/medbay{
 	c_tag = "Infirmary - Treatment Centre";
 	dir = 4
-	},
-/obj/structure/bed/roller,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 5;
-	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -20436,7 +20345,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/white/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery2)
 "jhS" = (
@@ -20456,6 +20364,10 @@
 	dir = 8;
 	icon_state = "edge"
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -20467,10 +20379,6 @@
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
@@ -20692,7 +20600,6 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/obj/effect/floor_decal/industrial/firstaid/corner,
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "jvb" = (
@@ -20724,7 +20631,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/white/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery)
 "jxG" = (
@@ -20846,23 +20752,38 @@
 /turf/simulated/wall/prepainted,
 /area/medical/morgue/autopsy)
 "jCU" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/medical{
-	autoset_access = 0;
-	id_tag = "inf_recep";
-	name = "Infirmary Reception";
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "infirm_pub";
+	name = "Infirmary Public Hallway Lockdown";
+	pixel_x = 7;
+	pixel_y = -34;
 	req_access = list("ACCESS_MEDICAL")
 	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id_tag = "inf_recep_window";
-	name = "Infirmary Reception Window Lockdown";
-	opacity = 0
+/obj/machinery/button/blast_door{
+	id_tag = "infirm_windows";
+	name = "Infirmary Windows Lockdown";
+	pixel_x = -7;
+	pixel_y = -34;
+	req_access = list("ACCESS_MEDICAL")
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/machinery/button/blast_door{
+	id_tag = "inf_recep_window";
+	name = "Infirmary Reception Lockdown";
+	pixel_x = 7;
+	pixel_y = -24;
+	req_access = list("ACCESS_MEDICAL")
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "infirm_stage";
+	name = "Infirmary Staging Lockdown";
+	pixel_x = -7;
+	pixel_y = -24;
+	req_access = list("ACCESS_MEDICAL")
+	},
+/turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "jDX" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -21149,13 +21070,15 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/corner/white/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery2)
 "jYZ" = (
-/obj/effect/floor_decal/corner/blue/half{
+/obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1;
 	icon_state = "bordercolorhalf"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
@@ -21175,7 +21098,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/medical,
 /obj/random/medical,
-/obj/random/medical/lite,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
 "kbb" = (
@@ -21196,6 +21118,11 @@
 	dir = 4;
 	icon_state = "edge"
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/effect/floor_decal/sign/or1,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -21207,11 +21134,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/sign/or1,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "kdb" = (
@@ -21276,6 +21198,9 @@
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
 "kfG" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/thruster/d1starboard)
 "kgi" = (
@@ -21416,7 +21341,7 @@
 	dir = 2;
 	pixel_y = 24
 	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
@@ -21597,29 +21522,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/storage)
-"kCZ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
 "kDb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 2;
@@ -21645,16 +21547,15 @@
 	pixel_y = -24;
 	pixel_z = 0
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/button/alternate/door{
 	id_tag = "examdoor";
 	name = "Examination Room Door Control";
 	pixel_x = 5;
 	pixel_y = -24;
 	req_access = list("ACCESS_MEDICAL")
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
@@ -21671,16 +21572,17 @@
 /turf/simulated/floor/tiled/white,
 /area/security/brig)
 "kGX" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/firealarm{
 	pixel_y = 24
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "kHb" = (
 /obj/structure/bed/padded,
+/obj/effect/floor_decal/corner/pink/mono,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23;
@@ -21689,27 +21591,21 @@
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
-/obj/item/bedsheet/medical,
-/obj/effect/floor_decal/corner/lime/mono,
-/obj/effect/floor_decal/spline/plain{
-	dir = 10;
-	icon_state = "spline_plain"
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
 "kIb" = (
 /obj/structure/closet/secure_closet/personal/patient,
+/obj/effect/floor_decal/corner/pink/mono,
 /obj/machinery/body_scan_display{
 	pixel_y = 24
 	},
 /obj/random/plushie,
-/obj/effect/floor_decal/corner/lime/mono,
-/obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
 "kJb" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/medical,
+/obj/effect/floor_decal/corner/pink/mono,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -21720,11 +21616,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/floor_decal/corner/lime/mono,
-/obj/effect/floor_decal/spline/plain{
-	dir = 6;
-	icon_state = "spline_plain"
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
 "kKb" = (
@@ -21734,15 +21625,14 @@
 /turf/simulated/floor/plating,
 /area/medical/staging)
 "kLb" = (
+/obj/machinery/bodyscanner{
+	dir = 1;
+	icon_state = "body_scanner_0"
+	},
+/obj/effect/floor_decal/corner/pink/mono,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/bodyscanner{
-	icon_state = "body_scanner_0";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/b_green/mono,
-/obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
 "kLY" = (
@@ -21756,16 +21646,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/laboratory)
-"kNi" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "kOb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -21808,6 +21688,10 @@
 /turf/simulated/wall/r_wall/hull,
 /area/thruster/d1port)
 "kQb" = (
+/obj/effect/floor_decal/corner/pink{
+	dir = 5
+	},
+/obj/effect/floor_decal/sign/pop,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -21819,14 +21703,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/effect/floor_decal/sign/pop,
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "kRb" = (
+/obj/effect/floor_decal/corner/pink{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -21843,14 +21725,13 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 5
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "kSb" = (
 /obj/structure/curtain/open/privacy,
+/obj/effect/floor_decal/corner/pink{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -21861,14 +21742,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
@@ -21897,6 +21770,7 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "kTb" = (
+/obj/effect/floor_decal/corner/pink/mono,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -21908,24 +21782,21 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 5
+/obj/machinery/body_scanconsole{
+	dir = 1
 	},
-/obj/effect/floor_decal/sign/d,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
 "kTl" = (
 /obj/structure/table/rack,
 /obj/item/defibrillator/compact/loaded,
 /obj/item/auto_cpr,
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/device/radio/intercom/department/medbay{
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/item/auto_cpr,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
 "kUb" = (
@@ -22134,15 +22005,11 @@
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
 "lhb" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/structure/sign/emergonly{
 	pixel_y = 26
-	},
-/obj/effect/floor_decal/industrial/firstaid/corner{
-	icon_state = "stripecorner";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
@@ -22253,10 +22120,6 @@
 	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d1port)
-"loS" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/white/monotile,
-/area/medical/exam_room)
 "lpb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -22296,8 +22159,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury)
 "lsT" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
@@ -22490,15 +22354,18 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "lAC" = (
 /obj/structure/table/standard,
@@ -22550,17 +22417,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/hardstorage/aux)
-"lCo" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/firstaid,
-/turf/simulated/floor/tiled/white,
-/area/medical/staging)
 "lCN" = (
 /obj/structure/table/standard,
 /obj/item/device/tape/random,
@@ -22568,10 +22424,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
 "lEb" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
 "lGw" = (
@@ -22711,14 +22567,13 @@
 	dir = 10;
 	icon_state = "edge"
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 4
+	},
 /obj/machinery/organ_printer/robot/mapped,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
-	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
@@ -22895,15 +22750,14 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/bed/chair/comfy/blue,
 /obj/random_multi/single_item/runtime,
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medpaperworkoffice)
 "mlw" = (
@@ -22928,6 +22782,12 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
 "mmb" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -22938,19 +22798,8 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/green,
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medpaperworkoffice)
-"mmA" = (
-/obj/machinery/vending/medical/torch{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/light/spot,
-/turf/simulated/floor/tiled/white/monotile,
-/area/medical/sleeper)
 "mmP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/research{
@@ -22989,11 +22838,11 @@
 /area/command/armoury/tactical)
 "mrW" = (
 /obj/structure/closet/secure_closet/medical_torchsenior,
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/locker)
 "mrX" = (
@@ -23065,6 +22914,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/center)
 "mvE" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -23167,6 +23019,10 @@
 	dir = 6;
 	icon_state = "edge"
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 1;
+	icon_state = "corner_white"
+	},
 /obj/effect/floor_decal/sign/or2,
 /obj/machinery/button/holosign{
 	id_tag = "or2";
@@ -23193,21 +23049,18 @@
 	c_tag = "Infirmary - Operating Theatre 2";
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "mzb" = (
-/obj/structure/disposalpipe/segment,
-/obj/item/device/radio/beacon,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
@@ -23349,11 +23202,10 @@
 /area/command/armoury)
 "mJY" = (
 /obj/structure/closet/wardrobe/chemistry_white,
+/obj/effect/floor_decal/corner/beige/mono,
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
-/obj/effect/floor_decal/corner/yellow/mono,
-/obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "mKb" = (
@@ -23671,8 +23523,7 @@
 	dir = 5;
 	icon_state = "edge"
 	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -23954,28 +23805,6 @@
 /obj/effect/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
-"nzg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass/medical{
-	dir = 4;
-	id_tag = "ETC_hall";
-	name = "Treatment Center"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id_tag = "infirm_pub";
-	name = "Infirmary Public Hallway Lockdown";
-	opacity = 0
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/firstaid/fulltile,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/medical/sleeper)
 "nAb" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9;
@@ -24000,19 +23829,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/opscheck)
-"nAm" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/pager/medical{
-	pixel_x = -21;
-	pixel_y = -10
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medicalhallway)
 "nAp" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/solgov,
@@ -24037,6 +23853,7 @@
 /turf/simulated/wall/prepainted,
 /area/medical/exam_room)
 "nDd" = (
+/obj/effect/floor_decal/corner/paleblue/mono,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -24044,8 +23861,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/photocopier,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/medpaperworkoffice)
 "nDx" = (
@@ -24068,8 +23883,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/firstaid/fulltile,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery2)
 "nDB" = (
@@ -24181,6 +23995,11 @@
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
 "nLo" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/item/storage/pill_bottle/tramadol,
+/obj/item/storage/pill_bottle/antitox,
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -24191,15 +24010,8 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/random/medical/lite,
-/obj/random/medical/lite,
+/obj/item/storage/pill_bottle,
+/obj/item/storage/pill_bottle,
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
 "nOO" = (
@@ -24561,6 +24373,29 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"ofb" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id_tag = "inf_recep_window";
+	name = "Infirmary Reception Window Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 4;
+	icon_state = "left";
+	name = "Medical Reception"
+	},
+/obj/machinery/door/firedoor,
+/obj/item/modular_computer/telescreen/preset/medical{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/medical/staging)
 "ogb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -24623,7 +24458,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/bed/chair/padded/blue,
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
@@ -24718,13 +24553,32 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
+"ovb" = (
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass/medical{
+	autoset_access = 0;
+	id_tag = "inf_recep";
+	name = "Infirmary Reception";
+	req_access = list("ACCESS_MEDICAL")
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id_tag = "inf_recep_window";
+	name = "Infirmary Reception Window Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/medical/staging)
 "ovZ" = (
 /obj/structure/closet/secure_closet/medical_torchsenior,
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/warning/nosmoking_1{
 	pixel_y = 24
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/locker)
 "owb" = (
@@ -24746,11 +24600,11 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/morgue/autopsy)
 "oxb" = (
-/obj/structure/table/standard,
-/obj/structure/flora/pottedplant/flower,
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "oyb" = (
@@ -24834,16 +24688,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/firstdeck)
 "oCf" = (
-/obj/machinery/body_scanconsole{
-	icon_state = "body_scannerconsole";
-	dir = 8
+/obj/effect/floor_decal/corner/pink{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/b_green/mono,
-/obj/effect/floor_decal/industrial/firstaid/corner{
-	icon_state = "stripecorner";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
+/obj/effect/floor_decal/sign/d,
+/turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "oDg" = (
 /turf/simulated/wall/prepainted,
@@ -24905,6 +24754,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "oLK" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 1;
+	pixel_y = -28
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "oMb" = (
@@ -24932,6 +24788,10 @@
 	dir = 8;
 	icon_state = "edge"
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /obj/structure/hygiene/sink{
 	dir = 8;
 	icon_state = "sink";
@@ -24944,10 +24804,6 @@
 /obj/item/device/radio/intercom/department/medbay{
 	dir = 4;
 	pixel_x = -24
-	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
@@ -24987,6 +24843,9 @@
 /area/security/opscheck)
 "oOt" = (
 /obj/effect/floor_decal/floordetail/edgedrain,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -24999,10 +24858,6 @@
 	dir = 5
 	},
 /obj/structure/closet/crate/secure/biohazard/alt,
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 5
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "oPb" = (
@@ -25056,10 +24911,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/locker)
-"oRI" = (
-/obj/effect/floor_decal/plaque,
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
 "oSb" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -25208,8 +25059,7 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "oZb" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -25359,6 +25209,10 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/detectives_office)
 "pjV" = (
+/obj/effect/floor_decal/corner/pink{
+	dir = 1;
+	icon_state = "corner_white"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -25369,10 +25223,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
@@ -25396,11 +25246,11 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "pmz" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
@@ -25607,20 +25457,17 @@
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
 "pzZ" = (
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
 	icon_state = "shutter0";
-	id_tag = "infirm_windows";
-	name = "Infirmary Window Lockdown";
+	id_tag = "infirm_pub";
+	name = "Infirmary Public Hallway Lockdown";
 	opacity = 0
 	},
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "pAb" = (
 /obj/machinery/newscaster{
@@ -25687,6 +25534,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "pEr" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -25772,9 +25622,9 @@
 	dir = 4;
 	icon_state = "edge"
 	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 9
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
@@ -25915,15 +25765,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
-"pTB" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/floor_decal/corner/lime/mono,
-/obj/effect/floor_decal/spline/plain{
-	dir = 9;
-	icon_state = "spline_plain"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/medical/exam_room)
 "pUb" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -25966,12 +25807,12 @@
 	},
 /obj/item/storage/firstaid/fire,
 /obj/random/medical/lite,
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
 "pWW" = (
@@ -26139,6 +25980,12 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "qfa" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -26178,10 +26025,6 @@
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology/xenoflora)
-"qhd" = (
-/obj/structure/sign/warning/hot_exhaust,
-/turf/simulated/wall/ocp_wall,
-/area/thruster/d1port)
 "qib" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/hygiene/sink{
@@ -26216,6 +26059,9 @@
 /area/rnd/misc_lab)
 "qju" = (
 /obj/effect/floor_decal/floordetail/edgedrain,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26227,10 +26073,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
@@ -26279,15 +26121,14 @@
 /area/medical/surgery2)
 "qnA" = (
 /obj/effect/floor_decal/floordetail/edgedrain,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/light,
 /obj/structure/closet/crate/freezer,
 /obj/item/device/mmi,
 /obj/item/reagent_containers/ivbag/nanoblood,
 /obj/item/reagent_containers/ivbag/nanoblood,
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 5
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "qqb" = (
@@ -26304,37 +26145,10 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "qrq" = (
-/obj/machinery/button/blast_door{
-	id_tag = "infirm_pub";
-	name = "Infirmary Public Hallway Lockdown";
-	pixel_x = 7;
-	pixel_y = -34;
-	req_access = list("ACCESS_MEDICAL")
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
 	},
-/obj/machinery/button/blast_door{
-	id_tag = "infirm_windows";
-	name = "Infirmary Windows Lockdown";
-	pixel_x = -7;
-	pixel_y = -34;
-	req_access = list("ACCESS_MEDICAL")
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "inf_recep_window";
-	name = "Infirmary Reception Lockdown";
-	pixel_x = 7;
-	pixel_y = -24;
-	req_access = list("ACCESS_MEDICAL")
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "infirm_stage";
-	name = "Infirmary Staging Lockdown";
-	pixel_x = -7;
-	pixel_y = -24;
-	req_access = list("ACCESS_MEDICAL")
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "qsO" = (
@@ -26572,18 +26386,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"qFY" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/thruster/d1starboard)
 "qGb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/reagentgrinder,
@@ -26614,6 +26416,12 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "qGx" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -26626,16 +26434,12 @@
 /obj/structure/sign/warning/nosmoking_1{
 	pixel_y = 24
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "qGE" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
 "qHb" = (
@@ -26682,12 +26486,11 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology/xenoflora)
 "qKx" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
@@ -26745,13 +26548,14 @@
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/xenobiology/xenoflora)
 "qLr" = (
+/obj/effect/floor_decal/corner/paleblue/mono,
 /obj/structure/table/standard,
 /obj/item/reagent_containers/food/snacks/lunacake/mooncake,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/medical/medicalhallway)
 "qMb" = (
 /obj/machinery/portable_atmospherics/hydroponics{
@@ -26785,22 +26589,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
-"qPj" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
 "qQb" = (
 /obj/machinery/atmospherics/valve{
 	dir = 8;
@@ -27249,8 +27037,7 @@
 	dir = 5;
 	icon_state = "edge"
 	},
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -27763,10 +27550,16 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "rPz" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/item/roller{
+	pixel_y = 8
 	},
-/turf/simulated/floor/tiled/white,
+/obj/item/roller{
+	pixel_y = 16
+	},
+/obj/item/roller,
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
 "rQb" = (
 /obj/structure/ladder,
@@ -27888,6 +27681,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/xenobiology/xenoflora)
 "rYd" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/thruster/d1port)
 "rYN" = (
@@ -28003,7 +27799,6 @@
 /obj/random/medical,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/medical,
-/obj/random/medical/lite,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
 "scr" = (
@@ -28137,34 +27932,17 @@
 /turf/simulated/wall/r_wall/hull,
 /area/security/locker)
 "siI" = (
-/obj/machinery/button/alternate/door{
-	id_tag = "inf_stage";
-	name = "Infirmary Staging Exit";
-	pixel_x = -7;
-	pixel_y = 23
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
 	},
-/obj/machinery/button/alternate/door{
-	id_tag = "ETC_stage";
-	name = "Treatment to Staging";
-	pixel_x = -7;
-	pixel_y = 33
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
-/obj/machinery/button/alternate/door{
-	id_tag = "ETC_hall";
-	name = "Treatment Center Exit";
-	pixel_x = 8;
-	pixel_y = 33
-	},
-/obj/machinery/button/alternate/door{
-	id_tag = "inf_recep";
-	name = "Reception Doors";
-	pixel_x = 8;
-	pixel_y = 23
-	},
-/obj/structure/bed/chair/comfy/blue,
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
+/obj/structure/table/standard,
+/obj/item/defibrillator/loaded,
+/obj/item/bodybag/rescue/loaded,
+/obj/item/auto_cpr,
+/obj/item/auto_cpr,
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "sjb" = (
@@ -28379,12 +28157,15 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "ssg" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
@@ -28673,14 +28454,12 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/obj/structure/bed/chair/comfy/blue{
-	icon_state = "comfychair_preview";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "sHb" = (
 /obj/structure/closet/secure_closet/medical_torchsenior,
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -28693,8 +28472,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/locker)
 "sHN" = (
@@ -28720,20 +28497,9 @@
 /area/maintenance/firstdeck/aftport)
 "sLb" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline,
+/obj/effect/floor_decal/corner/paleblue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
-"sLS" = (
-/obj/structure/bed/chair/padded/blue{
-	dir = 8;
-	icon_state = "chair_preview"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medicalhallway)
 "sMf" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/alarm{
@@ -28820,23 +28586,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
-"sPa" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medicalhallway)
 "sPb" = (
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
 	id_tag = "xeno_airlock_control";
@@ -28994,31 +28743,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"sWJ" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id_tag = "infirm_windows";
-	name = "Infirmary Window Lockdown";
-	opacity = 0
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/medicalhallway)
 "sWP" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/structure/bed/chair/wheelchair,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/shipping_wall/filled{
 	pixel_y = 32
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
 "sXb" = (
@@ -29172,6 +28905,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
+"tgg" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/item/modular_computer/telescreen/preset/medical{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medicalhallway)
 "tgs" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig Chief"
@@ -29309,6 +29051,9 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology)
 "tmc" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -29357,17 +29102,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"tpJ" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	controlled = 0;
-	internal_pressure_bound = 35000;
-	internal_pressure_bound_default = 35000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	use_power = 1
-	},
-/turf/simulated/floor/airless,
-/area/thruster/d1starboard)
 "tqb" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/window/southright{
@@ -29530,6 +29264,9 @@
 	dir = 10;
 	icon_state = "edge"
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -29538,13 +29275,15 @@
 /obj/item/device/mmi,
 /obj/item/reagent_containers/ivbag/nanoblood,
 /obj/item/reagent_containers/ivbag/nanoblood,
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "tCO" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/item/auto_cpr,
 /obj/item/bodybag/rescue/loaded,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
@@ -29559,8 +29298,7 @@
 	pixel_y = 32
 	},
 /obj/structure/table/standard,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "tEs" = (
 /obj/structure/filingcabinet/chestdrawer{
@@ -29697,10 +29435,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
-"tVf" = (
-/obj/effect/floor_decal/industrial/firstaid/corner,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "tVi" = (
 /obj/structure/sign/warning/hot_exhaust{
 	dir = 8;
@@ -29857,21 +29591,20 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
 "umT" = (
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 4;
+	icon_state = "spline_plain"
+	},
 /obj/structure/bed/roller,
 /obj/item/device/radio/intercom/department/medbay{
 	dir = 4;
 	pixel_x = -24
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 4;
-	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -29905,16 +29638,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "uuS" = (
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 1;
-	pixel_y = -28
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
 "uvj" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -30024,22 +29759,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "uKs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	icon_state = "borderfloor_white";
-	dir = 8
+/obj/machinery/pager/medical{
+	pixel_x = -23;
+	pixel_y = -10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
@@ -30134,27 +29859,25 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/brig)
 "uUK" = (
-/obj/structure/closet/secure_closet/chemical,
-/obj/item/storage/box/pillbottles,
-/obj/item/device/radio/headset/headset_med,
-/obj/item/book/manual/chemistry_recipes,
-/obj/item/clothing/glasses/science,
-/obj/machinery/button/blast_door{
-	id_tag = "chemcounter";
-	name = "Chemistry Counter Lockdown Control";
-	pixel_x = -6;
-	pixel_y = -24
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Infirmary - Chemistry";
+/obj/structure/table/rack{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
+/obj/item/device/scanner/spectrometer,
+/obj/item/storage/box/freezer,
+/obj/item/storage/box/beakers/insulated,
+/obj/item/reagent_containers/dropper,
+/obj/item/storage/box/beakers,
+/obj/item/hand_labeler,
+/obj/item/stack/package_wrap/twenty_five,
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
+	name = "Chemistry Cleaner"
 	},
-/obj/effect/floor_decal/corner/yellow/mono,
-/obj/effect/floor_decal/industrial/outline,
-/obj/item/screwdriver,
+/obj/effect/floor_decal/corner/beige/mono,
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "uVf" = (
@@ -30304,7 +30027,7 @@
 /area/command/conference)
 "vii" = (
 /obj/structure/closet/secure_closet/medical_torch,
-/obj/effect/floor_decal/corner/blue/mono,
+/obj/effect/floor_decal/corner/paleblue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/locker)
@@ -30351,6 +30074,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury)
 "vnC" = (
+/obj/effect/floor_decal/corner/paleblue/mono,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -30364,7 +30088,6 @@
 /obj/structure/table/standard,
 /obj/item/device/flashlight/pen,
 /obj/item/clothing/accessory/stethoscope,
-/obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/exam_room)
 "vpA" = (
@@ -30454,7 +30177,7 @@
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
 "vEa" = (
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
@@ -30494,12 +30217,14 @@
 /area/thruster/d1port)
 "vHB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "vIn" = (
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -30508,13 +30233,13 @@
 	name = "Infirmary Public Hallway Lockdown";
 	opacity = 0
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/firstaid/fulltile,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "vIP" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -30612,6 +30337,9 @@
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d1starboard)
 "vZI" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/camera/network/medbay{
 	c_tag = "Infirmary - Equipment Storage";
@@ -30626,20 +30354,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
 "vZK" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
@@ -30652,18 +30377,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
-"wdq" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id_tag = "infirm_windows";
-	name = "Infirmary Window Lockdown";
-	opacity = 0
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/medpaperworkoffice)
 "whd" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -30747,11 +30460,11 @@
 /obj/item/storage/box/rxglasses,
 /obj/item/clothing/accessory/stethoscope,
 /obj/item/device/flashlight/pen,
+/obj/effect/floor_decal/corner/paleblue/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
 "wmK" = (
@@ -30902,10 +30615,6 @@
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
-"wLC" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/wall/ocp_wall,
-/area/thruster/d1starboard)
 "wMh" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/orange,
@@ -31083,6 +30792,10 @@
 	dir = 6;
 	icon_state = "edge"
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 1;
+	icon_state = "corner_white"
+	},
 /obj/machinery/button/windowtint{
 	id = "or1";
 	pixel_x = -6;
@@ -31098,10 +30811,6 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/secure/biohazard/alt,
-/obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "xxB" = (
@@ -31146,6 +30855,7 @@
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "xzN" = (
+/obj/effect/floor_decal/corner/paleblue/mono,
 /obj/item/flame/candle/scented/incense{
 	desc = "An incense cone. It produces fragrant smoke when burned. This one is branded 'IQ-incense, for the smart and sensual.' "
 	},
@@ -31155,7 +30865,6 @@
 	},
 /obj/structure/table/glass,
 /obj/random_multi/single_item/memo_medical,
-/obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/medpaperworkoffice)
 "xBk" = (
@@ -31237,6 +30946,14 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
+"xKz" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass/civilian,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/hallway/primary/firstdeck/center)
 "xKY" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8;
@@ -31246,18 +30963,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
-"xLj" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	controlled = 0;
-	dir = 1;
-	internal_pressure_bound = 35000;
-	internal_pressure_bound_default = 35000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	use_power = 1
-	},
-/turf/simulated/floor/airless,
-/area/thruster/d1port)
 "xMx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -31276,9 +30981,6 @@
 /area/maintenance/firstdeck/centralport)
 "xMy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
 "xMP" = (
@@ -31332,10 +31034,6 @@
 /obj/structure/sign/emergonly{
 	pixel_y = 26
 	},
-/obj/effect/floor_decal/industrial/firstaid/corner{
-	icon_state = "stripecorner";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/center)
 "xTc" = (
@@ -31359,8 +31057,7 @@
 /obj/machinery/sleeper{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline,
+/obj/effect/floor_decal/corner/paleblue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
 "xTT" = (
@@ -31399,7 +31096,7 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
 "ycz" = (
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
@@ -31447,11 +31144,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
-"yhw" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/prepainted,
-/area/medical/chemistry)
 "yii" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
@@ -49940,7 +49636,7 @@ kHb
 acy
 sGs
 leb
-axa
+xKz
 aym
 jsk
 aAK
@@ -50944,7 +50640,7 @@ jcu
 umT
 glb
 bGZ
-tVf
+ezb
 gyV
 oCf
 pjV
@@ -51145,14 +50841,14 @@ etb
 eRb
 anM
 ads
-cqc
-gQx
+ewb
+fEb
 aga
 agc
 ago
-lCo
+agc
 agZ
-gaB
+ycz
 heb
 ure
 auN
@@ -51342,7 +51038,7 @@ cFb
 deb
 poS
 dMb
-azu
+dZb
 eTb
 eHb
 avO
@@ -51354,7 +51050,7 @@ agi
 ags
 agI
 aha
-gaB
+ycz
 ayg
 ure
 auN
@@ -51549,7 +51245,7 @@ ewb
 fEb
 fEb
 adB
-kNi
+dZb
 afd
 gyV
 agj
@@ -51751,13 +51447,13 @@ exb
 ixf
 anL
 adH
-kNi
+dZb
 afB
 lHO
-gMF
+agj
 aGx
 agY
-leb
+fMr
 ivT
 gxX
 dDc
@@ -51951,9 +51647,9 @@ sLb
 agB
 pPa
 xTh
-xTh
+fvb
 adL
-kNi
+dZb
 afD
 lHO
 afH
@@ -52155,13 +51851,13 @@ pPa
 ezb
 fKb
 adL
-kNi
+dZb
 afK
 gyV
 agH
-cic
+agx
 oLK
-fMr
+leb
 ivT
 hgb
 flB
@@ -52356,14 +52052,14 @@ ebb
 eAb
 eUb
 mvE
-dpZ
-kNi
-mmA
-lHO
+adL
+dZb
+afK
+gyV
 siI
-bMp
+aGx
 qrq
-leb
+ahc
 vHB
 ayB
 nWl
@@ -52559,11 +52255,11 @@ aby
 abH
 acf
 adO
-nzg
+dZb
 afY
 lHO
 anH
-ieS
+agx
 jCU
 leb
 hdb
@@ -52759,16 +52455,16 @@ abl
 abr
 abA
 abK
-yhw
+acf
 adQ
 afb
-agd
-nAm
-orb
-orb
-owb
-sWJ
-ivT
+afZ
+lHO
+ofb
+gzb
+ovb
+leb
+dMe
 hnN
 mpq
 htb
@@ -52964,13 +52660,13 @@ abQ
 acO
 aed
 afe
-hyG
+agd
 uKs
-sPa
-sPa
-sPa
+orb
+orb
+owb
 gWb
-igk
+ivT
 hhb
 iVb
 hub
@@ -53154,8 +52850,8 @@ mpy
 mpy
 uXe
 adw
-uXe
-uXe
+sde
+sde
 uXe
 scd
 acf
@@ -53169,8 +52865,8 @@ aff
 agf
 fWb
 mzb
-aGp
-aGp
+mzb
+mzb
 vIn
 ssg
 bEQ
@@ -53356,10 +53052,10 @@ mpy
 mpy
 acJ
 adw
+sde
 uXe
 uXe
-uXe
-uXe
+sde
 acf
 acf
 abu
@@ -53372,7 +53068,7 @@ agh
 hEU
 ael
 oxb
-sLS
+oxb
 pzZ
 axw
 iTC
@@ -53571,11 +53267,11 @@ acf
 aen
 afh
 aqL
-nCb
-nCb
-gEb
-gEb
-nCb
+dXM
+tgg
+gDb
+gDb
+gWb
 hdb
 jAM
 equ
@@ -53760,9 +53456,9 @@ mpy
 mpy
 xTT
 adv
-uXe
-uXe
-uXe
+sde
+sde
+sde
 dEb
 dQb
 acf
@@ -53771,14 +53467,14 @@ uUK
 acf
 acf
 aeo
-afg
+afi
 aqM
-nBb
-fsX
-loS
-pTB
-gXb
-ivT
+nCb
+nCb
+gEb
+gEb
+nCb
+axy
 hib
 oAp
 haT
@@ -53970,14 +53666,14 @@ rAu
 rAu
 rAu
 rAu
-rAu
+acz
 adj
 aep
-afb
-owb
+afh
+fOb
 nBb
 ata
-loS
+aua
 avl
 gXb
 vHB
@@ -54172,7 +53868,7 @@ cZb
 rAu
 ejb
 eIb
-rAu
+acz
 adl
 aeu
 afk
@@ -54181,7 +53877,7 @@ fYb
 atb
 xMy
 gRb
-hGo
+gXb
 ivT
 hnN
 gAU
@@ -54381,7 +54077,7 @@ afl
 aqP
 nBb
 iMW
-oRI
+twz
 oZb
 gXb
 ivT
@@ -54576,10 +54272,10 @@ rAu
 rAu
 udY
 aOt
-rAu
+acz
 adn
 aeB
-afl
+afm
 qLr
 nCb
 omb
@@ -55797,7 +55493,7 @@ nDd
 eoj
 gFb
 bLJ
-wdq
+xYM
 jYZ
 ugg
 jlb
@@ -55999,9 +55695,9 @@ ipc
 eoj
 gFb
 xzN
-wdq
-ivT
-hnN
+xYM
+axD
+ayC
 job
 abk
 abk
@@ -56202,8 +55898,8 @@ dSR
 mlb
 avu
 xYM
-qPj
-kCZ
+ivT
+hnN
 cgu
 ahd
 ahk
@@ -56787,7 +56483,7 @@ aaa
 aaa
 abM
 abN
-qFY
+aci
 mEV
 abL
 abL
@@ -56831,7 +56527,7 @@ aSf
 dIA
 bUZ
 wEw
-hqs
+bvI
 xPU
 abM
 aaa
@@ -56989,7 +56685,7 @@ aaa
 aaa
 abM
 abN
-qFY
+aci
 mEV
 abL
 abL
@@ -57033,8 +56729,8 @@ tCu
 nPT
 xaC
 wEw
-hqs
-xPU
+bvI
+jbk
 abM
 aaa
 aaa
@@ -57191,7 +56887,7 @@ aaa
 aaa
 abM
 abN
-qFY
+aci
 mEV
 abL
 abL
@@ -57235,8 +56931,8 @@ aDB
 aDB
 aDB
 wEw
-hqs
-xPU
+bvI
+jbk
 abM
 aaa
 aaa
@@ -57393,7 +57089,7 @@ aaa
 aaa
 abN
 abN
-qFY
+aci
 abN
 mpy
 mpy
@@ -59016,7 +58712,7 @@ aet
 afw
 agw
 aet
-hkQ
+abN
 aaa
 acd
 acd
@@ -59046,7 +58742,7 @@ acd
 acd
 acd
 aaa
-hPp
+xPU
 aPq
 aRg
 aSh
@@ -59612,11 +59308,11 @@ aaa
 aaa
 aaa
 aaa
-hQd
+abN
 abN
 abN
 acp
-kfG
+add
 adI
 aey
 afz
@@ -59658,11 +59354,11 @@ aRj
 aSk
 aSS
 aTo
-rYd
+aTX
 aUm
 xPU
 xPU
-qhd
+xPU
 aaa
 aaa
 aaa
@@ -59814,8 +59510,8 @@ aaa
 aaa
 aaa
 aaa
-tpJ
-wLC
+abN
+abN
 abZ
 acq
 ade
@@ -59863,8 +59559,8 @@ qDM
 aTY
 aUn
 aUy
-fBP
-xLj
+xPU
+xPU
 aaa
 aaa
 aaa
@@ -60016,7 +59712,7 @@ aaa
 aaa
 aaa
 aaa
-hQd
+abN
 abN
 aca
 aca
@@ -60066,7 +59762,7 @@ xPU
 aQo
 aQo
 xPU
-qhd
+xPU
 aaa
 aaa
 aaa


### PR DESCRIPTION
## About the Pull Request

[This PR](https://github.com/Baystation12/Baystation12/pull/30712) on Bay made a major shift in the aesthetic to the infirmary, and some minor structural changes. It was reverted after about a week due to a few things, although some compromises happened. The PR itself broke a few things, and removed more than one important thing in the infirmary. These were fixed on Bay before the revert, but we still use a version of bay without the fixes.

This was done by just copying the deck 1 file from mainstream bay and dropping it here. There is very little code differences and no further changes to deck 1 between the two, so it worked out of the box.

## Why It's Good For The Game

The current infirmary lacks several key items: the nanoblood locker, a rescue bag, and an extra auto-compressor. With these things, especially the nanoblood, medical is much harder to play. A lot of the aesthetics also received mixed reception. It's my hope that going into Baycode with a proper medbay will help people learn.

## Did you test it?

Compiles with no errors. I also entered a round and toured the area with a captain ID to make sure everything was correct. I didn't have any runtimes while looking around, and it loads correctly with no errors in both Dream Maker and SDMM.

## Changelog

:cl:
maptweak: Reverts the prior medbay changes committed by Huntime due to a few stability errors and general mixed reception.
/:cl: