### PR TITLE
Updates the changelog header, tegu-ifies some bay references

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -1,4 +1,4 @@
-/var/server_name = "Baystation 12"
+/var/server_name = "TeguStation"
 /var/game_id = null
 
 GLOBAL_VAR(href_logfile)

--- a/code/hub.dm
+++ b/code/hub.dm
@@ -3,7 +3,7 @@
  * You can also toggle visibility from in-game with toggle-hub-visibility; be aware that it takes a few minutes for the hub go
  */
 	hub = "Exadv1.spacestation13"
-	name = "Space Station 13 - Baystation 12"
+	name = "Space Station 13 - TeguStation"
 
 /world/proc/update_hub_visibility(new_status)
 	if (isnull(new_status))

--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -1,11 +1,11 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-  <title>Baystation 12 Changelog</title>
+  <title>TeguStation Changelog</title>
   <link rel="stylesheet" type="text/css" href="changelog.css">
   <base target="_blank" />
   <script type='text/javascript'>
-  
+
 	function changeText(tagID, newText, linkTagID){
 		var tag = document.getElementById(tagID);
 		tag.innerHTML = newText;
@@ -13,8 +13,8 @@
 		linkTag.removeAttribute("href");
 		linkTag.removeAttribute("onclick");
 	}
-	
-  </script>  
+
+  </script>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 </head>
 
@@ -23,36 +23,35 @@
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-			<div align='center'><font size='3'><b>Baystation 12</b></font></div>
+			<div align='center'><font size='3'><b>TeguStation</b></font></div>
 			<div align='center'><font size='3'><b><i>A Space Station 13 Project</i></b></font></div>
-			
-			<p><div align='center'><font size='3'><a href="http://wiki.baystation12.net/">Wiki</a> | <a href="https://github.com/Baystation12/Baystation12/">Source code</a></font></div></p>
+
+			<p><div align='center'><font size='3'><a href="https://wiki.tegustation.com">Wiki</a> | <a href="https://github.com/vlggms/tegustation-bay12">Source code</a></font></div></p>
             <font size='2'>Code licensed under <a href="http://www.gnu.org/licenses/agpl.html">AGPLv3</a>. Content licensed under <a href="http://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>.<br><br>
-			<font size='2'><b>Visit our IRC channels:</b> #bs12 and #codershuttle on irc.sorcery.net</font><br>
-			<font size='2'><b>Join our Discord server:</b> <a href='https://discord.gg/DrtRFxs'>-Click Here-</a><br></font>
-			<font size='2'><b>Support Baystation on Patreon:</b> <a href='https://www.patreon.com/bs12'>-Click Here-</a><br></font>
+			<font size='2'><b>Join our Discord server:</b> <a href='https://discord.gg/AzmEhtH'>-Click Here-</a><br></font>
+			<font size='2'><b>Support TeguStation on Patreon:</b> <a href='https://www.patreon.com/vlggms'>-Click Here-</a><br></font>
 			</td>
 	</tr>
 </table>
 
-<br><b>Baystation 12 Credit List</b>
+<br><b>TeguStation Credit List</b>
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-            <font size='2'><b>Developers:</b> afterthought, chinsky, F-Tang Steve, mloc, PsiOmegaDelta, xales<br></font>
-			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/Baystation12/Baystation12/graphs/contributors'>-Click Here-</a><br></font>
-			<p><font size='2'><b>Credits:</b> Abi79, Apple_Master, Arcalane, Aryn, babydoll, Cael_Aislinn, Ccomp5950, chinsky, CompactNinja, Deus Dactyl, DopeGhoti, Erthilo, Flashkirby, Hawk_v3, Head, Ipsil, Invisty, JoeyJo0, Lexusjjss, Melonstorm, Miniature, mloc, NerdyBoy1104, PsiOmegaDelta, Searif, SkyMarshal, Snapshot, Spectre, Strumpetplaya, Sunfall, Tastyfish, Uristqwerty, Xenone, cib, faux, Zuhayr<br></p>
-			<font size='2'><b>Special thanks to:</b> The developers of /tg/station, /vg/station, GoonStation, the original Space Station 13, and BYOND</font>
-			<div align='center'><font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Baystation12/Baystation12/issues?labels=Bug&state=open">Issue Tracker</a>.<br></font></div>
+            <font size='2'><b>Project creators:</b> Egor Dinamit, Cupax3, DeadmonWonderland, Ilysen, Mizalona, Samuuu3, SkyCinnamon, Atlas & Steppy<br></font>
+			<font size='2'><b>Currently active GitHub contributor list:</b> <a href='https://github.com/vlggms/tegustation-bay12/graphs/contributors'>-Click Here-</a><br></font>
+			<p><font size='2'><b>Credits:</b> Abi79, afterthought, Apple_Master, Arcalane, Aryn, Azlan, babydoll, Cael_Aislinn, Ccomp5950, chinsky, CompactNinja, Deus Dactyl, DopeGhoti, Erthilo, Flashkirby, F-Tang Steve, Hawk_v3, Head, Ipsil, Invisty, JoeyJo0, Lexusjjss, Melonstorm, Miniature, MistakeNot4982, mloc, NerdyBoy1104, Pawn, PsiOmegaDelta, Searif, SierraKomodo, SkyMarshal, Snapshot, Spectre, Spookerton, Strumpetplaya, Sunfall, Tastyfish, Uristqwerty, xales, Xenone, cib, faux, Zuhayr<br></p>
+			<font size='2'><b>Special thanks to:</b> The developers of Baystation 12, /tg/station, /vg/station, GoonStation, the original Space Station 13, and BYOND</font>
+			<div align='center'><font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/vlggms/tegustation-bay12/issues">Issue Tracker</a>.<br></font></div>
 		</td>
 	</tr>
 </table>
 
 		<!--
-		
-		TO ADD AN ENTRY, ADD AND MAINTAIN YOUR OWN changelog/USERNAME.yml FILE. 
-		
+
+		TO ADD AN ENTRY, ADD AND MAINTAIN YOUR OWN changelog/USERNAME.yml FILE.
+
 		*** DO NOT MODIFY THIS FILE OR YOU WILL CAUSE MERGE CONFLICTS. ***
-		
+
 		-->
 		<div class="commit sansserif">


### PR DESCRIPTION
## About the Pull Request

The Bay codebases has a lot of default references to `Baystation 12`, including world name, the changelog header, and so on. This PR renames these instances to `TeguStation` where applicable. Other changes include:

* The changelog header's links have all been updated.
* The `Developers` section has been changed to `Project creators`, and filled out with the names of people who helped start up Bay-Tegu. I wouldn't have put my own name in, but Sam chewed me out about giving myself more credit.
* Baystation 12 has been added to the front of the special thanks list.
* Azlan and Pawn have been added to Credits list, as we'll likely be porting their voidsuit sprites once they're ready.

## Why It's Good For The Game

TeguStation aims to be different in a few ways from Bay, and updating the naming schemes both solidifies its identity as well as maintaining a more solid look, instead of inheriting a lot of old links from Bay.

Additionally, a lot of people were involved in initiating and finalizing the move to baycode, and giving these people proper credit seems like a kind thing to do. The Baystation 12 project itself is also owed an immense debt due to the whole codebase being what it is right now, and so they've been included at the top of Special thanks.

## Did you test it?

The changelog header and world name updates work in-game. The changelog update only happens correctly when changing `changelog.html`, but I believe that this file is auto-generated from `header.html` - the file with the changes. Hopefully, automatic changelog generation will thus make that happen!

I can't test the hub name things, for obvious reasons.

Config changes to the wiki URL and so on may also be necessary, but I can't do those from a PR. They'll be to up to the admins.

<details><summary>Window name</summary>

![image](https://user-images.githubusercontent.com/47678781/121853597-18b0ec80-ccbf-11eb-803e-1f17dcfc0e76.png)
</details>

<details><summary>Changelog popup</summary>

![image](https://user-images.githubusercontent.com/47678781/121956416-1c7c5780-cd2f-11eb-9273-0f354e70b517.png)
</details>

## Changelog

🆑
spellcheck: Rewrote the in-game Changelog popup to mention TeguStation instead of Baystation 12. Lots of people from the Baystation 12 dev team have been added to the credits as a result.
/🆑

## Notes

The individuals currently on the creators list includes the following. A checked box means the individual is aware of their spot in the list and have given the all-clear to include themselves in it.
- [x] Egor Dinamit
- [x] Cupax3
- [x] DeadmonWonderland
- [x] Ilysen (myself, at Sam's insistence)
- [x] Mizalona
- [x] Samuuu3
- [x] SkyCinnamon
- [x] Atlas & Steppy (as an easter egg/little joke)

I'd like to be very certain that all of these individuals are okay with being on this list. In addition, if anyone is missing from this list that should be on there, please let me know so that I can add them.