### PR TITLE
Admin restart button

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -29,6 +29,9 @@ SUBSYSTEM_DEF(ticker)
 
 	var/secret_force_mode = "secret"
 
+	///Set to TRUE when an admin forcibly ends round.
+	var/forced_end = FALSE
+
 /datum/controller/subsystem/ticker/Initialize()
 	to_world("<span class='info'><B>Welcome to the pre-game lobby!</B></span>")
 	to_world("Please, setup your character and select ready. Game will start in [round(pregame_timeleft/10)] seconds")
@@ -347,6 +350,9 @@ Helpers
 	return 0
 
 /datum/controller/subsystem/ticker/proc/game_finished()
+	if (forced_end)
+		return TRUE
+
 	if(mode.explosion_in_progress)
 		return 0
 	if(config.continous_rounds)
@@ -355,6 +361,9 @@ Helpers
 		return mode.check_finished() || (evacuation_controller.round_over() && evacuation_controller.emergency_evacuation) || universe_has_ended
 
 /datum/controller/subsystem/ticker/proc/mode_finished()
+	if (forced_end)
+		return TRUE
+
 	if(config.continous_rounds)
 		return mode.check_finished()
 	else

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -782,6 +782,22 @@ var/global/floorIsLava = 0
 	SSstatistics.add_field_details("admin_verb","TLOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 
+/datum/admins/proc/endnow()
+	set category = "Server"
+	set desc = "round goes bye bye"
+	set name = "End Round"
+
+	var/check = alert("This will immediately end the round. Are you sure about this?", "End Game", "Yes", "No") == "Yes"
+
+	if (!check)
+		return
+
+	if (GAME_STATE > RUNLEVEL_LOBBY)
+		SSticker.forced_end = TRUE
+		log_and_message_admins("has ended the round.")
+	else
+		to_chat(usr,FONT_LARGE(SPAN_WARNING("You cannot end the round before it's begun!")))
+
 /datum/admins/proc/toggledsay()
 	set category = "Server"
 	set desc="Globally Toggles DSAY"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -137,6 +137,7 @@ var/list/admin_verbs_spawn = list(
 var/list/admin_verbs_server = list(
 	/datum/admins/proc/capture_map_part,
 	/datum/admins/proc/startnow,
+	/datum/admins/proc/endnow,
 	/datum/admins/proc/restart,
 	/datum/admins/proc/delay,
 	/datum/admins/proc/toggleaban,
@@ -248,6 +249,7 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/toggle_random_events,
 	/client/proc/cmd_admin_add_random_ai_law,
 	/datum/admins/proc/startnow,
+	/datum/admins/proc/endnow,
 	/datum/admins/proc/restart,
 	/datum/admins/proc/delay,
 	/datum/admins/proc/toggleaban,


### PR DESCRIPTION
## About the Pull Request

Allows admins a way to restart rounds while showing credits

port from [bay](https://github.com/Baystation12/Baystation12/pull/30808) with permission from original author

## Why It's Good For The Game

We need to give the power to the players. with this PR the 1984 admins will have no power in the ways of instant shut downs. for too long have gamers been oppressed.  We **deserve** to see those credit scenes after the SM blows up and a voted end round occurs. 

## Did you test it?

Hell yeah brother!

## Changelog

:cl: MuckerMayhem and Sky
admin: adds a button to end the round while still showing credit scene
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
