### PR TITLE
Adds command voidsuit cycler

### DIFF
--- a/code/datums/item_modifiers/space_suits.dm
+++ b/code/datums/item_modifiers/space_suits.dm
@@ -187,6 +187,24 @@
 		)
 	)
 
+/decl/item_modifier/space_suit/command
+	name = "Command"
+	type_setups = list(
+		/obj/item/clothing/head/helmet/space = list(
+			SETUP_NAME = "command voidsuit helmet",
+			SETUP_ICON_STATE = "rig0_command",
+			SETUP_ITEM_STATE = "command_helm"
+		),
+		/obj/item/clothing/suit/space/void = list(
+			SETUP_NAME = "command voidsuit",
+			SETUP_ICON_STATE = "rig_command",
+			SETUP_ITEM_STATE_SLOTS = list(
+				slot_l_hand_str = "s_suit",
+				slot_r_hand_str = "s_suit"
+			)
+		)
+	)
+
 /decl/item_modifier/space_suit/mercenary
 	name = "Mercenary"
 	type_setups = list(

--- a/maps/torch/items/machinery.dm
+++ b/maps/torch/items/machinery.dm
@@ -48,6 +48,13 @@
 	available_modifications = list(/decl/item_modifier/space_suit/explorer)
 	species = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI)
 
+/obj/machinery/suit_cycler/command
+	name = "Command suit cycler"
+	model_text = "Command"
+	req_access = list(access_bridge, access_keycard_auth)
+	available_modifications = list(/decl/item_modifier/space_suit/command)
+	species = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI)
+
 /obj/machinery/suit_storage_unit/explorer
 	name = "Exploration Voidsuit Storage Unit"
 	suit = /obj/item/clothing/suit/space/void/exploration

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -3765,6 +3765,8 @@
 	},
 /obj/item/tank/emergency/oxygen/double,
 /obj/item/tank/emergency/oxygen/double,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aux_eva)
 "hj" = (
@@ -6527,12 +6529,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "pR" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_cycler/command,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aux_eva)
 "pS" = (


### PR DESCRIPTION
## About the Pull Request
New suit cycler, fits in command EVA (just had to move 2 suit coolers), only works on command voidsuits.
<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Unless I'm having a manic episode, we're allowing skrell etc in command positions, so it'd be best for them to be able to wear the command voidsuits. Also just nice to have a cycler for them for cleaning/repairs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Did you test it?
Yes
<!--
Please decribe if you ran local tests to ensure compilation. If that is not the case, please make it abundantly clear so a maintainer knows they need to run local checks.
Note that this can include own balancing/gameplay tests, but does not need to.
-->

## Changelog

:cl: Rock
rscadd: Command EVA now has a suit cycler for command voidsuits.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
