### PR TITLE
Bioprinter/prosthetics fabricator refactoring and UI overhaul

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -292,3 +292,9 @@
 #define INIT_MACHINERY_PROCESS_ALL 0x3
 //--
 
+
+// Helper procs for easy HTML browser button creation.
+#define UIBUTTON(key, label, title) "[title ? title + ": " : ""]<a href='?src=\ref[src];[key]=1'>[label]</a>"
+
+#define UI_FONT_GOOD(X) "<font color='55cc55'>[X]</font>"
+#define UI_FONT_BAD(X) "<font color='cc5555'>[X]</font>"

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -25,19 +25,21 @@
 
 /obj/machinery/organ_printer/state_transition(var/decl/machine_construction/default/new_state)
 	. = ..()
-	if(istype(new_state))
+	if (istype(new_state))
 		updateUsrDialog()
 
 /obj/machinery/organ_printer/on_update_icon()
 	overlays.Cut()
-	if(panel_open)
+	if (panel_open)
 		overlays += "[icon_state]_panel_open"
-	if(printing)
+	if (printing)
 		overlays += "[icon_state]_working"
 
 /obj/machinery/organ_printer/examine(mob/user)
 	. = ..()
 	to_chat(user, SPAN_NOTICE("It is loaded with [stored_matter]/[max_stored_matter] matter units."))
+	if (printing)
+		to_chat(user, SPAN_NOTICE("It is currently printing."))
 
 /obj/machinery/organ_printer/RefreshParts()
 	print_delay = initial(print_delay)
@@ -52,57 +54,116 @@
 	return !printing && ..()
 
 /obj/machinery/organ_printer/cannot_transition_to(path)
-	if(printing)
-		return SPAN_NOTICE("You must wait for \the [src] to finish printing first!")
+	if (printing)
+		return SPAN_WARNING("You must wait for \the [src] to finish printing first!")
 	return ..()
 
-/obj/machinery/organ_printer/physical_attack_hand(mob/user, var/choice = null)
-	if(printing)
+/obj/machinery/organ_printer/attackby(obj/item/I, mob/user)
+	if (process_item(I, user))
 		return
+	. = ..()
 
-	if(!choice)
-		choice = input("What would you like to print?") as null|anything in products
+/obj/machinery/organ_printer/interface_interact(mob/living/user)
+	ui_interact(user)
+	return TRUE
 
-	if(!choice || printing || !CanPhysicallyInteract(user))
-		return TRUE
+/obj/machinery/organ_printer/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null)
+	var/data = list()
 
-	if(!can_print(choice))
-		return TRUE
+	data["special_data"] = get_special_data()
+	data["print_time"] = print_delay / 10
+	data["stored_matter"] = stored_matter
+	data["max_matter"] = max_stored_matter
+	data["printing"] = printing
 
-	stored_matter -= products[choice][2]
+	data["product_list"] = list()
+	if (products)
+		for (var/V in products)
+			var/product_data = list()
+			product_data["product"] = V
+			product_data["req_matter"] = products[V][2]
+			product_data["parsed_name"] = parse_zone(V)
+			product_data["can_print"] = can_print(V)
+			data["product_list"] += list(product_data)
 
-	update_use_power(POWER_USE_ACTIVE)
-	printing = 1
-	update_icon()
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, data)
+	if(!ui)
+		ui = new(user, src, ui_key, "bioprinter.tmpl", name, 550, 700)
+		ui.set_initial_data(data)
+		ui.open()
+		ui.auto_update_layout = TRUE
+		ui.set_auto_update(1)
 
-	sleep(print_delay)
+/// Attempts to run special logic for this item, such as turning it into matter or giving DNA samples. Return TRUE if you want to interrupt the normal attackby.
+/obj/machinery/organ_printer/proc/process_item(obj/item/I, mob/living/user)
+	return
 
-	update_use_power(POWER_USE_IDLE)
-	printing = 0
-	update_icon()
+/// Returns an joined list of HTML data for this organ printer's interface.
+/obj/machinery/organ_printer/proc/get_ui_data()
+	var/list/dat = list()
+	dat += get_special_data()
+	dat += "<b>Stored matter:</b> [stored_matter]/[max_stored_matter]"
+	dat += "<b>Time to print:</b> [print_delay <= 0 ? "Instant" : "[print_delay / 10] second\s"]"
+	dat += "<hr>"
+	if (!printing)
+		for (var/O in products)
+			var/parsed_zone = parse_zone(O)
+			var/print_cost = products[O][2]
+			if (!can_print(O))
+				dat += "Print [parsed_zone] - [stored_matter]/[print_cost] <b>[UI_FONT_BAD("\[INSUFFICIENT\]")]</b>"
+			else
+				dat += "[UIBUTTON("to_print=[O];print", "Print", null)] [parsed_zone] - [print_cost]/[print_cost]"
+	else
+		dat += UI_FONT_BAD("\The [name] is currently operating. Please wait...")
+	return jointext(dat, "<br>")
 
-	if(!choice || !src || (stat & (BROKEN|NOPOWER)))
-		return TRUE
+/// Fetches HTML data unique to this subtype.
+/obj/machinery/organ_printer/proc/get_special_data()
+	return
 
-	print_organ(choice)
+/// Checks if this machine can print an organ. By default, this only checks for stored matter.
+/obj/machinery/organ_printer/proc/can_print(choice)
+	return stored_matter >= products[choice][2]
 
-/obj/machinery/organ_printer/proc/can_print(var/choice)
-	if(stored_matter < products[choice][2])
-		visible_message(SPAN_NOTICE("\The [src] displays a warning: 'Not enough matter. [stored_matter] stored and [products[choice][2]] needed.'"))
-		return 0
-	return 1
-
-/obj/machinery/organ_printer/proc/print_organ(var/choice)
+/// Creates an organ based on the provided choice and places it on our turf. Returns the created organ.
+/obj/machinery/organ_printer/proc/print_organ(choice)
 	var/new_organ = products[choice][1]
 	var/obj/item/organ/O = new new_organ(get_turf(src))
 	O.status |= ORGAN_CUT_AWAY
 	return O
-// END GENERIC PRINTER
 
-// ROBOT ORGAN PRINTER
+/// Attempts to print an organ based on the chosen type. Returns the created organ if it is made, or FALSE if it is not.
+/obj/machinery/organ_printer/proc/attempt_to_print(choice, mob/living/user)
+	update_use_power(POWER_USE_IDLE)
+	printing = FALSE
+	update_icon()
+	if (!choice || inoperable())
+		return FALSE
+	if (!QDELETED(user) && CanPhysicallyInteract(user))
+		ui_interact(user) // Refresh the window if we're still nearby
+	return print_organ(choice)
+
+/obj/machinery/organ_printer/OnTopic(mob/user, href_list, datum/topic_state/state)
+	if (href_list["to_print"])
+		if (operable() && !printing)
+			visible_message(SPAN_NOTICE("\The [src] begins printing \the [parse_zone(href_list["to_print"])]."))
+			stored_matter -= products[href_list["to_print"]][2]
+			update_use_power(POWER_USE_ACTIVE)
+			printing = TRUE
+			update_icon()
+			addtimer(CALLBACK(src, .proc/attempt_to_print, href_list["to_print"], user), print_delay)
+			return TOPIC_REFRESH
+
+
+
+
+////////////////////////////////////////////////
+// PROSTHESES FABRICACTOR - Mechanical organs //
+////////////////////////////////////////////////
+
 /obj/machinery/organ_printer/robot
-	name = "prosthetic organ fabricator"
-	desc = "It's a machine that prints prosthetic organs."
+	name = "prostheses fabricator"
+	desc = "It's a machine that fabricates mechanical limbs and organs from compressed steel."
 	icon_state = "roboprinter"
 	base_type = /obj/machinery/organ_printer/robot
 
@@ -121,10 +182,10 @@
 		BP_R_FOOT   = list(/obj/item/organ/external/foot/right, 40),
 		BP_L_HAND   = list(/obj/item/organ/external/hand,       40),
 		BP_R_HAND   = list(/obj/item/organ/external/hand/right, 40),
-		BP_CELL		= list(/obj/item/organ/internal/cell, 25)
-		)
+		BP_CELL		= list(/obj/item/organ/internal/cell,       25)
+	)
 
-	machine_name = "prosthetic organ fabricator"
+	machine_name = "prostheses fabricator"
 	machine_desc = "Creates prosthetic limbs and organs by using steel sheets."
 	var/matter_amount_per_sheet = 10
 	var/matter_type = MATERIAL_STEEL
@@ -134,71 +195,88 @@
 	stored_matter = max_stored_matter
 
 /obj/machinery/organ_printer/robot/dismantle()
-	if(stored_matter >= matter_amount_per_sheet)
+	if (stored_matter >= matter_amount_per_sheet)
 		new /obj/item/stack/material/steel(get_turf(src), Floor(stored_matter/matter_amount_per_sheet))
 	return ..()
 
-/obj/machinery/organ_printer/robot/print_organ(var/choice)
+/obj/machinery/organ_printer/robot/print_organ(choice)
 	var/obj/item/organ/O = ..()
 	O.robotize()
 	O.status |= ORGAN_CUT_AWAY  // robotize() resets status to 0
-	visible_message(SPAN_INFO("\The [src] churns for a moment, then spits out \a [O]."))
-	playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
+	visible_message(SPAN_NOTICE("\The [src] churns for a moment, then spits out \a [O]."))
+	playsound(src, 'sound/machines/ding.ogg', 50, TRUE)
 	return O
 
-/obj/machinery/organ_printer/robot/attackby(var/obj/item/W, var/mob/user)
+/obj/machinery/organ_printer/robot/process_item(obj/item/W, mob/living/user)
 	var/add_matter = 0
-	var/object_name = "[W]"
+	var/object_name = "[W]" // Cache the name of our object in case we use it up
 
-	if(istype(W, /obj/item/stack/material) && W.get_material_name() == matter_type)
-		if((max_stored_matter-stored_matter) >= matter_amount_per_sheet)
+	// Attempt to process material sheets into stored matter
+	if (istype(W, /obj/item/stack/material) && W.get_material_name() == matter_type)
+		if ((max_stored_matter - stored_matter) >= matter_amount_per_sheet)
 			var/obj/item/stack/S = W
 			var/space_left = max_stored_matter - stored_matter
-			var/sheets_to_take = min(S.amount, Floor(space_left/matter_amount_per_sheet))
-			if(sheets_to_take > 0)
-				add_matter = min(max_stored_matter - stored_matter, sheets_to_take*matter_amount_per_sheet)
+			var/sheets_to_take = min(S.amount, Floor(space_left / matter_amount_per_sheet))
+			if (sheets_to_take > 0)
+				add_matter = min(max_stored_matter - stored_matter, sheets_to_take * matter_amount_per_sheet)
+				object_name = "[sheets_to_take] [S.name]"
 				S.use(sheets_to_take)
 
-	else if(istype(W,/obj/item/organ))
+	// Attempt to process synthetic organs
+	else if (istype(W, /obj/item/organ))
 		var/obj/item/organ/O = W
-		if((O.organ_tag in products) && istype(O, products[O.organ_tag][1]))
-			if(!BP_IS_ROBOTIC(O))
+		if ((O.organ_tag in products) && istype(O, products[O.organ_tag][1]))
+			if (!BP_IS_ROBOTIC(O))
 				to_chat(user, SPAN_WARNING("\The [src] only accepts robotic organs."))
 				return
 			var/recycle_worth = Floor(products[O.organ_tag][2] * 0.5)
-			if((max_stored_matter-stored_matter) >= recycle_worth)
+			if ((max_stored_matter - stored_matter) >= recycle_worth)
 				add_matter = recycle_worth
 				qdel(O)
 		else
 			to_chat(user, SPAN_WARNING("\The [src] does not know how to recycle \the [O]."))
 			return
 
-	stored_matter += add_matter
-
-	if(add_matter)
-		to_chat(user, SPAN_INFO("\The [src] processes \the [object_name]. Levels of stored matter now: [stored_matter]"))
+	// We can't recycle this object - continue with normal attackby
 	else
-		to_chat(user, SPAN_WARNING("\The [src] is too full."))
+		return FALSE
 
-	return ..()
-// END ROBOT ORGAN PRINTER
+	// If we got this far, we've attempted to process an item. Give feedback as a result
+	if (add_matter)
+		stored_matter += add_matter
+		to_chat(user, SPAN_NOTICE("\The [src] recycles \the [object_name]. New matter level: [stored_matter]/[max_stored_matter]."))
+	else
+		to_chat(user, SPAN_WARNING("\The [src] can't hold any more material."))
 
-// FLESH ORGAN PRINTER
+	return TRUE // And finally block the normal attackby so we don't smack the fabricator with the item if we still have it
+
+/obj/machinery/organ_printer/robot/get_special_data()
+	return "<b>Some species cannot use prosthetic organs.</b>"
+
+
+
+
+////////////////////////////////
+// BIOPRINTER - Fleshy organs //
+////////////////////////////////
+
 /obj/machinery/organ_printer/flesh
 	name = "bioprinter"
-	desc = "It's a machine that prints replacement organs."
+	desc = "It's a machine that flash-clones organs using biological stock and a provided DNA sample. Compatible with most species."
 	icon_state = "bioprinter"
 	base_type = /obj/machinery/organ_printer/flesh
 	machine_name = "bioprinter"
 	machine_desc = "Bioprinters can create surrogate organs for many species by using a blood sample from the intended recipient. Uses meat for biological matter."
+	// Products are created for the bioprinter when it is given a valid blood sample. The list starts empty
+	products = null
 	// null amount means it will calculate the cost based on get_organ_cost()
 	var/list/amount_list = list(
 		/obj/item/reagent_containers/food/snacks/meat = 50,
 		/obj/item/reagent_containers/food/snacks/rawcutlet = 15,
 		/obj/item/organ = null
-		)
+	)
 	var/datum/dna/loaded_dna_datum
-	var/datum/species/loaded_species //For quick refrencing
+	var/datum/species/loaded_species //For quick referencing
 
 /obj/machinery/organ_printer/flesh/mapped/Initialize()
 	. = ..()
@@ -206,7 +284,7 @@
 
 /obj/machinery/organ_printer/flesh/dismantle()
 	var/turf/T = get_turf(src)
-	if(T)
+	if (T)
 		while(stored_matter >= amount_list[/obj/item/reagent_containers/food/snacks/meat])
 			stored_matter -= amount_list[/obj/item/reagent_containers/food/snacks/meat]
 			new /obj/item/reagent_containers/food/snacks/meat(T)
@@ -215,94 +293,100 @@
 /obj/machinery/organ_printer/flesh/print_organ(var/choice)
 	var/obj/item/organ/O
 	var/new_organ
-	if(loaded_species.has_organ[choice])
+	if (loaded_species.has_organ[choice])
 		new_organ = loaded_species.has_organ[choice]
-	else if(loaded_species.has_limbs[choice])
+	else if (loaded_species.has_limbs[choice])
 		new_organ = loaded_species.has_limbs[choice]["path"]
-	if(new_organ)
+	if (new_organ)
 		O = new new_organ(get_turf(src), loaded_dna_datum)
 		O.status |= ORGAN_CUT_AWAY
 	else
 		O = ..()
-	visible_message(SPAN_INFO("\The [src] churns for a moment, injects its stored DNA into the biomass, then spits out \a [O]."))
-	playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
+	O.name = "surrogate [O.name]"
+	O.color = rgb(230, 255, 230, 255) // Give it a greenish tint to show it's artificially grown
+	visible_message(SPAN_NOTICE("\The [src] churns for a moment, injects its stored DNA into the biomass, then spits out \a [O]."))
+	playsound(src, 'sound/machines/ding.ogg', 50, TRUE)
 	return O
 
-/obj/machinery/organ_printer/flesh/physical_attack_hand(mob/user)
-	if(!loaded_dna_datum || !loaded_species)
-		visible_message(SPAN_INFO("\The [src] displays a warning: 'No DNA saved. Insert a blood sample.'"))
-		return
+/obj/machinery/organ_printer/flesh/get_special_data()
+	if (!loaded_dna_datum || !loaded_species)
+		return UI_FONT_BAD("<b>No DNA saved. Insert a blood sample.</b>")
+	else
+		. = list()
+		. += "<b>DNA hash:</b> [loaded_dna_datum.unique_enzymes]"
+		. += "<b>DNA species:</b> [loaded_species.name]"
+		. = jointext(., "<br>") // This proc call exemplifies byond.
 
-	var/choice = input("What [loaded_species.name] organ would you like to print?") as null|anything in products
-
-	if(!choice)
-		return
-
-	..(user, choice)
-
-/obj/machinery/organ_printer/flesh/attackby(obj/item/W, mob/user)
-	// Load with matter for printing.
-	for(var/path in amount_list)
-		if(istype(W, path))
-			if(max_stored_matter == stored_matter)
-				to_chat(user, SPAN_WARNING("\The [src] is too full."))
+/obj/machinery/organ_printer/flesh/process_item(obj/item/W, mob/living/user)
+	// Attempt to process items for matter
+	for (var/path in amount_list)
+		if (istype(W, path))
+			if (max_stored_matter == stored_matter)
+				to_chat(user, SPAN_WARNING("\The [src] can't hold any more material."))
 				return
-			if(!user.unEquip(W))
+			if (!user.unEquip(W))
 				return
-			var/add_matter = amount_list[path] ? amount_list[path] : 0.5*get_organ_cost(W)
+			var/add_matter = amount_list[path] ? amount_list[path] : 0.5 * get_organ_cost(W)
 			stored_matter += min(add_matter, max_stored_matter - stored_matter)
-			to_chat(user, SPAN_INFO("\The [src] processes \the [W]. Levels of stored biomass now: [stored_matter]"))
+			to_chat(user, SPAN_INFO("\The [src] processes \the [W]. New biomass: [stored_matter]/[max_stored_matter]."))
 			qdel(W)
+			return TRUE
 
-	// DNA sample from syringe.
-	if(istype(W,/obj/item/reagent_containers/syringe))
+	// Get DNA sample from a syringe
+	if (istype(W,/obj/item/reagent_containers/syringe))
 		var/obj/item/reagent_containers/syringe/S = W
 		var/datum/reagent/blood/injected = locate() in S.reagents.reagent_list //Grab some blood
-		if(injected && LAZYLEN(injected.data))
+		if (injected && LAZYLEN(injected.data))
 			var/loaded_dna = injected.data
 			var/weakref/R = loaded_dna["donor"]
 			var/mob/living/carbon/human/H = R.resolve()
-			if(H && istype(H) && H.species && H.dna)
+			if (H && istype(H) && H.species && H.dna)
 				loaded_species = H.species
 				loaded_dna_datum = H.dna && H.dna.Clone()
 				products = get_possible_products()
-				to_chat(user, SPAN_INFO("You inject the blood sample into the bioprinter."))
+				S.reagents.remove_reagent(/datum/reagent/blood, S.amount_per_transfer_from_this)
+				user.visible_message(
+					SPAN_NOTICE("\The [user] injects \the [src] with a blood sample."),
+					SPAN_NOTICE("You inject the blood sample into \the [src].")
+				)
 				return TRUE
-		to_chat(user, SPAN_NOTICE("\The [src] displays an error: no viable blood sample could be obtained from \the [W]."))
-	return ..()
+		// Fail to get a blood sample, but still intercept the normal attackby
+		to_chat(user, SPAN_WARNING("No viable blood can be obtained from \the [W]."))
+		return TRUE
 
+/// Returns a list of viable organs based on our blood sample. Certain species have different logic.
 /obj/machinery/organ_printer/flesh/proc/get_possible_products()
 	. = list()
-	if(!loaded_species)
+	if (!loaded_species)
 		return
 	var/list/organs = list()
-	for(var/organ in loaded_species.has_organ)
+	for (var/organ in loaded_species.has_organ)
 		organs += loaded_species.has_organ[organ]
-	for(var/organ in loaded_species.has_limbs)
+	for (var/organ in loaded_species.has_limbs)
 		if ((loaded_species.name == SPECIES_NABBER) || (organ == BP_GROIN))
 			organs += loaded_species.has_limbs[organ]["path"]
-	for(var/organ in organs)
+	for (var/organ in organs)
 		var/obj/item/organ/O = organ
-		if(check_printable(organ))
+		if (check_printable(organ))
 			.[initial(O.organ_tag)] = list(O, get_organ_cost(O))
 
-/obj/machinery/organ_printer/flesh/proc/get_organ_cost(var/obj/item/organ/O)
+/// Gets the matter cost to print a biological organ based on its max damage amount.
+/obj/machinery/organ_printer/flesh/proc/get_organ_cost(obj/item/organ/O)
 	. = initial(O.print_cost)
-	if(!.)
+	if (!.)
 		. = round(0.75 * initial(O.max_damage))
 
-/obj/machinery/organ_printer/flesh/proc/check_printable(var/organtype)
+/// Checks if a fleshy organ can be printed. Returns TRUE if it can, and FALSE if it cannot.
+/obj/machinery/organ_printer/flesh/proc/check_printable(organtype)
 	var/obj/item/organ/O = organtype
-	if(!initial(O.can_be_printed))
+	if (!initial(O.can_be_printed))
 		return FALSE
-	if(initial(O.vital))
+	if (initial(O.vital))
 		return FALSE
-	if(initial(O.status) & ORGAN_ROBOTIC)
+	if (initial(O.status) & ORGAN_ROBOTIC)
 		return FALSE
-	if(ispath(organtype, /obj/item/organ/external))
+	if (ispath(organtype, /obj/item/organ/external))
 		var/obj/item/organ/external/E = organtype
-		if(initial(E.limb_flags) & ORGAN_FLAG_HEALS_OVERKILL)
+		if (initial(E.limb_flags) & ORGAN_FLAG_HEALS_OVERKILL)
 			return FALSE
 	return TRUE
-
-// END FLESH ORGAN PRINTER

--- a/code/modules/client/preference_setup/_defines.dm
+++ b/code/modules/client/preference_setup/_defines.dm
@@ -14,8 +14,3 @@ if(!decls_by_name) \
 		decls_by_name[decl_instance.name] = decl_instance;\
 	}\
 }
-
-#define UIBUTTON(key, label, title) "[title ? title + ": " : ""]<a href='?src=\ref[src];[key]=1'>[label]</a>"
-
-#define UI_FONT_GOOD(X) "<font color='55cc55'>[X]</font>"
-#define UI_FONT_BAD(X) "<font color='cc5555'>[X]</font>"

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -91,9 +91,9 @@
 /obj/item/organ/internal/stomach/proc/metabolize()
 	if(is_usable())
 		ingested.metabolize()
-	
+
 #define STOMACH_VOLUME 65
-	
+
 /obj/item/organ/internal/stomach/Process()
 	..()
 
@@ -121,14 +121,14 @@
 			owner.custom_pain("Your stomach cramps agonizingly!",1)
 
 		var/alcohol_volume = ingested.get_reagent_amount(/datum/reagent/ethanol)
-		
+
 		var/alcohol_threshold_met = alcohol_volume > STOMACH_VOLUME / 2
 		if(alcohol_threshold_met && (owner.disabilities & EPILEPSY) && prob(20))
 			owner.seizure()
-		
+
 		// Alcohol counts as double volume for the purposes of vomit probability
 		var/effective_volume = ingested.total_volume + alcohol_volume
-		
+
 		// Just over the limit, the probability will be low. It rises a lot such that at double ingested it's 64% chance.
 		var/vomit_probability = (effective_volume / STOMACH_VOLUME) ** 6
 		if(prob(vomit_probability))

--- a/nano/templates/bioprinter.tmpl
+++ b/nano/templates/bioprinter.tmpl
@@ -1,0 +1,28 @@
+<div class='item'>
+	{{if data.special_data}}
+		{{:data.special_data}}<br>
+	{{/if}}
+	<b>Stored matter:</b> {{:data.stored_matter}}/{{:data.max_matter}}<br>
+	<b>Time to print:</b> {{:data.print_time}} seconds
+</div>
+<hr>
+<div class='item'>
+	{{if data.printing}}
+		<font color='cc5555'>Machine is currently operating. Please wait...</font>
+	{{else}}
+		<div class="itemContent" style="width:100%;">
+			<table>
+			{{for data.product_list}}
+				<tr>
+				{{if value.can_print}}
+					<td>{{:helper.link('Print', null, {"to_print" : value.product}, null)}}
+					<td>{{:value.parsed_name}} - {{:value.req_matter}}/{{:value.req_matter}}
+				{{else}}
+					<td>{{:helper.link('Print', null, {"to_print" : value.product}, 'disabled')}}
+					<td>{{:value.parsed_name}} - {{:data.stored_matter}}/{{:value.req_matter}}
+				{{/if}}
+			{{/for}}
+			</table>
+		</div>
+	{{/if}}
+</div>


### PR DESCRIPTION
## About the Pull Request

Right now, organ printers use a byond popup when choosing which organ to print, if any. They also don't have any indicator of their cached species, and picking an organ isn't at all straightforward. Their UI feels very outdated!

This PR replaces their old interface with a new one based in NanoUI. The top part shows stored matter and the time to print new organs, while the bottom part shows a readout of human-readable organ names and buttons to print them at will. Bioprinters also display the DNA hash and stored species of the blood sample they've been injected with.

Showing can be better than telling, so here's some pictures.

<details><summary>The two printers side-by-side at the start of the round</summary>

![image](https://user-images.githubusercontent.com/47678781/121983830-f58a4980-cd5f-11eb-9a32-02f25cda1494.png)
</details>

<details><summary>Bioprinter loaded with a human blood sample</summary>

![image](https://user-images.githubusercontent.com/47678781/121984036-469a3d80-cd60-11eb-8c40-51485d8d8f35.png)
</details>

<details><summary>Works with other species as well, such as GAS</summary>

![image](https://user-images.githubusercontent.com/47678781/121984049-4c901e80-cd60-11eb-9879-e5494ddd8cb7.png)
</details>

<details><summary>A prostheses fabricator without enough metal to print some things</summary>

![image](https://user-images.githubusercontent.com/47678781/121984072-57e34a00-cd60-11eb-9efe-67116969487e.png)
</details>

<details><summary>The aesthetic difference between bioprinted and normal organs. Printed on the left, normal on the right</summary>

![image](https://user-images.githubusercontent.com/47678781/121984106-6893c000-cd60-11eb-83e0-bb132d0949d5.png)
</details>

Assorted backend changes:
* Moved the UI defines (`UI_BUTTON`, `UI_FONT_GOOD`, and `UI_FONT_BAD`) to `__defines/misc.dm`. Their current position made it impossible to use them in the bioprinter file because DM is silly and file position in the hierarchy matters.
* Organ printers have a few new procs that their logic has been split into.
* Organ printers use timers now, instead of running a `sleep()` call and then running logic after the delay.
* Code and style modernization. Parentheses bumping, removal of `var/` in proc arguments, boolean defines, and so on.
* SDMM documentation for procs that lack it.

The code for actually storing data about choices etc. is unchanged.

## Why It's Good For The Game

Bioprinters are a very important part of medical due to organs being such a big part of baymed, but unfortunately, they're very outdated. They lack feedback in a few spots, aren't super intuitive to use, and have a clunky interface. I'm hopeful that giving them a facelift will modernize them to fit in with the rest of the infirmary's machines, which are, for the most part, all well-functioning.

**Why'd you rename the prosthetic organ fabricator to the prostheses fabricator?**
It isn't obvious at first glance with the original name, but the fabricator can print both limbs (such as arms, legs, hands, and feet) and organs (everything else). I felt the name was unintuitive because of this, so I generalized it more to describe all prosthetics. I'm fine with reverting this, however, if people are unhappy about it.

**Why are printed organs greenish and have a different name?**
Vat-grown humans have a greenish tint to their skin due to being cloned, and I thought it'd be cool to reflect this in other places, too. The "surrogate" name is just to differentiate the two - both so doctors can know in future scans that a person got an organ replaced, as well as for flavor reasons - but as above, I'm also fine getting rid of this if it's desired.

## Did you test it?

Compiles fine and appears to work with no runtimes. I tested this by printing organs from both machines and putting them inside people in place of their normal ones. The organs work correctly! Feeding matter into the machines also works as intended, as well as now intercepting attackby calls to prevent you from bludgeoning the poor thing with your stack of steel sheets.

As an added bonus, surrogate organs do not share a name with other ones during surgery, so attaching replacement organs appears to be easier - you'll be able to tell between a set of very damaged lungs and the "pristine" surrogate ones at a glance. This might mess with other things, however - give me a shout if it does.

## Changelog

:cl:
rscadd: Bioprinters and prosthetic organ fabricators have a new interface, based in NanoUI, instead of using a basic HTML popup.
rscadd: Organs printed from a bioprinter are now called "surrogate" organs, and have a slightly green tint. These changes are purely aesthetic, and the organs function the exact same as their normal counterparts.
tweak: Organ printing machines now show the human-readable name for the part they're creating, instead of the in-code name (i.e. "l_arm" is now referred to as "left arm").
tweak: Added feedback for when an organ printer starts creating an organ.
tweak: Injecting blood samples into a bioprinter now actually removes the blood sample from the syringe.
tweak: Prosthetic organ fabricators have been renamed to prostheses fabricators, in an effort to clarify that they can print robotic limbs as well as robotic organs.
/:cl: