### PR TITLE
Minor charge pylon tweaks, renames adherent cell

### DIFF
--- a/code/game/objects/structures/charge_pylon.dm
+++ b/code/game/objects/structures/charge_pylon.dm
@@ -8,54 +8,64 @@
 	opacity = FALSE
 	var/next_use
 
-/obj/structure/adherent_pylon/attack_ai(var/mob/living/user)
-	if(Adjacent(user))
+/obj/structure/adherent_pylon/attack_ai(mob/living/user)
+	if (Adjacent(user))
 		attack_hand(user)
 
-/obj/structure/adherent_pylon/attack_hand(var/mob/living/user)
+/obj/structure/adherent_pylon/attack_hand(mob/living/user)
 	charge_user(user)
 
-/obj/structure/adherent_pylon/proc/charge_user(var/mob/living/user)
-	if(next_use > world.time) return
+/obj/structure/adherent_pylon/proc/charge_user(mob/living/user)
+	if (next_use > world.time)
+		return
 	next_use = world.time + 10
 	var/mob/living/carbon/human/H = user
 	var/obj/item/cell/power_cell
-	if(ishuman(user))
+	if (ishuman(user))
 		var/obj/item/organ/internal/cell/cell = locate() in H.internal_organs
-		if(cell && cell.cell)
+		if (cell && cell.cell)
 			power_cell = cell.cell
-	else if(isrobot(user))
+	else if (isrobot(user))
 		var/mob/living/silicon/robot/robot = user
 		power_cell = robot.get_cell()
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	user.visible_message(SPAN_WARNING("There is a loud crack and the smell of ozone as \the [user] touches \the [src]."))
-	playsound(loc, 'sound/effects/snap.ogg', 50, 1)
-	if(power_cell)
+	user.visible_message(
+		SPAN_WARNING("There is a loud crack and the smell of ozone as \the [user] touches \the [src]."),
+		SPAN_WARNING("There is a loud crack and the smell of ozone as you touch \the [src]."),
+		SPAN_WARNING("You hear a loud electric crack, and smell ozone.")
+	)
+	playsound(loc, 'sound/effects/snap.ogg', 50, TRUE)
+	if (power_cell)
 		power_cell.charge = power_cell.maxcharge
-		to_chat(user, "<span class='notice'><b>Your [power_cell] has been charged to capacity.</b></span>")
-	if(istype(H) && H.species.name == SPECIES_ADHERENT)
+		to_chat(user, SPAN_NOTICE("<b>Your [power_cell.name] has been charged to capacity.</b>"))
+	if (istype(H) && H.species.name == SPECIES_ADHERENT)
 		return
-	if(isrobot(user))
+	if (isrobot(user))
 		user.apply_damage(150, BURN, def_zone = BP_CHEST)
-		visible_message("<span class='danger'>Electricity arcs off [user] as it touches \the [src]!</span>")
-		to_chat(user, "<span class='danger'><b>You detect damage to your components!</b></span>")
+		visible_message(SPAN_DANGER("Electricity arcs off [user] as it touches \the [src]!"))
+		to_chat(user, SPAN_DANGER("<b>You detect damage to your components!</b>"))
 	else
 		user.electrocute_act(100, src, def_zone = BP_CHEST)
-		visible_message("<span class='danger'>\The [user] has been shocked by \the [src]!</span>")
-	user.throw_at(get_step(user,get_dir(src,user)), 5, 10)
+		to_chat(user, SPAN_DANGER("A massive arc of electricity sends you flying!"))
+	user.throw_at(get_step(user, get_dir(src, user)), 5, 10)
 
 /obj/structure/adherent_pylon/attackby(obj/item/grab/normal/G, mob/user)
-	if(!istype(G))
+	if (!istype(G) || !istype(G.affecting))
 		return
 	var/mob/M = G.affecting
+	M.visible_message(
+		SPAN_DANGER("\The [user] slams \the [M] into \the [src]!"),
+		SPAN_DANGER("\The [user] slams you into \the [src]!")
+	)
+	G.force_drop() // Get rid of the grab since they're going to be flying across the room
 	charge_user(M)
 
 /obj/structure/adherent_pylon/Bumped(atom/AM)
-	if(ishuman(AM))
+	if (ishuman(AM))
 		charge_user(AM)
 
 /obj/structure/adherent_pylon/hitby(atom/AM)
-	. =..()
-	if(ishuman(AM))
+	. = ..()
+	if (ishuman(AM))
 		charge_user(AM)

--- a/code/modules/organs/internal/species/adherent.dm
+++ b/code/modules/organs/internal/species/adherent.dm
@@ -125,6 +125,7 @@
 	name = "piezoelectric core"
 	icon = 'icons/mob/human_races/species/adherent/organs.dmi'
 	icon_state = "cell"
+	cell = /obj/item/cell/hyper/adherent
 
 /obj/item/organ/internal/powered/cooling_fins
 	name = "cooling fins"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -205,6 +205,12 @@
 /obj/item/cell/hyper/empty
 	charge = 0
 
+/obj/item/cell/hyper/adherent
+	name = "crystal-ceramic grid"
+	desc = "A dense, smooth blue polygon the size of a clenched fist. It's etched with symmetrical facets that are filled with a thick, gelatinous material."
+	icon = 'icons/mob/human_races/species/adherent/organs.dmi'
+	icon_state = "cell"
+
 /obj/item/cell/infinite
 	name = "experimental power cell"
 	desc = "This special experimental power cell has both very large capacity, and ability to recharge itself by draining power from contained bluespace pocket."


### PR DESCRIPTION
## About the Pull Request

Adherents right now have a standard superior power cell, which goes against the notion that they're self-contained and use their own kinds of hardware. This PR gives them a unique cell "organ" that is mechanically identical, but has a different name on rechargeing.

While I was in the neighborhood, I also made some code improvements to the electron reservoir, such as giving it first-person messages for the user, and made it so that zapping someone with it drops the grab because they go flying across the room.

## Why It's Good For The Game

Adherents are in a weird spot where their hardware is utterly unique with the sole exception of their internal power cell. Because of the abnormal name for them, it creates a strange dichotomy when recharging.

The other changes to the zap pole were made primarily for consistency, since most of them are backend.

## Did you test it?

Compiles fine, and tested in-game on both adherents and organics. Several test dummies were harmed in the making of this PR.

![image](https://user-images.githubusercontent.com/47678781/122624885-3a6bf400-d070-11eb-8fe9-404002f34821.png)

## Changelog

:cl:
tweak: Adherents now have a special cell, called the "crystal-ceramic grid", instead of a standard superior power cell. It is mechanically identical, but shows instead of "superior power cell" when you recharge from an electron reservoir.
tweak: The electron reservoir now has first-person messages towards the person using it. Zap.
bugfix: Slamming someone into the electron reservoir now drops the grab, since the victim goes flying across the room.
/:cl:
