### PR TITLE
Lube1

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -31,7 +31,6 @@
 /datum/reagent/crayon_dust/purple
 	name = "Purple crayon dust"
 	color = "#cc0099"
-
 /datum/reagent/crayon_dust/grey //Mime
 	name = "Grey crayon dust"
 	color = "#808080"
@@ -306,7 +305,7 @@
 /datum/reagent/lube/touch_turf(var/turf/simulated/T)
 	if(!istype(T))
 		return
-	if(volume >= 1)
+	if(volume >= 20)
 		T.wet_floor(80)
 
 /datum/reagent/oil

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -295,6 +295,20 @@
 	M.update_icons()
 	M.clean_blood()
 
+/datum/reagent/lube
+	name = "Space Lube"
+	description = "Lubricant is a substance introduced between two moving surfaces to reduce the friction and wear between them. giggity."
+	taste_description = "slime"
+	reagent_state = LIQUID
+	color = "#009ca8"
+	value = 0.6
+
+/datum/reagent/lube/touch_turf(var/turf/simulated/T)
+	if(!istype(T))
+		return
+	if(volume >= 1)
+		T.wet_floor(80)
+
 /datum/reagent/oil
 	name = "Oil"
 	description = "A thick greasy industrial lubricant. Commonly found in robotics."
@@ -523,27 +537,27 @@
 /datum/reagent/colored_hair_dye/red
 	name = "Red Hair Dye"
 	color = "#b33636"
-	
+
 /datum/reagent/colored_hair_dye/orange
 	name = "Orange Hair Dye"
 	color = "#b5772f"
-	
+
 /datum/reagent/colored_hair_dye/yellow
 	name = "Yellow Hair Dye"
 	color = "#a6a035"
-		
+
 /datum/reagent/colored_hair_dye/green
 	name = "Green Hair Dye"
 	color = "#61a834"
-	
+
 /datum/reagent/colored_hair_dye/blue
 	name = "Blue Hair Dye"
 	color = "#3470a8"
-	
+
 /datum/reagent/colored_hair_dye/purple
 	name = "Purple Hair Dye"
 	color = "#6d2d91"
-		
+
 /datum/reagent/colored_hair_dye/grey
 	name = "Grey Hair Dye"
 	color = "#696969"


### PR DESCRIPTION
Re-adds space lube

Now obtainable as a random chance inside plants on exoplanets. Changes the way lube works so that 20 units of it are needed to make one tile of floor slippery, to prevent grief. 

Space lube is a fun chemical with an interesting function. Everyone loves slip-n-slides, but the potential for grief with the chemical was far too great. This is no longer the case, as it is now much harder to obtain, and works differently (you used to only need one unit to make a tile slippery). In it's changed form, it is now almost completely harmless and those of us who enjoy lubricated flooring can rest easy knowing it is once again, with a considerable amount of effort and luck, to use space lube again in a way that doesn't ruin the experience of others.

Tested on a local server, works like it should.
