### PR TITLE
Brings back fleet jackets, polos, et cetera

### DIFF
--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -433,7 +433,7 @@
 	name = "Fleet support SNCO"
 	min_rank = 7
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/polopants/command,/obj/item/clothing/suit/storage/jacket/solgov/fleet/command)
+	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/polopants/command,/obj/item/clothing/suit/storage/jacket/solgov/fleet/command,/obj/item/clothing/head/beret/solgov/fleet/command,/obj/item/clothing/head/ushanka/solgov/fleet,/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,/obj/item/clothing/head/soft/solgov/fleet,/obj/item/clothing/gloves/thick/duty/solgov/cmd)
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 

--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -3,14 +3,14 @@
 	departments = COM
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/command,
-				/obj/item/clothing/head/beret/solgov/fleet/command,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/cmd
-			)
+	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command,
+						 /obj/item/clothing/head/beret/solgov/fleet/command,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/head/soft/solgov/fleet,
+						 /obj/item/clothing/gloves/thick/duty/solgov/cmd,
+						 /obj/item/clothing/under/solgov/utility/fleet/polopants/command,
+						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/command)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
@@ -41,15 +41,14 @@
 	departments = ENG
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/engineering
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/engineering,
-				/obj/item/clothing/head/beret/solgov/fleet/engineering,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/eng
-			)
-
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/engineering,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/head/soft/solgov/fleet,
+						 /obj/item/clothing/gloves/thick/duty/solgov/eng,
+						 /obj/item/clothing/under/solgov/utility/fleet/polopants,
+						 /obj/item/clothing/suit/storage/jacket/solgov/fleet)
+						 
 /decl/hierarchy/mil_uniform/fleet/eng/noncom
 	name = "Fleet engineering NCO"
 	min_rank = 4
@@ -77,15 +76,15 @@
 	name = "Fleet engineering CO"
 	min_rank = 11
 
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/engineering,
-				/obj/item/clothing/head/beret/solgov/fleet/command,
-				/obj/item/clothing/head/beret/solgov/fleet/engineering,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/eng
-			)
+	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/engineering,
+						 /obj/item/clothing/head/beret/solgov/fleet/command,
+						 /obj/item/clothing/head/beret/solgov/fleet/engineering,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/head/soft/solgov/fleet,
+						 /obj/item/clothing/gloves/thick/duty/solgov/eng,
+						 /obj/item/clothing/under/solgov/utility/fleet/polopants,
+						 /obj/item/clothing/suit/storage/jacket/solgov/fleet)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
@@ -120,14 +119,15 @@
 	departments = SEC
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/security
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/security,
-				/obj/item/clothing/head/beret/solgov/fleet/security,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/sec
-			)
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/security,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/head/soft/solgov/fleet,
+						 /obj/item/clothing/gloves/thick/duty/solgov/sec,
+						 /obj/item/clothing/under/solgov/utility/fleet/security,
+						 /obj/item/clothing/under/solgov/utility/fleet/polopants/security,
+						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/security)
+	utility_under = /obj/item/clothing/under/solgov/utility/fleet/combat/security
 
 
 /decl/hierarchy/mil_uniform/fleet/sec/noncom
@@ -161,15 +161,15 @@
 	name = "Fleet security CO"
 	min_rank = 11
 
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/security,
-				/obj/item/clothing/head/beret/solgov/fleet/command,
-				/obj/item/clothing/head/beret/solgov/fleet/security,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/sec
-			)
+	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/security,
+						 /obj/item/clothing/head/beret/solgov/fleet/command,
+						 /obj/item/clothing/head/beret/solgov/fleet/security,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/head/soft/solgov/fleet,
+						 /obj/item/clothing/gloves/thick/duty/solgov/sec,
+						 /obj/item/clothing/under/solgov/utility/fleet/polopants/security,
+						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/security)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
@@ -200,15 +200,14 @@
 	name = "Fleet medical"
 	departments = MED
 
-	utility_under = /obj/item/clothing/under/solgov/utility/fleet/medical
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/medical,
-				/obj/item/clothing/head/beret/solgov/fleet/medical,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/med
-			)
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/medical,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/head/soft/solgov/fleet,
+						 /obj/item/clothing/under/solgov/utility/fleet/combat/medical,
+						 /obj/item/clothing/gloves/thick/duty/solgov/med,
+						 /obj/item/clothing/under/solgov/utility/fleet/polopants/medical,
+						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/medical)
 
 /decl/hierarchy/mil_uniform/fleet/med/noncom
 	name = "Fleet medical NCO"
@@ -235,15 +234,15 @@
 	name = "Fleet medical CO"
 	min_rank = 11
 
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/medical,
-				/obj/item/clothing/head/beret/solgov/fleet/command,
-				/obj/item/clothing/head/beret/solgov/fleet/medical,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/med
-			)
+	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/medical,
+						 /obj/item/clothing/head/beret/solgov/fleet/command,
+						 /obj/item/clothing/head/beret/solgov/fleet/medical,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/head/soft/solgov/fleet,
+						 /obj/item/clothing/gloves/thick/duty/solgov/med,
+						 /obj/item/clothing/under/solgov/utility/fleet/polopants/medical,
+						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/medical)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
@@ -275,14 +274,13 @@
 	departments = SUP
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/supply
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/supply,
-				/obj/item/clothing/head/beret/solgov/fleet/supply,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/sup
-			)
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/supply,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/head/soft/solgov/fleet,
+						 /obj/item/clothing/gloves/thick/duty/solgov/sup,
+						 /obj/item/clothing/under/solgov/utility/fleet/polopants/supply,
+						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/supply)
 
 /decl/hierarchy/mil_uniform/fleet/sup/noncom
 	name = "Fleet supply NCO"
@@ -309,15 +307,15 @@
 	name = "Fleet supply CO"
 	min_rank = 11
 
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/supply,
-				/obj/item/clothing/head/beret/solgov/fleet/command,
-				/obj/item/clothing/head/beret/solgov/fleet/supply,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/sup
-			)
+		utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command,
+						 /obj/item/clothing/head/beret/solgov/fleet/command,
+						 /obj/item/clothing/head/beret/solgov/fleet/supply,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/head/soft/solgov/fleet,
+						 /obj/item/clothing/gloves/thick/duty/solgov/sup,
+						 /obj/item/clothing/under/solgov/utility/fleet/polopants/supply,
+						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/supply)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
@@ -353,14 +351,13 @@
 	departments = SRV
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/service
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/service,
-				/obj/item/clothing/head/beret/solgov/fleet/service,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/svc
-			)
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/service,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/head/soft/solgov/fleet,
+						 /obj/item/clothing/gloves/thick/duty/solgov/svc,
+						 /obj/item/clothing/under/solgov/utility/fleet/polopants/service,
+						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/service)
 
 /decl/hierarchy/mil_uniform/fleet/srv/noncom
 	name = "Fleet service NCO"
@@ -388,15 +385,15 @@
 	name = "Fleet service CO"
 	min_rank = 11
 
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/service,
-				/obj/item/clothing/head/beret/solgov/fleet/command,
-				/obj/item/clothing/head/beret/solgov/fleet/service,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/svc
-			)
+utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command,
+						 /obj/item/clothing/head/beret/solgov/fleet/command,
+						 /obj/item/clothing/head/beret/solgov/fleet/service,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/head/soft/solgov/fleet,
+						 /obj/item/clothing/gloves/thick/duty/solgov/svc,
+						 /obj/item/clothing/under/solgov/utility/fleet/polopants/service,
+						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/service)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
@@ -410,14 +407,12 @@
 	departments = EXP
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/exploration
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/exploration,
-				/obj/item/clothing/head/beret/solgov/fleet/exploration,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/exp
-			)
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/exploration,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/under/solgov/utility/fleet/combat/exploration,
+						 /obj/item/clothing/head/soft/solgov/fleet,
+						 /obj/item/clothing/gloves/thick/duty/solgov/exp)
 
 /decl/hierarchy/mil_uniform/fleet/exp/noncom
 	name = "Fleet exploration NCO"
@@ -445,15 +440,13 @@
 	name = "Fleet exploration CO"
 	min_rank = 11
 
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/exploration,
-				/obj/item/clothing/head/beret/solgov/fleet/command,
-				/obj/item/clothing/head/beret/solgov/fleet/exploration,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/exp
-			)
+	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command,
+						 /obj/item/clothing/head/beret/solgov/fleet/command,
+						 /obj/item/clothing/head/beret/solgov/fleet/exploration,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/head/soft/solgov/fleet,
+						 /obj/item/clothing/gloves/thick/duty/solgov/exp)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer

--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -3,7 +3,8 @@
 	departments = COM
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/command,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/head/soft/solgov/fleet,
@@ -37,7 +38,8 @@
 	departments = ENG
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/engineering
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/engineering,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/engineering,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/head/soft/solgov/fleet,
@@ -68,7 +70,8 @@
 	name = "Fleet engineering CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/command,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/head/soft/solgov/fleet,
@@ -104,7 +107,8 @@
 	name = "Fleet security"
 	departments = SEC
 
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/security,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/security,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/head/soft/solgov/fleet,
@@ -137,7 +141,8 @@
 	name = "Fleet security CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/command,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/head/soft/solgov/fleet,
@@ -173,7 +178,8 @@
 	name = "Fleet medical"
 	departments = MED
 
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/medical,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/medical,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/head/soft/solgov/fleet,
@@ -206,7 +212,8 @@
 	name = "Fleet medical CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/command,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/head/soft/solgov/fleet,
@@ -243,7 +250,8 @@
 	departments = SUP
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/supply
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/supply,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/supply,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/head/soft/solgov/fleet,
@@ -274,7 +282,8 @@
 	name = "Fleet supply CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/command,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/head/soft/solgov/fleet,
@@ -322,7 +331,8 @@
 	departments = SRV
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/service
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/service,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/service,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/head/soft/solgov/fleet,
@@ -353,7 +363,8 @@
 	name = "Fleet service CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/command,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/head/soft/solgov/fleet,
@@ -372,7 +383,8 @@
 	departments = EXP
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/exploration
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/exploration,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/exploration,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/under/solgov/utility/fleet/combat/exploration,
@@ -402,7 +414,8 @@
 	name = "Fleet exploration CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/command,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/head/soft/solgov/fleet,
@@ -433,7 +446,14 @@
 	name = "Fleet support SNCO"
 	min_rank = 7
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/polopants/command,/obj/item/clothing/suit/storage/jacket/solgov/fleet/command,/obj/item/clothing/head/beret/solgov/fleet/command,/obj/item/clothing/head/ushanka/solgov/fleet,/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,/obj/item/clothing/head/soft/solgov/fleet,/obj/item/clothing/gloves/thick/duty/solgov/cmd)
+	utility_extra = list(
+				 /obj/item/clothing/under/solgov/utility/fleet/polopants/command,
+				 /obj/item/clothing/suit/storage/jacket/solgov/fleet/command,
+				 /obj/item/clothing/head/beret/solgov/fleet/command,
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/gloves/thick/duty/solgov/cmd)
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
@@ -444,7 +464,12 @@
 	name = "Fleet command support CO"
 	min_rank = 11
 
-	utility_extra = list (/obj/item/clothing/head/beret/solgov/fleet/command, /obj/item/clothing/head/ushanka/solgov/fleet, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet, /obj/item/clothing/head/soft/solgov/fleet, /obj/item/clothing/under/solgov/utility/fleet/polopants/command,/obj/item/clothing/suit/storage/jacket/solgov/fleet/command)
+	utility_extra = list (
+				 /obj/item/clothing/head/beret/solgov/fleet/command,
+				 /obj/item/clothing/head/ushanka/solgov/fleet, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/under/solgov/utility/fleet/polopants/command,
+				 /obj/item/clothing/suit/storage/jacket/solgov/fleet/command)
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
@@ -458,7 +483,8 @@
 	name = "Fleet senior command support"
 	min_rank = 15
 
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/command,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/head/soft/solgov/fleet,
@@ -478,7 +504,8 @@
 	name = "Fleet flag command support"
 	min_rank = 17
 
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
+	utility_extra = list(
+				 /obj/item/clothing/head/beret/solgov/fleet/command,
 				 /obj/item/clothing/head/ushanka/solgov/fleet,
 				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				 /obj/item/clothing/head/soft/solgov/fleet)

--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -3,8 +3,7 @@
 	departments = COM
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command,
-						 /obj/item/clothing/head/beret/solgov/fleet/command,
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
 						 /obj/item/clothing/head/ushanka/solgov/fleet,
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 						 /obj/item/clothing/head/soft/solgov/fleet,
@@ -17,10 +16,7 @@
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/officer
 	dress_hat = /obj/item/clothing/head/solgov/dress/fleet/command
-	dress_extra = list(
-		/obj/item/material/sword/replica/officersword,
-		/obj/item/clothing/head/beret/solgov/fleet/dress/command
-	)
+	dress_extra = list(/obj/item/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/com/seniorofficer
 	name = "Fleet senior command"
@@ -48,7 +44,7 @@
 						 /obj/item/clothing/gloves/thick/duty/solgov/eng,
 						 /obj/item/clothing/under/solgov/utility/fleet/polopants,
 						 /obj/item/clothing/suit/storage/jacket/solgov/fleet)
-						 
+
 /decl/hierarchy/mil_uniform/fleet/eng/noncom
 	name = "Fleet engineering NCO"
 	min_rank = 4
@@ -66,35 +62,25 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
-	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
-	dress_extra = list(
-		/obj/item/material/sword/replica/officersword/pettyofficer,
-		/obj/item/clothing/head/beret/solgov/fleet/dress
-	)
+	dress_extra = list(/obj/item/material/sword/replica/officersword/pettyofficer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/eng/officer
 	name = "Fleet engineering CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/engineering,
-						 /obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/beret/solgov/fleet/engineering,
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
 						 /obj/item/clothing/head/ushanka/solgov/fleet,
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 						 /obj/item/clothing/head/soft/solgov/fleet,
 						 /obj/item/clothing/gloves/thick/duty/solgov/eng,
 						 /obj/item/clothing/under/solgov/utility/fleet/polopants,
 						 /obj/item/clothing/suit/storage/jacket/solgov/fleet)
-
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/officer
 	dress_hat = /obj/item/clothing/head/solgov/dress/fleet/command
-	dress_extra = list(
-		/obj/item/material/sword/replica/officersword,
-		/obj/item/clothing/head/beret/solgov/fleet/dress/command
-	)
+	dress_extra = list(/obj/item/material/sword/replica/officersword, /obj/item/clothing/head/beret/solgov/fleet/dress/command)
 
 /decl/hierarchy/mil_uniform/fleet/eng/officer/com //Can only be officers
 	name = "Fleet engineering command"
@@ -118,7 +104,6 @@
 	name = "Fleet security"
 	departments = SEC
 
-	utility_under = /obj/item/clothing/under/solgov/utility/fleet/security
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/security,
 						 /obj/item/clothing/head/ushanka/solgov/fleet,
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
@@ -129,7 +114,6 @@
 						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/security)
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/combat/security
 
-
 /decl/hierarchy/mil_uniform/fleet/sec/noncom
 	name = "Fleet security NCO"
 	min_rank = 4
@@ -138,10 +122,6 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet
-	dress_extra = list(
-		/obj/item/clothing/head/beret/solgov/fleet/dress
-	)
-
 
 /decl/hierarchy/mil_uniform/fleet/sec/snco
 	name = "Fleet security SNCO"
@@ -151,26 +131,19 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
-	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
-	dress_extra = list(
-		/obj/item/material/sword/replica/officersword/pettyofficer,
-		/obj/item/clothing/head/beret/solgov/fleet/dress
-	)
+	dress_extra = list(/obj/item/material/sword/replica/officersword/pettyofficer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/sec/officer
 	name = "Fleet security CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/security,
-						 /obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/beret/solgov/fleet/security,
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
 						 /obj/item/clothing/head/ushanka/solgov/fleet,
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 						 /obj/item/clothing/head/soft/solgov/fleet,
 						 /obj/item/clothing/gloves/thick/duty/solgov/sec,
 						 /obj/item/clothing/under/solgov/utility/fleet/polopants/security,
 						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/security)
-
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
 
@@ -208,6 +181,7 @@
 						 /obj/item/clothing/gloves/thick/duty/solgov/med,
 						 /obj/item/clothing/under/solgov/utility/fleet/polopants/medical,
 						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/medical)
+	utility_under = /obj/item/clothing/under/solgov/utility/fleet/medical
 
 /decl/hierarchy/mil_uniform/fleet/med/noncom
 	name = "Fleet medical NCO"
@@ -217,7 +191,6 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet
-	dress_extra = /obj/item/clothing/head/beret/solgov/fleet/dress
 
 /decl/hierarchy/mil_uniform/fleet/med/snco
 	name = "Fleet medical SNCO"
@@ -227,23 +200,19 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
-	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
 	dress_extra = list(/obj/item/material/sword/replica/officersword/pettyofficer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/med/officer
 	name = "Fleet medical CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/medical,
-						 /obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/beret/solgov/fleet/medical,
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
 						 /obj/item/clothing/head/ushanka/solgov/fleet,
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 						 /obj/item/clothing/head/soft/solgov/fleet,
 						 /obj/item/clothing/gloves/thick/duty/solgov/med,
 						 /obj/item/clothing/under/solgov/utility/fleet/polopants/medical,
 						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/medical)
-
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
 
@@ -290,7 +259,6 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet
-	dress_extra = /obj/item/clothing/head/beret/solgov/fleet/dress
 
 /decl/hierarchy/mil_uniform/fleet/sup/snco
 	name = "Fleet supply SNCO"
@@ -300,23 +268,19 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
-	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
 	dress_extra = list(/obj/item/material/sword/replica/officersword/pettyofficer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/sup/officer
 	name = "Fleet supply CO"
 	min_rank = 11
 
-		utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command,
-						 /obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/beret/solgov/fleet/supply,
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
 						 /obj/item/clothing/head/ushanka/solgov/fleet,
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 						 /obj/item/clothing/head/soft/solgov/fleet,
 						 /obj/item/clothing/gloves/thick/duty/solgov/sup,
 						 /obj/item/clothing/under/solgov/utility/fleet/polopants/supply,
 						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/supply)
-
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
 
@@ -328,8 +292,12 @@
 	name = "Fleet supply senior command"
 	min_rank = 15
 
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command, /obj/item/clothing/head/ushanka/solgov/fleet, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet, /obj/item/clothing/head/soft/solgov/fleet)
+	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
+
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command
+
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
 	dress_hat = /obj/item/clothing/head/solgov/dress/fleet/command
@@ -338,6 +306,9 @@
 /decl/hierarchy/mil_uniform/fleet/sup/flagofficer
 	name = "Fleet spply flag command"
 	min_rank = 17
+
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command, /obj/item/clothing/head/ushanka/solgov/fleet, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet, /obj/item/clothing/head/soft/solgov/fleet)
+	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/flag
@@ -367,8 +338,6 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet
-	dress_extra = /obj/item/clothing/head/beret/solgov/fleet/dress
-
 
 /decl/hierarchy/mil_uniform/fleet/srv/snco
 	name = "Fleet service SNCO"
@@ -378,23 +347,19 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
-	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
 	dress_extra = list(/obj/item/material/sword/replica/officersword/pettyofficer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/srv/officer
 	name = "Fleet service CO"
 	min_rank = 11
 
-utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command,
-						 /obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/beret/solgov/fleet/service,
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
 						 /obj/item/clothing/head/ushanka/solgov/fleet,
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 						 /obj/item/clothing/head/soft/solgov/fleet,
 						 /obj/item/clothing/gloves/thick/duty/solgov/svc,
 						 /obj/item/clothing/under/solgov/utility/fleet/polopants/service,
 						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/service)
-
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
 
@@ -422,8 +387,6 @@ utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/comma
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet
-	dress_extra = /obj/item/clothing/head/beret/solgov/fleet/dress
-
 
 /decl/hierarchy/mil_uniform/fleet/exp/snco
 	name = "Fleet exploration SNCO"
@@ -433,21 +396,17 @@ utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/comma
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
-	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
 	dress_extra = list(/obj/item/material/sword/replica/officersword/pettyofficer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/exp/officer
 	name = "Fleet exploration CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command,
-						 /obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/beret/solgov/fleet/exploration,
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
 						 /obj/item/clothing/head/ushanka/solgov/fleet,
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 						 /obj/item/clothing/head/soft/solgov/fleet,
 						 /obj/item/clothing/gloves/thick/duty/solgov/exp)
-
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
 
@@ -460,14 +419,6 @@ utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/comma
 	departments = SPT
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/command,
-				/obj/item/clothing/head/beret/solgov/fleet/command,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/cmd
-			)
 
 /decl/hierarchy/mil_uniform/fleet/spt/noncom
 	name = "Fleet support NCO"
@@ -477,33 +428,24 @@ utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/comma
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet
-	dress_extra = /obj/item/clothing/head/beret/solgov/fleet/dress
-
 
 /decl/hierarchy/mil_uniform/fleet/spt/snco
 	name = "Fleet support SNCO"
 	min_rank = 7
 
+	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/polopants/command,/obj/item/clothing/suit/storage/jacket/solgov/fleet/command)
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
-	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
 	dress_extra = list(/obj/item/material/sword/replica/officersword/pettyofficer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/spt/officer
 	name = "Fleet command support CO"
 	min_rank = 11
 
+	utility_extra = list (/obj/item/clothing/head/beret/solgov/fleet/command, /obj/item/clothing/head/ushanka/solgov/fleet, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet, /obj/item/clothing/head/soft/solgov/fleet, /obj/item/clothing/under/solgov/utility/fleet/polopants/command,/obj/item/clothing/suit/storage/jacket/solgov/fleet/command)
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
-	utility_extra = list(
-				/obj/item/clothing/under/solgov/utility/fleet/combat/command,
-				/obj/item/clothing/head/beret/solgov/fleet/command,
-				/obj/item/clothing/head/ushanka/solgov/fleet,
-				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/cmd
-			)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
@@ -516,6 +458,14 @@ utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/comma
 	name = "Fleet senior command support"
 	min_rank = 15
 
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/head/soft/solgov/fleet,
+						 /obj/item/clothing/under/solgov/utility/fleet/polopants/command,
+						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/command)
+	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
+
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command
 
@@ -527,6 +477,12 @@ utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/comma
 /decl/hierarchy/mil_uniform/fleet/spt/flagofficer
 	name = "Fleet flag command support"
 	min_rank = 17
+
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
+						 /obj/item/clothing/head/ushanka/solgov/fleet,
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/head/soft/solgov/fleet)
+	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/flag

--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -4,12 +4,12 @@
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/gloves/thick/duty/solgov/cmd,
-						 /obj/item/clothing/under/solgov/utility/fleet/polopants/command,
-						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/command)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/gloves/thick/duty/solgov/cmd,
+				 /obj/item/clothing/under/solgov/utility/fleet/polopants/command,
+				 /obj/item/clothing/suit/storage/jacket/solgov/fleet/command)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
@@ -38,12 +38,12 @@
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/engineering
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/engineering,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/gloves/thick/duty/solgov/eng,
-						 /obj/item/clothing/under/solgov/utility/fleet/polopants,
-						 /obj/item/clothing/suit/storage/jacket/solgov/fleet)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/gloves/thick/duty/solgov/eng,
+				 /obj/item/clothing/under/solgov/utility/fleet/polopants,
+				 /obj/item/clothing/suit/storage/jacket/solgov/fleet)
 
 /decl/hierarchy/mil_uniform/fleet/eng/noncom
 	name = "Fleet engineering NCO"
@@ -69,12 +69,12 @@
 	min_rank = 11
 
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/gloves/thick/duty/solgov/eng,
-						 /obj/item/clothing/under/solgov/utility/fleet/polopants,
-						 /obj/item/clothing/suit/storage/jacket/solgov/fleet)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/gloves/thick/duty/solgov/eng,
+				 /obj/item/clothing/under/solgov/utility/fleet/polopants,
+				 /obj/item/clothing/suit/storage/jacket/solgov/fleet)
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
 
@@ -105,13 +105,13 @@
 	departments = SEC
 
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/security,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/gloves/thick/duty/solgov/sec,
-						 /obj/item/clothing/under/solgov/utility/fleet/security,
-						 /obj/item/clothing/under/solgov/utility/fleet/polopants/security,
-						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/security)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/gloves/thick/duty/solgov/sec,
+				 /obj/item/clothing/under/solgov/utility/fleet/security,
+				 /obj/item/clothing/under/solgov/utility/fleet/polopants/security,
+				 /obj/item/clothing/suit/storage/jacket/solgov/fleet/security)
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/combat/security
 
 /decl/hierarchy/mil_uniform/fleet/sec/noncom
@@ -138,12 +138,12 @@
 	min_rank = 11
 
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/gloves/thick/duty/solgov/sec,
-						 /obj/item/clothing/under/solgov/utility/fleet/polopants/security,
-						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/security)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/gloves/thick/duty/solgov/sec,
+				 /obj/item/clothing/under/solgov/utility/fleet/polopants/security,
+				 /obj/item/clothing/suit/storage/jacket/solgov/fleet/security)
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
 
@@ -174,13 +174,13 @@
 	departments = MED
 
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/medical,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/under/solgov/utility/fleet/combat/medical,
-						 /obj/item/clothing/gloves/thick/duty/solgov/med,
-						 /obj/item/clothing/under/solgov/utility/fleet/polopants/medical,
-						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/medical)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/under/solgov/utility/fleet/combat/medical,
+				 /obj/item/clothing/gloves/thick/duty/solgov/med,
+				 /obj/item/clothing/under/solgov/utility/fleet/polopants/medical,
+				 /obj/item/clothing/suit/storage/jacket/solgov/fleet/medical)
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/medical
 
 /decl/hierarchy/mil_uniform/fleet/med/noncom
@@ -207,12 +207,12 @@
 	min_rank = 11
 
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/gloves/thick/duty/solgov/med,
-						 /obj/item/clothing/under/solgov/utility/fleet/polopants/medical,
-						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/medical)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/gloves/thick/duty/solgov/med,
+				 /obj/item/clothing/under/solgov/utility/fleet/polopants/medical,
+				 /obj/item/clothing/suit/storage/jacket/solgov/fleet/medical)
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
 
@@ -244,12 +244,12 @@
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/supply
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/supply,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/gloves/thick/duty/solgov/sup,
-						 /obj/item/clothing/under/solgov/utility/fleet/polopants/supply,
-						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/supply)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/gloves/thick/duty/solgov/sup,
+				 /obj/item/clothing/under/solgov/utility/fleet/polopants/supply,
+				 /obj/item/clothing/suit/storage/jacket/solgov/fleet/supply)
 
 /decl/hierarchy/mil_uniform/fleet/sup/noncom
 	name = "Fleet supply NCO"
@@ -275,12 +275,12 @@
 	min_rank = 11
 
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/gloves/thick/duty/solgov/sup,
-						 /obj/item/clothing/under/solgov/utility/fleet/polopants/supply,
-						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/supply)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/gloves/thick/duty/solgov/sup,
+				 /obj/item/clothing/under/solgov/utility/fleet/polopants/supply,
+				 /obj/item/clothing/suit/storage/jacket/solgov/fleet/supply)
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
 
@@ -323,12 +323,12 @@
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/service
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/service,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/gloves/thick/duty/solgov/svc,
-						 /obj/item/clothing/under/solgov/utility/fleet/polopants/service,
-						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/service)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/gloves/thick/duty/solgov/svc,
+				 /obj/item/clothing/under/solgov/utility/fleet/polopants/service,
+				 /obj/item/clothing/suit/storage/jacket/solgov/fleet/service)
 
 /decl/hierarchy/mil_uniform/fleet/srv/noncom
 	name = "Fleet service NCO"
@@ -354,12 +354,12 @@
 	min_rank = 11
 
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/gloves/thick/duty/solgov/svc,
-						 /obj/item/clothing/under/solgov/utility/fleet/polopants/service,
-						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/service)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/gloves/thick/duty/solgov/svc,
+				 /obj/item/clothing/under/solgov/utility/fleet/polopants/service,
+				 /obj/item/clothing/suit/storage/jacket/solgov/fleet/service)
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
 
@@ -373,11 +373,11 @@
 
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/exploration
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/exploration,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/under/solgov/utility/fleet/combat/exploration,
-						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/gloves/thick/duty/solgov/exp)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/under/solgov/utility/fleet/combat/exploration,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/gloves/thick/duty/solgov/exp)
 
 /decl/hierarchy/mil_uniform/fleet/exp/noncom
 	name = "Fleet exploration NCO"
@@ -403,10 +403,10 @@
 	min_rank = 11
 
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/gloves/thick/duty/solgov/exp)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/gloves/thick/duty/solgov/exp)
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
 
@@ -459,11 +459,11 @@
 	min_rank = 15
 
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/under/solgov/utility/fleet/polopants/command,
-						 /obj/item/clothing/suit/storage/jacket/solgov/fleet/command)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet,
+				 /obj/item/clothing/under/solgov/utility/fleet/polopants/command,
+				 /obj/item/clothing/suit/storage/jacket/solgov/fleet/command)
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
@@ -479,9 +479,9 @@
 	min_rank = 17
 
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/command,
-						 /obj/item/clothing/head/ushanka/solgov/fleet,
-						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/head/soft/solgov/fleet)
+				 /obj/item/clothing/head/ushanka/solgov/fleet,
+				 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				 /obj/item/clothing/head/soft/solgov/fleet)
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command


### PR DESCRIPTION
## About the pull request
Puts the Fleet Jacket and Polo and Pants back into the uniform vendor under utility extra

## Why it's good for the game
Brings back the uniform variety that the last branch didn't really replace when it made these admin spawn only.  Also looks cool.

## Did you test it?
Yes https://i.gyazo.com/dd943613aeb66729ee211b5ceba3a36e.png

## Changelog

:cl:
rscadd: Readds Alternative Fleet Utility Uniform Items to the uniform vendor
/:cl:

