### PR TITLE
new UI for modular cookers (griddle, oven, etc)

### DIFF
--- a/code/game/machinery/kitchen/cookers.dm
+++ b/code/game/machinery/kitchen/cookers.dm
@@ -67,6 +67,7 @@
 	icon_state = "[initial(icon_state)]_on"
 	started = world.time
 	threshold = 0
+	playsound(src, 'sound/machines/quiet_beep.ogg', 50, FALSE)
 
 /obj/machinery/cooker/proc/disable()
 	update_use_power(idle_power_usage)
@@ -78,46 +79,65 @@
 		I.dropInto(loc)
 	cooking.Cut()
 
-/obj/machinery/cooker/attack_hand(mob/user)
-	. = ..()
-	if (.)
-		return
+/obj/machinery/cooker/interface_interact(mob/living/user)
+	var/dat = ""
+	if (stat)
+		dat += UI_FONT_BAD("\The [src] is in no condition to operate.")
+	else
+		dat += "[UIBUTTON("empty_cooker", "Empty Ingredients", null)]<br>"
+		dat += "[UIBUTTON("toggle_state", "Turn [is_processing ? "Off" : "On"]", null)]<br>"
+		if (cook_modes.len > 1)
+			dat += "[UIBUTTON("cook_mode", "Change Cook Mode", null)] (current: [cook_mode])"
+		dat += "<br><hr>"
+		dat += "<b>Contents[is_processing ? UI_FONT_BAD(" (<i>Cooking!</i>)") : ""]:</b><br>"
+		if (!cooking.len)
+			dat += UI_FONT_BAD("None!")
+		else
+			for (var/obj/item/I in cooking)
+				dat += "[lowertext("[I]")]<br>"
+
+	var/datum/browser/popup = new(user, "cooker", name, 350, 300, src)
+	popup.set_content(dat)
+	popup.open()
+
+/obj/machinery/cooker/OnTopic(mob/user, href_list, datum/topic_state/state)
 	if (stat)
 		to_chat(user, SPAN_WARNING("\The [src] is in no condition to operate."))
 		return
-	var/option = alert(user, "", "[src] Options", "Empty", "Turn [is_processing ? "Off" : "On"]", cook_modes.len > 1 ? "Cook Mode" : null)
-	if (!option || QDELETED(src) || stat)
-		return
-	if (!Adjacent(user) || user.stat)
-		to_chat(user, SPAN_WARNING("You're not able to do that to \the [src] right now."))
-		return
-	switch (option)
-		if ("Empty")
-			if (is_processing)
-				to_chat(user, SPAN_WARNING("Turn off \the [src] first."))
-				return
-			if (!length(cooking))
-				to_chat(user, SPAN_WARNING("\The [src] is already empty."))
-				return
+	else if (href_list["empty_cooker"])
+		if (is_processing)
+			to_chat(user, SPAN_WARNING("Turn off \the [src] first."))
+			return
+		else if(length(cooking))
 			empty()
-		if ("Turn Off")
+		interface_interact(user)
+	else if (href_list["toggle_state"])
+		if (is_processing)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] turns off \the [src]."),
+				SPAN_NOTICE("You turn off \the [src].")
+			)
 			disable()
-			visible_message(SPAN_NOTICE("\The [user] turns off \the [src]."), SPAN_NOTICE("You turn off \the [src]."), range = 5)
-		if ("Turn On")
+		else
+			user.visible_message(
+				SPAN_NOTICE("\The [user] turns on \the [src]."),
+				SPAN_NOTICE("You turn on \the [src].")
+			)
 			enable()
-			visible_message(SPAN_NOTICE("\The [user] turns on \the [src]."), SPAN_NOTICE("You turn on \the [src]."), range = 5)
-		if ("Cook Mode")
-			if (is_processing)
-				to_chat(user, SPAN_WARNING("Turn off \the [src] first."))
-				return
-			var/mode = input(user, "", "[src] Cook Modes") as null|anything in cook_modes
-			if (!mode || QDELETED(src) || stat)
-				return
-			if (!Adjacent(user) || user.stat)
-				to_chat(user, SPAN_WARNING("You're not able to do that to \the [src] right now."))
-				return
-			cook_mode = mode
-			to_chat(user, "The contents of \the [src] will now be [cook_modes[mode]["desc"]].")
+		interface_interact(user)
+	else if (href_list["cook_mode"])
+		if (is_processing)
+			to_chat(user, SPAN_WARNING("Turn off \the [src] first."))
+			return
+		var/mode = input(user, "", "[src] Cook Modes") as null|anything in cook_modes
+		if (!mode || QDELETED(src) || !operable())
+			return
+		if (!CanDefaultInteract(user))
+			to_chat(user, SPAN_WARNING("You're not able to do that to \the [src] right now."))
+			return
+		cook_mode = mode
+		to_chat(user, "The contents of \the [src] will now be [cook_modes[mode]["desc"]].")
+		interface_interact(user)
 
 /obj/machinery/cooker/attackby(obj/item/I, mob/user)
 	if (is_processing)
@@ -140,6 +160,8 @@
 	user.visible_message("\The [user] puts \the [I] into \the [src].")
 	I.forceMove(src)
 	cooking += I
+	if (winget(user, "cooker", "is-visible") == "true") // Refresh the interface if we have it open
+		interface_interact(user)
 
 /obj/machinery/cooker/Process()
 	if (!cooking.len)
@@ -155,8 +177,8 @@
 			cooking += cook_item(source[index])
 			--index
 		QDEL_NULL_LIST(source)
-		audible_message(SPAN_ITALIC("\The [src] lets out a happy ding."))
-		playsound(src, 'sound/machines/ding.ogg', 0.5)
+		audible_message(SPAN_NOTICE("\The [src] lets out a happy ding."))
+		playsound(src, 'sound/machines/ding.ogg', 50, FALSE)
 		threshold = 1
 	if (!burn_time)
 		empty()
@@ -255,7 +277,7 @@
 			"desc" = "made into jelly"
 		)
 	)
-	
+
 	machine_name = "modular cooker"
 	machine_desc = "Can prepare nearly any kind of food a certain way, such as making pies, cookies, or candy bars."
 


### PR DESCRIPTION
## About the Pull Request

This PR adds proper interfaces for the modular cookers in the galley - the griddle, deep fryer, candy machine, cereal maker, and oven (and maybe one or two I forgot the names of.) Instead of showing a button popup, it will have a simple interface with quick controls and the ability to turn it on and off. It features all abilities the current interface has, as well as the ability to see if the cooker is active without having to look at its sprite.

This also unifies spans for messages and fixes a bug where the "ding" sound was effectively silent (0.5% volume) and adds a beep sound that plays when the cooker turns on.

## Why It's Good For The Game

Cookers are great, but their interface is not. I've found that using them is functional, but barebones. In addition to the botched audio/visual feedback, the alert system is clunky to use when you use cookers extensively for lots of different types of food. A UI facelift should hopefully make them a lot more intuitive.

## Did you test it?

Yes. I grabbed some food from the cold room and ran them through several cookers to make a bunch of different varieties on food, often on different settings. See below for screenshots. While not pictured in the screenies, I also did some light testing as a service cyborg, and they appeared to work as normal, with their service gripper being able to put food into the cookers and turn them into other things.

## Changelog

:cl:
rscadd: The chef's cookers (griddle, oven, etc.) have received a UI facelift.
bugfix: Cookers now properly play a ding when they finish cooking - previously the sound played at 0.5% volume.
/:cl:

## Media

Minor note for these: in these pictures, there's an errant space between `Cooking` and the colon. This has been fixed in the code and isn't present in the PR.

<details><summary>Interface for the griddle</summary>

![image](https://user-images.githubusercontent.com/47678781/123042038-3b7c8880-d3c4-11eb-9a56-920e79a06095.png)

</details>

<details><summary>Grilling some meat. Best wear oven mitts</summary>

![image](https://user-images.githubusercontent.com/47678781/123042082-46cfb400-d3c4-11eb-9c8b-147b2b95dd78.png)

</details>

<details><summary>Some food, post-steaming</summary>

![dreamseeker_Su06vlqrKy](https://user-images.githubusercontent.com/47678781/123042115-518a4900-d3c4-11eb-9ebf-8aa7dcf52316.png)

</details>

<details><summary>Deep fryer example - note the missing cooking options button due to only having a single setting</summary>

![dreamseeker_RaEVqk1Ajf](https://user-images.githubusercontent.com/47678781/123042162-623abf00-d3c4-11eb-9917-2068db6fb1b3.png)

</details>

<details><summary>Popup to switch cooking modes</summary>

![dreamseeker_Bef3n9HSPx](https://user-images.githubusercontent.com/47678781/123042262-8c8c7c80-d3c4-11eb-9945-b043f60ac1c7.png)

</details>

<details><summary>A culinary abomination</summary>

![dreamseeker_VjJGEdA5ZW](https://user-images.githubusercontent.com/47678781/123042204-71217180-d3c4-11eb-8504-4364eaa1000e.png)
![dreamseeker_wSwWIG89q2](https://user-images.githubusercontent.com/47678781/123042208-7383cb80-d3c4-11eb-8740-b62a6b61e560.png)

</details>

<details><summary>Many different types of food cooked, ft Runtime (Runtime was not harmed in the making of this PR)</summary>

![dreamseeker_EZVJNtoOpj](https://user-images.githubusercontent.com/47678781/123042224-7d0d3380-d3c4-11eb-9200-2230716ffa85.png)

</details>