### PR TITLE
Small update to borers

### DIFF
--- a/code/game/antagonist/alien/borer.dm
+++ b/code/game/antagonist/alien/borer.dm
@@ -11,9 +11,9 @@ GLOBAL_DATUM_INIT(borers, /datum/antagonist/borer, new)
 	antag_indicator = "hudborer"
 	antaghud_indicator = "hudborer"
 
-	faction_role_text = "Borer Thrall"
+	faction_role_text = "a Borer Host"
 	faction_descriptor = "Unity"
-	faction_welcome = "You are now a thrall to a cortical borer. Please listen to what they have to say; they're in your head."
+	faction_welcome = "You are now a host to a cortical borer. Please listen to what they have to say; they're in your head."
 	faction = "borer"
 	faction_indicator = "hudalien"
 
@@ -32,8 +32,6 @@ GLOBAL_DATUM_INIT(borers, /datum/antagonist/borer, new)
 	if(!..())
 		return
 	player.objectives += new /datum/objective/borer_survive()
-	player.objectives += new /datum/objective/borer_reproduce()
-	player.objectives += new /datum/objective/escape()
 
 /datum/antagonist/borer/place_mob(var/mob/living/mob)
 	var/mob/living/simple_animal/borer/borer = mob

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -26,9 +26,18 @@
 	bleed_colour = "#816e12"
 
 	var/static/list/chemical_types = list(
+		"inaprovaline" =   /datum/reagent/inaprovaline,
 		"bicaridine" = /datum/reagent/bicaridine,
 		"hyperzine" =  /datum/reagent/hyperzine,
-		"tramadol" =   /datum/reagent/tramadol
+		"tramadol" =   /datum/reagent/tramadol,
+		"dermaline" =   /datum/reagent/dermaline,
+		"dylovene" =   /datum/reagent/dylovene,
+		"dexalin plus" =   /datum/reagent/dexalinp,
+		"Alkysine" =   /datum/reagent/alkysine,
+		"peridaxon" =   /datum/reagent/peridaxon,
+		"spaceacillin" =   /datum/reagent/spaceacillin,
+		"iron" =   /datum/reagent/iron,
+		"carbon" =   /datum/reagent/carbon,
 	)
 
 	var/generation = 1


### PR DESCRIPTION
Changes the description for Borer Thralls to Borer Hosts
Removes objectives other than survive to the borer since antags don't have objectives in general anyways
Adds a larger chem selection for the borer to inject into their hosts

## About the Pull Request

PR renames borer thralls to borer hosts to more accurately represent what they are.
gives the borer more options for chemicals to inject
removes objectives other than survive for the borer.

## Why It's Good For The Game

Borers are very weak and have low chemical regen so giving them more chemicals only gives them more options, they can't spam any of them to give their hosts unfair advantages. All this does is make it so if the host isn't killed on the spot they can attempt to fix their hosts. Also the borers are only admin spawn at the moment so its not a big risk.

## Did you test it?
I tested it with every chemical and looked for the objective and name changes

## Changelog

:cl:
rscadd: Adds more chemical injection options for cortical borers
tweak: Changes the name and description of borer thralls to borer hosts
/:cl:

