### PR TITLE
Add config for sleep_offline

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -199,6 +199,8 @@ var/list/gamemode_cache = list()
 	var/error_silence_time = 6000 // How long a unique error will be silenced for
 	var/error_msg_delay = 50 // How long to wait between messaging admins about occurrences of a unique error
 
+	var/sleep_offline_after_init = FALSE
+
 	var/max_gear_cost = 10 // Used in chargen for accessory loadout limit. 0 disables loadout, negative allows infinite points.
 
 	var/allow_ic_printing = TRUE //Whether players should be allowed to print IC circuits from scripts.
@@ -699,6 +701,9 @@ var/list/gamemode_cache = list()
 					config.max_acts_per_interval = text2num(value)
 				if ("act_interval")
 					config.act_interval = text2num(value) SECONDS
+
+				if ("sleep_offline_after_init")
+					config.sleep_offline_after_init = TRUE
 
 				if ("chat_markup")
 					var/list/line = splittext(value, ";")

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -201,11 +201,11 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	// Sort subsystems by display setting for easy access.
 	sortTim(subsystems, /proc/cmp_subsystem_display)
 	// Set world options.
-#ifdef UNIT_TEST
-	world.sleep_offline = FALSE
-#else
-	world.sleep_offline = TRUE
-#endif
+	if(config.sleep_offline_after_init)
+		world.sleep_offline = TRUE
+	else
+		world.sleep_offline = FALSE
+
 	world.fps = config.fps
 	var/initialized_tod = REALTIMEOFDAY
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -381,6 +381,9 @@ RADIATION_LOWER_LIMIT 0.15
 ## Clients will be unable to connect unless their build is equal to or higher than this (a number, e.g. 1000)
 #MINIMUM_BYOND_BUILD 1488
 
+## Uncomment this to make the server pause when no players are online.
+#SLEEP_OFFLINE_AFTER_INIT
+
 ## Uncomment or create lines to add user-accessible chat markup
 ## A chat markup line is in the form regex;replacer. The regular expression should be in the common
 # /matcher/flags format. The replacer is a common regex replacer string, using $n ($1, $2, etc) to


### PR DESCRIPTION
## About the Pull Request

Adds a config option, `SLEEP_OFFLINE_AFTER_INIT` to the example config, disabled by default. If enabled, `world.sleep_offline` will be set to true once the MC finishes initializing, meaning that if there are zero players, the server will pause processing.

## Why It's Good For The Game

17 hour rounds bad.

## Did you test it?

I used breakpoints to determine if the appropriate statements were executed, which they were, but I have **not** actually tested leaving the server and joining back since VSC doesn't support that.

## Changelog

:cl:
admin: Added a config setting for world.sleep_offline.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
