### PR TITLE
gas canister refactor + modernization

### DIFF
--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -443,7 +443,7 @@ Class Procs:
 			var/obj/item/fake_thing = type
 			parts += "[num2text(missing[type])] [initial(fake_thing.name)]"
 		to_chat(user, "\The [src] is missing [english_list(parts)], rendering it inoperable.")
-	if (user.skill_check(SKILL_CONSTRUCTION, SKILL_BASIC) || isobserver(user))
+	if (machine_desc && (user.skill_check(SKILL_CONSTRUCTION, SKILL_BASIC) || isobserver(user)))
 		to_chat(user, SPAN_NOTICE(machine_desc))
 
 // This is really pretty crap and should be overridden for specific machines.

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -1,138 +1,248 @@
+#define CANISTER_FLAG_HASTANK 1
+#define CANISTER_FLAG_ISCONNECTED 2
+#define CANISTER_FLAG_PRESSURE_VERYLOW 4
+#define CANISTER_FLAG_PRESSURE_LOW 8
+#define CANISTER_FLAG_PRESSURE_HIGH 16
+#define CANISTER_FLAG_PRESSURE_VERYHIGH 32
+
 /obj/machinery/portable_atmospherics/canister
-	name = "\improper Canister: \[CAUTION\]"
+	name = "gas canister \[CAUTION\]"
+	desc = "A semi-portable canister for holding pressurized gases."
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "yellow"
 	density = TRUE
-	var/health = 100.0
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	w_class = ITEM_SIZE_GARGANTUAN
 	construct_state = null
 
-	var/valve_open = 0
+	start_pressure = 45 * ONE_ATMOSPHERE
+	volume = 1000
+	interact_offline = TRUE // Allows this to be used when not in powered area.
+
+	var/health = 100.0
+	var/valve_open = FALSE
 	var/release_pressure = ONE_ATMOSPHERE
 	var/release_flow_rate = ATMOS_DEFAULT_VOLUME_PUMP //in L/s
+	var/temperature_resistance = 1000 + T0C
 
 	var/canister_color = "yellow"
-	var/can_label = 1
-	start_pressure = 45 * ONE_ATMOSPHERE
-	var/temperature_resistance = 1000 + T0C
-	volume = 1000
-	interact_offline = 1 // Allows this to be used when not in powered area.
+	var/can_label = TRUE
+
+	/// Bitflag containing information about this canister's status (wrenched, pressure, etc.) See defines in canister.dm for more details.
 	var/update_flag = 0
+	/// Associative list of gases for this canister to begin with and the moles to have. A negative value will fill the tank to its starting pressure with the gas.
+	var/list/initial_gases = list()
+	/// A temperature in Kelvin for this canister's air contents to begin with. Use this for pre-chilled gases.
+	var/initial_temperature
+
+/obj/machinery/portable_atmospherics/canister/LateInitialize(mapload)
+	. = ..(mapload)
+	if (prob(1))
+		desc += " Does not hold GAS." // huhuhu
+	if (!mapload) // Call gas creation after normal init if we're midround - otherwise, we'll runtime and have no gases
+		addtimer(CALLBACK(src, .proc/create_initial_gases), 0)
+	else
+		create_initial_gases()
+
+/// Fills this canister with gas based on its subtype's initial_gases list. Should only happen during initial creation.
+/obj/machinery/portable_atmospherics/canister/proc/create_initial_gases()
+	if (initial_gases?.len)
+		for (var/gas_id in initial_gases)
+			air_contents.adjust_gas(gas_id, initial_gases[gas_id] < 0 ? MolesForPressure() : initial_gases[gas_id])
+	if (initial_temperature)
+		air_contents.temperature = initial_temperature
+	update_icon()
 
 /obj/machinery/portable_atmospherics/canister/drain_power()
 	return -1
 
+/obj/machinery/portable_atmospherics/canister/examine(mob/user)
+	. = ..()
+	if (health >= initial(health))
+		to_chat(user, SPAN_NOTICE("It looks to be in good condition."))
+	else
+		if (!destroyed)
+			var/ratio = health / initial(health)
+			if (ratio >= 0.6)
+				to_chat(user, SPAN_WARNING("It looks slightly damaged."))
+			else if (ratio >= 0.3)
+				to_chat(user, SPAN_WARNING("It looks heavily damaged."))
+			else
+				to_chat(user, SPAN_WARNING("<b>It's on the verge of falling apart!</b>"))
+		else
+			to_chat(user, "It has been ruptured.")
+
 /obj/machinery/portable_atmospherics/canister/sleeping_agent
-	name = "\improper Canister: \[N2O\]"
+	name = "gas canister \[N2O\]"
 	icon_state = "redws"
 	canister_color = "redws"
-	can_label = 0
+	can_label = FALSE
+	initial_gases = list(
+		GAS_N2O = -1
+	)
 
 /obj/machinery/portable_atmospherics/canister/nitrogen
-	name = "\improper Canister: \[N2\]"
+	name = "gas canister \[N2\]"
 	icon_state = "red"
 	canister_color = "red"
-	can_label = 0
+	can_label = FALSE
+	initial_gases = list(
+		GAS_NITROGEN = -1
+	)
 
 /obj/machinery/portable_atmospherics/canister/nitrogen/prechilled
-	name = "\improper Canister: \[N2 (Cooling)\]"
+	name = "gas canister \[N2 (Cooling)\]"
+	initial_temperature = 80
 
 /obj/machinery/portable_atmospherics/canister/oxygen
-	name = "\improper Canister: \[O2\]"
+	name = "gas canister \[O2\]"
 	icon_state = "blue"
 	canister_color = "blue"
-	can_label = 0
+	can_label = FALSE
+	initial_gases = list(
+		GAS_OXYGEN = -1
+	)
 
 /obj/machinery/portable_atmospherics/canister/oxygen/prechilled
-	name = "\improper Canister: \[O2 (Cryo)\]"
+	name = "gas canister \[O2 (Cryo)\]"
 	start_pressure = 20 * ONE_ATMOSPHERE
+	initial_temperature = 80
 
 /obj/machinery/portable_atmospherics/canister/hydrogen
-	name = "\improper Canister: \[Hydrogen\]"
+	name = "gas canister \[Hydrogen\]"
 	icon_state = "purple"
 	canister_color = "purple"
-	can_label = 0
+	can_label = FALSE
+	initial_gases = list(
+		GAS_HYDROGEN = -1
+	)
 
 /obj/machinery/portable_atmospherics/canister/phoron
-	name = "\improper Canister \[Phoron\]"
+	name = "gas canister \[Phoron\]"
 	icon_state = "orange"
 	canister_color = "orange"
-	can_label = 0
+	can_label = FALSE
+	initial_gases = list(
+		GAS_PHORON = -1
+	)
 
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide
-	name = "\improper Canister \[CO2\]"
+	name = "gas canister \[CO2\]"
 	icon_state = "black"
 	canister_color = "black"
-	can_label = 0
+	can_label = FALSE
+	initial_gases = list(
+		GAS_CO2 = -1
+	)
 
 /obj/machinery/portable_atmospherics/canister/air
-	name = "\improper Canister \[Air\]"
+	name = "gas canister \[Air\]"
 	icon_state = "grey"
 	canister_color = "grey"
-	can_label = 0
+	can_label = FALSE
+	// We don't have an initial_gases defined here because this is a mix of gases instead. Check the create_initial_gases() for details
+
+/obj/machinery/portable_atmospherics/canister/air/create_initial_gases()
+	var/list/air_mix = StandardAirMix()
+	air_contents.adjust_multi(GAS_OXYGEN, air_mix[GAS_OXYGEN], GAS_NITROGEN, air_mix[GAS_NITROGEN])
+	update_icon()
+
+/obj/machinery/portable_atmospherics/canister/helium
+	name = "gas canister \[Helium\]"
+	icon_state = "black"
+	canister_color = "black"
+	can_label = FALSE
+	initial_gases = list(
+		GAS_HELIUM = -1
+	)
+
+/obj/machinery/portable_atmospherics/canister/methyl_bromide
+	name = "gas canister \[Methyl Bromide\]"
+	icon_state = "black"
+	canister_color = "black"
+	can_label = FALSE
+	initial_gases = list(
+		GAS_METHYL_BROMIDE = -1
+	)
+
+/obj/machinery/portable_atmospherics/canister/chlorine
+	name = "gas canister \[Chlorine\]"
+	icon_state = "black"
+	canister_color = "black"
+	can_label = FALSE
+	initial_gases = list(
+		GAS_CHLORINE = -1
+	)
 
 /obj/machinery/portable_atmospherics/canister/air/airlock
 	start_pressure = 3 * ONE_ATMOSPHERE
 
+
+
+/// Empty canister subtypes. These will start with no gas but will take the appearance of the defined canister_type.
 /obj/machinery/portable_atmospherics/canister/empty
 	start_pressure = 0
-	can_label = 1
+	can_label = TRUE
 	var/obj/machinery/portable_atmospherics/canister/canister_type = /obj/machinery/portable_atmospherics/canister
 
-/obj/machinery/portable_atmospherics/canister/empty/New()
-	..()
+/obj/machinery/portable_atmospherics/canister/empty/LateInitialize()
+	. = ..()
 	name = 	initial(canister_type.name)
-	icon_state = 	initial(canister_type.icon_state)
-	canister_color = 	initial(canister_type.canister_color)
+	icon_state = initial(canister_type.icon_state)
+	canister_color = initial(canister_type.canister_color)
 
 /obj/machinery/portable_atmospherics/canister/empty/air
 	icon_state = "grey"
 	canister_type = /obj/machinery/portable_atmospherics/canister/air
+
 /obj/machinery/portable_atmospherics/canister/empty/oxygen
 	icon_state = "blue"
 	canister_type = /obj/machinery/portable_atmospherics/canister/oxygen
+
 /obj/machinery/portable_atmospherics/canister/empty/phoron
 	icon_state = "orange"
 	canister_type = /obj/machinery/portable_atmospherics/canister/phoron
+
 /obj/machinery/portable_atmospherics/canister/empty/nitrogen
 	icon_state = "red"
 	canister_type = /obj/machinery/portable_atmospherics/canister/nitrogen
+
 /obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide
 	icon_state = "black"
 	canister_type = /obj/machinery/portable_atmospherics/canister/carbon_dioxide
+
 /obj/machinery/portable_atmospherics/canister/empty/sleeping_agent
 	icon_state = "redws"
 	canister_type = /obj/machinery/portable_atmospherics/canister/sleeping_agent
+
 /obj/machinery/portable_atmospherics/canister/empty/hydrogen
 	icon_state = "purple"
 	canister_type = /obj/machinery/portable_atmospherics/canister/hydrogen
 
 
 
-
 /obj/machinery/portable_atmospherics/canister/proc/check_change()
 	var/old_flag = update_flag
 	update_flag = 0
-	if(holding)
-		update_flag |= 1
-	if(connected_port)
-		update_flag |= 2
+	if (holding)
+		update_flag |= CANISTER_FLAG_HASTANK
+	if (connected_port)
+		update_flag |= CANISTER_FLAG_ISCONNECTED
 
 	var/tank_pressure = return_pressure()
-	if(tank_pressure < 10)
-		update_flag |= 4
-	else if(tank_pressure < ONE_ATMOSPHERE)
-		update_flag |= 8
-	else if(tank_pressure < 15*ONE_ATMOSPHERE)
-		update_flag |= 16
+	if (tank_pressure < 10)
+		update_flag |= CANISTER_FLAG_PRESSURE_VERYLOW
+	else if (tank_pressure < ONE_ATMOSPHERE)
+		update_flag |= CANISTER_FLAG_PRESSURE_LOW
+	else if (tank_pressure < 15 * ONE_ATMOSPHERE)
+		update_flag |= CANISTER_FLAG_PRESSURE_HIGH
 	else
-		update_flag |= 32
+		update_flag |= CANISTER_FLAG_PRESSURE_VERYHIGH
 
-	if(update_flag == old_flag)
-		return 1
+	if (update_flag == old_flag)
+		return TRUE
 	else
-		return 0
+		return FALSE
 
 /obj/machinery/portable_atmospherics/canister/on_update_icon()
 /*
@@ -145,58 +255,59 @@ update_flag
 32 = tank_pressure go boom.
 */
 
-	if (src.destroyed)
+	if (destroyed)
 		overlays.Cut()
-		src.icon_state = text("[]-1", src.canister_color)
+		icon_state = text("[]-1", canister_color)
 		return
 
-	if(icon_state != "[canister_color]")
+	if (icon_state != "[canister_color]")
 		icon_state = "[canister_color]"
 
-	if(check_change()) //Returns 1 if no change needed to icons.
+	if (check_change()) //Returns 1 if no change needed to icons.
 		return
 
 	overlays.Cut()
 
-	if(update_flag & 1)
+	if (update_flag & CANISTER_FLAG_HASTANK)
 		overlays += "can-open"
-	if(update_flag & 2)
+	if (update_flag & CANISTER_FLAG_ISCONNECTED)
 		overlays += "can-connector"
-	if(update_flag & 4)
+	if (update_flag & CANISTER_FLAG_PRESSURE_VERYLOW)
 		overlays += "can-o0"
-	if(update_flag & 8)
+	if (update_flag & CANISTER_FLAG_PRESSURE_LOW)
 		overlays += "can-o1"
-	else if(update_flag & 16)
+	else if (update_flag & CANISTER_FLAG_PRESSURE_HIGH)
 		overlays += "can-o2"
-	else if(update_flag & 32)
+	else if (update_flag & CANISTER_FLAG_PRESSURE_VERYHIGH)
 		overlays += "can-o3"
 	return
 
 /obj/machinery/portable_atmospherics/canister/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(exposed_temperature > temperature_resistance)
+	if (exposed_temperature > temperature_resistance)
 		health -= 5
 		healthcheck()
 
 /obj/machinery/portable_atmospherics/canister/proc/healthcheck()
-	if(destroyed)
-		return 1
+	if (destroyed)
+		return TRUE
 
-	if (src.health <= 10)
-		var/atom/location = src.loc
+	if (health <= 0) // Rupture!
+		var/atom/location = loc
 		location.assume_air(air_contents)
 
-		src.destroyed = 1
-		playsound(src.loc, 'sound/effects/spray.ogg', 10, 1, -3)
-		src.set_density(0)
+		destroyed = TRUE
+		visible_message(SPAN_DANGER("\The [src] ruptures!"))
+		playsound(src, 'sound/effects/spray.ogg', 10, 1, -3)
+		set_density(FALSE)
 		update_icon()
 
-		if (src.holding)
-			src.holding.dropInto(loc)
-			src.holding = null
+		if (holding)
+			holding.dropInto(loc)
+			holding = null
 
-		return 1
+		return TRUE
 	else
-		return 1
+		return TRUE
 
 /obj/machinery/portable_atmospherics/canister/Process()
 	if (destroyed)
@@ -204,9 +315,9 @@ update_flag
 
 	..()
 
-	if(valve_open)
+	if (valve_open)
 		var/datum/gas_mixture/environment
-		if(holding)
+		if (holding)
 			environment = holding.air_contents
 		else
 			environment = loc.return_air()
@@ -214,64 +325,144 @@ update_flag
 		var/env_pressure = environment.return_pressure()
 		var/pressure_delta = release_pressure - env_pressure
 
-		if((air_contents.temperature > 0) && (pressure_delta > 0))
+		if ((air_contents.temperature > 0) && (pressure_delta > 0))
 			var/transfer_moles = calculate_transfer_moles(air_contents, environment, pressure_delta)
 			transfer_moles = min(transfer_moles, (release_flow_rate/air_contents.volume)*air_contents.total_moles) //flow rate limit
 
 			var/returnval = pump_gas_passive(src, air_contents, environment, transfer_moles)
-			if(returnval >= 0)
-				src.update_icon()
-				if(holding)
+			if (returnval >= 0)
+				update_icon()
+				if (holding)
 					holding.queue_icon_update()
 
-	if(air_contents.return_pressure() < 1)
-		can_label = 1
+	if (air_contents.return_pressure() < 1)
+		can_label = TRUE
 	else
-		can_label = 0
+		can_label = FALSE
 
 	air_contents.react() //cooking up air cans - add phoron and oxygen, then heat above PHORON_MINIMUM_BURN_TEMPERATURE
 
 /obj/machinery/portable_atmospherics/canister/proc/return_temperature()
-	var/datum/gas_mixture/GM = src.return_air()
-	if(GM && GM.volume>0)
+	var/datum/gas_mixture/GM = return_air()
+	if (GM && GM.volume>0)
 		return GM.temperature
 	return 0
 
 /obj/machinery/portable_atmospherics/canister/proc/return_pressure()
-	var/datum/gas_mixture/GM = src.return_air()
-	if(GM && GM.volume>0)
+	var/datum/gas_mixture/GM = return_air()
+	if (GM && GM.volume>0)
 		return GM.return_pressure()
 	return 0
 
-/obj/machinery/portable_atmospherics/canister/bullet_act(var/obj/item/projectile/Proj)
-	if(!(Proj.damage_type == BRUTE || Proj.damage_type == BURN))
+/obj/machinery/portable_atmospherics/canister/bullet_act(obj/item/projectile/P)
+	if (!(P.damage_type == BRUTE || P.damage_type == BURN))
 		return
 
-	if(Proj.damage)
-		src.health -= round(Proj.damage / 2)
+	if (P.damage)
+		playsound(src, 'sound/weapons/slice.ogg', 50, TRUE)
+		health -= round(P.damage / 2)
 		healthcheck()
 	..()
 
-/obj/machinery/portable_atmospherics/canister/attackby(var/obj/item/W as obj, var/mob/user as mob)
-	if(!isWrench(W) && !istype(W, /obj/item/tank) && !istype(W, /obj/item/device/scanner/gas) && !istype(W, /obj/item/modular_computer/pda))
-		visible_message("<span class='warning'>\The [user] hits \the [src] with \a [W]!</span>")
-		src.health -= W.force
-		healthcheck()
+/obj/machinery/portable_atmospherics/canister/attackby(obj/item/W, mob/living/user)
+	if (isWelder(W) && (user.a_intent != I_HURT || destroyed))
+		var/obj/item/weldingtool/WT = W
+		if (!WT.isOn())
+			to_chat(user, SPAN_WARNING("Turn \the [WT] on first."))
+			return
+		else if (air_contents.return_pressure() > ONE_ATMOSPHERE * 0.5 && !destroyed)
+			to_chat(user, SPAN_WARNING("\The [src] has too much gas to safely cut apart."))
+			return
+		else if (air_contents.get_by_flag(XGM_GAS_FUEL) && user.a_intent == I_HELP)
+			if (alert(user, "\The [src] has trace amounts of dangerous gas. Continue anyway?", name, "Continue", "Cancel") != "Continue")
+				return
+		else if (!WT.remove_fuel(1, user))
+			to_chat(user, SPAN_WARNING("\The [WT] doesn't have enough fuel."))
+			return
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts deconstructing \the [src] with \the [W]."),
+			SPAN_NOTICE("You start cutting through \the [src], slicing at its weak points."),
+			SPAN_NOTICE("You hear the sound of \a [W].")
+		)
+		playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
+		if (!user.do_skilled(6 SECONDS, SKILL_CONSTRUCTION, src))
+			return
+		var/returned_sheets = destroyed ? 5 : 10
+		if (!destroyed)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] cuts apart \the [src]."),
+				SPAN_NOTICE("You slice through \the [src]'s seams, and it falls apart into metal sheets."),
+				SPAN_NOTICE("You hear sheets of metal collapsing.")
+			)
+		else
+			user.visible_message(
+				SPAN_NOTICE("\The [user] cuts apart \the [src]'s remains'."),
+				SPAN_NOTICE("You deconstruct what remains of \the [src], reclaiming some of its material."),
+				SPAN_NOTICE("You hear sheets of metal collapsing.")
+			)
+		playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
+		var/turf/location = get_turf(src)
+		if (!destroyed)
+			location.assume_air(air_contents)
+			if (holding)
+				holding.dropInto(location)
+				holding = null
+		if (connected_port)
+			disconnect()
+		new /obj/item/stack/material/steel(location, returned_sheets)
+		qdel(src)
+		return
 
-	if(istype(user, /mob/living/silicon/robot) && istype(W, /obj/item/tank/jetpack))
+	if (istype(W, /obj/item/tape_roll) && user.a_intent != I_HURT)
+		if (destroyed)
+			to_chat(user, SPAN_WARNING("It's a little too late to repair \the [src]."))
+			return
+		else if (health >= initial(health))
+			to_chat(user, SPAN_NOTICE("\The [src] is already in mint condition."))
+			return
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts patching damage to \the [src]."),
+			SPAN_NOTICE("You start sealing the damage to \the [src]."),
+			SPAN_NOTICE("You hear tape being used.")
+		)
+		playsound(src, 'sound/effects/tape.ogg', 25)
+		if (!user.do_skilled((initial(health) - health) * 0.5, SKILL_CONSTRUCTION, src) || destroyed)
+			return
+		user.visible_message(
+			SPAN_NOTICE("\The [user] repairs \the [src]!"),
+			SPAN_NOTICE("You patch up \the [src], sealing the worst of its damage."),
+			SPAN_NOTICE("You hear tape being used.")
+		)
+		playsound(src, 'sound/effects/tape.ogg', 25)
+		health = initial(health)
+		return
+
+	if (istype(user, /mob/living/silicon/robot) && istype(W, /obj/item/tank/jetpack))
 		var/datum/gas_mixture/thejetpack = W:air_contents
 		var/env_pressure = thejetpack.return_pressure()
-		var/pressure_delta = min(10*ONE_ATMOSPHERE - env_pressure, (air_contents.return_pressure() - env_pressure)/2)
+		var/pressure_delta = min(10 * ONE_ATMOSPHERE - env_pressure, (air_contents.return_pressure() - env_pressure) / 2)
 		//Can not have a pressure delta that would cause environment pressure > tank pressure
 		var/transfer_moles = 0
-		if((air_contents.temperature > 0) && (pressure_delta > 0))
-			transfer_moles = pressure_delta*thejetpack.volume/(air_contents.temperature * R_IDEAL_GAS_EQUATION)//Actually transfer the gas
+		if ((air_contents.temperature > 0) && (pressure_delta > 0))
+			transfer_moles = pressure_delta*thejetpack.volume/(air_contents.temperature * R_IDEAL_GAS_EQUATION) //Actually transfer the gas
 			var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
 			thejetpack.merge(removed)
-			to_chat(user, "You pulse-pressurize your jetpack from the tank.")
+			to_chat(user, SPAN_NOTICE("You pulse-pressurize your jetpack from the tank."))
 		return
 
-	..()
+	if (!isWrench(W) && !istype(W, /obj/item/tank) && !istype(W, /obj/item/device/scanner/gas) && !istype(W, /obj/item/modular_computer/pda))
+		if (W.force < 5 || W.damtype != BRUTE)
+			visible_message(SPAN_WARNING("\The [user] hits \the [src] with \the [W], but it bounces off!"))
+		else
+			visible_message(SPAN_DANGER("\The [user] hits \the [src] with \the [W]!"))
+			health -= W.force
+			healthcheck()
+		user.do_attack_animation(src)
+		user.setClickCooldown(W.attack_cooldown + W.w_class) // Mirror the logic from base attack cooldowns
+		playsound(user, 'sound/weapons/smash.ogg', 50, TRUE)
+		return
+
+	. = ..()
 
 	SSnano.update_uis(src) // Update all NanoUIs attached to src
 
@@ -297,25 +488,25 @@ update_flag
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "canister.tmpl", "Canister", 480, 400)
+		ui = new(user, src, ui_key, "canister.tmpl", "canister", 480, 400)
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)
 
 /obj/machinery/portable_atmospherics/canister/OnTopic(var/mob/user, href_list, state)
-	if(href_list["toggle"])
+	if (href_list["toggle"])
 		if (!valve_open)
-			if(!holding)
+			if (!holding)
 				log_open()
 		valve_open = !valve_open
 		. = TOPIC_REFRESH
 
 	else if (href_list["remove_tank"])
-		if(!holding)
+		if (!holding)
 			return TOPIC_HANDLED
 		if (valve_open)
-			valve_open = 0
-		if(istype(holding, /obj/item/tank))
+			valve_open = FALSE
+		if (istype(holding, /obj/item/tank))
 			holding.manipulated_by = user.real_name
 		holding.dropInto(loc)
 		holding = null
@@ -324,7 +515,7 @@ update_flag
 
 	else if (href_list["pressure_adj"])
 		var/diff = text2num(href_list["pressure_adj"])
-		if(diff > 0)
+		if (diff > 0)
 			release_pressure = min(10*ONE_ATMOSPHERE, release_pressure+diff)
 		else
 			release_pressure = max(ONE_ATMOSPHERE/10, release_pressure+diff)
@@ -343,149 +534,37 @@ update_flag
 			"\[Air\]" = "grey", \
 			"\[CAUTION\]" = "yellow", \
 		)
-		var/label = input(user, "Choose canister label", "Gas canister") as null|anything in colors
+		var/label = input(user, "Choose canister label", name) as null|anything in colors
 		if (label && CanUseTopic(user, state))
 			canister_color = colors[label]
 			icon_state = colors[label]
-			SetName("\improper Canister: [label]")
+			SetName("gas canister [label]")
 		update_icon()
 		. = TOPIC_REFRESH
 
 /obj/machinery/portable_atmospherics/canister/CanUseTopic()
-	if(destroyed)
+	if (destroyed)
 		return STATUS_CLOSE
 	return ..()
 
-/obj/machinery/portable_atmospherics/canister/phoron/New()
-	..()
-
-	src.air_contents.adjust_gas(GAS_PHORON, MolesForPressure())
-	src.update_icon()
-	return 1
-
-/obj/machinery/portable_atmospherics/canister/oxygen/New()
-	..()
-
-	src.air_contents.adjust_gas(GAS_OXYGEN, MolesForPressure())
-	src.update_icon()
-	return 1
-
-/obj/machinery/portable_atmospherics/canister/hydrogen/New()
-	..()
-	src.air_contents.adjust_gas(GAS_HYDROGEN, MolesForPressure())
-	src.update_icon()
-	return 1
-
-/obj/machinery/portable_atmospherics/canister/oxygen/prechilled/New()
-	..()
-	src.air_contents.temperature = 80
-	src.update_icon()
-	return 1
-
-/obj/machinery/portable_atmospherics/canister/sleeping_agent/New()
-	..()
-
-	air_contents.adjust_gas(GAS_N2O, MolesForPressure())
-	src.update_icon()
-	return 1
-
-//Dirty way to fill room with gas. However it is a bit easier to do than creating some floor/engine/n2o -rastaf0
-/obj/machinery/portable_atmospherics/canister/sleeping_agent/roomfiller/New()
-	..()
-	air_contents.gas[GAS_N2O] = 9*4000
-	spawn(10)
-		var/turf/simulated/location = src.loc
-		if (istype(src.loc))
-			while (!location.air)
-				sleep(10)
-			location.assume_air(air_contents)
-			air_contents = new
-	return 1
-
-/obj/machinery/portable_atmospherics/canister/nitrogen/New()
-	..()
-	src.air_contents.adjust_gas(GAS_NITROGEN, MolesForPressure())
-	src.update_icon()
-	return 1
-
-/obj/machinery/portable_atmospherics/canister/nitrogen/prechilled/New()
-	..()
-	src.air_contents.temperature = 80
-	src.update_icon()
-	return 1
-
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide/New()
-	..()
-	src.air_contents.adjust_gas(GAS_CO2, MolesForPressure())
-	src.update_icon()
-	return 1
 
 
-/obj/machinery/portable_atmospherics/canister/air/New()
-	..()
-	var/list/air_mix = StandardAirMix()
-	src.air_contents.adjust_multi(GAS_OXYGEN, air_mix[GAS_OXYGEN], GAS_NITROGEN, air_mix[GAS_NITROGEN])
+// Special types used for engine setup admin verb. They contain double the amount of gas as a normal canister.
+/obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup
+	start_pressure = 90 * ONE_ATMOSPHERE
 
-	src.update_icon()
-	return 1
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup
+	start_pressure = 90 * ONE_ATMOSPHERE
 
+/obj/machinery/portable_atmospherics/canister/phoron/engine_setup
+	start_pressure = 90 * ONE_ATMOSPHERE
 
+/obj/machinery/portable_atmospherics/canister/hydrogen/engine_setup
+	start_pressure = 90 * ONE_ATMOSPHERE
 
-// Special types used for engine setup admin verb, they contain double amount of that of normal canister.
-/obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup/New()
-	..()
-	src.air_contents.adjust_gas(GAS_NITROGEN, MolesForPressure())
-	src.update_icon()
-	return 1
-
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup/New()
-	..()
-	src.air_contents.adjust_gas(GAS_CO2, MolesForPressure())
-	src.update_icon()
-	return 1
-
-/obj/machinery/portable_atmospherics/canister/phoron/engine_setup/New()
-	..()
-	src.air_contents.adjust_gas(GAS_PHORON, MolesForPressure())
-	src.update_icon()
-	return 1
-
-/obj/machinery/portable_atmospherics/canister/hydrogen/engine_setup/New()
-	..()
-	src.air_contents.adjust_gas(GAS_HYDROGEN, MolesForPressure())
-	src.update_icon()
-
-// Spawn debug tanks.
-/obj/machinery/portable_atmospherics/canister/helium
-	name = "\improper Canister \[He\]"
-	icon_state = "black"
-	canister_color = "black"
-	can_label = 0
-
-/obj/machinery/portable_atmospherics/canister/helium/New()
-	..()
-	air_contents.adjust_gas(GAS_HELIUM, MolesForPressure())
-	update_icon()
-
-/obj/machinery/portable_atmospherics/canister/methyl_bromide
-	name = "\improper Canister \[CH3Br\]"
-	icon_state = "black"
-	canister_color = "black"
-	can_label = 0
-
-/obj/machinery/portable_atmospherics/canister/methyl_bromide/New()
-	..()
-	air_contents.adjust_gas(GAS_METHYL_BROMIDE, MolesForPressure())
-	update_icon()
-
-/obj/machinery/portable_atmospherics/canister/chlorine
-	name = "\improper Canister \[Cl\]"
-	icon_state = "black"
-	canister_color = "black"
-	can_label = 0
-
-/obj/machinery/portable_atmospherics/canister/chlorine/New()
-	..()
-	air_contents.adjust_gas(GAS_CHLORINE, MolesForPressure())
-	update_icon()
-// End debug tanks.
+#undef CANISTER_FLAG_HASTANK
+#undef CANISTER_FLAG_ISCONNECTED
+#undef CANISTER_FLAG_PRESSURE_VERYLOW
+#undef CANISTER_FLAG_PRESSURE_LOW
+#undef CANISTER_FLAG_PRESSURE_HIGH
+#undef CANISTER_FLAG_PRESSURE_VERYHIGH

--- a/code/modules/codex/entries/atmospherics.dm
+++ b/code/modules/codex/entries/atmospherics.dm
@@ -167,10 +167,14 @@
 /datum/codex_entry/atmos_canister
 	display_name = "gas canister" // because otherwise it shows up as 'canister: [caution]'
 	associated_paths = list(/obj/machinery/portable_atmospherics/canister)
-	mechanics_text = "The canister can be connected to a connector port with a wrench.  Tanks of gas (the kind you can hold in your hand) \
-	can be filled by the canister, by using the tank on the canister, increasing the release pressure, then opening the valve until it is full, and then close it.  \
-	*DO NOT* remove the tank until the valve is closed.  A gas analyzer can be used to check the contents of the canister."
-	antag_text = "Canisters can be damaged, spilling their contents into the air, or you can just leave the release valve open."
+	mechanics_text = "These metal canisters hold large amounts of gas under pressure. Tanks of gas (the kind you can hold in your hand) \
+	can be filled by the canister, by using the tank on the canister, increasing the release pressure, then opening the valve until it is full, and then closing it. \
+	*DO NOT* remove the tank until the valve is closed!<br><br>\
+	A wrench can be used to connect a canister to a port, or disconnect it. \
+	A gas analyzer, or a PDA with a gas analyzer program, can be used to check the contents of the canister. \
+	Duct tape can be used to repair damage, or a welding tool can be used to deconstruct it, as long as it's mostly empty (or has been destroyed.)"
+	antag_text = "Canisters take damage from attacks, bullets, and extreme temperatures, and can rupture, instantly spilling all their contents into the air. \
+	You can also just leave the release valve open. Fires can also occur <i>inside</i> of canisters, which can be hilariously terrifying."
 
 //Portable pumps
 /datum/codex_entry/atmos_power_pump

--- a/code/modules/materials/recipes_furniture.dm
+++ b/code/modules/materials/recipes_furniture.dm
@@ -165,7 +165,7 @@ ARMCHAIR(yellow)
 	time = 15
 
 /datum/stack_recipe/furniture/canister
-	title = "canister"
+	title = "gas canister"
 	result_type = /obj/machinery/portable_atmospherics/canister
 	req_amount = 10
 	time = 10

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -40,7 +40,7 @@ exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 437 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 436 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 4 ".Replace( matches" '\.Replace(_char)?\(' -P
 exactly 5 ".Find( matches" '\.Find(_char)?\(' -P


### PR DESCRIPTION
## About the Pull Request

Extensively refactors canisters and modernizes their code. Several features have been added, such as deconstruction, repair, and examining changes.

<details><summary>User-facing changes. Read this if you're a player:</summary>
<hr>

Canisters have been renamed to gas canisters, and are now lowercase named. 

Added a simple description for canisters.

Updated the codex entry for canisters.

You can examine canisters to see how damaged they are.

Canisters now rupture at 0 health, instead of 10, which effectively very slightly increases their max health.

You can deconstruct canisters with 50 kPa or less (or if they've been ruptured) using a welding tool. You get all the sheets back if it's intact, or half sheets back if it's destroyed.

You can repair canister damage with duct tape. Repair time depends on how much damage it's sustained.

Examining some machines with at least Basic construction skill no longer produces an empty line in the chat box.
<hr>
</details>

<details><summary>Backend changes. Read this if you're a coder:</summary>
<hr>

Canisters no longer gain air contents in `New()`. Instead they have a new assoc. list variable, `initial_gases`, that accepts gas IDs associated with the moles they should have. Negative numbers are used to fill the canister to its starting pressure. For instance, hydrogen canisters have `GAS_HYDROGEN = -1`, instead of filling manually in New.

Similarly, canisters now have an `initial_temperature` variable in Kelvin, that does what it says on the tin.

Most canister starting logic has been moved to a new base type proc, called `create_initial_gases()`. This is called normally in `LateInitialize()` during mapgen, or afterwards if it's mid-round.

`examine()` now has logic to tell the user how damaged the canister is at various thresholds.

Added new functionality: a welding tool can deconstruct canisters with low pressure. Duct tape can repair damage to a canister.
Renamed a lot of `0`s and `1`s to `FALSE` and `TRUE`.

`if()` statement linting.

Removed a subtype of N2O canister that continually produced gas. There's a build mode function that lets you place gas, and this code was super old, so I figured it was an alright time to call it obsolete. I'm totally fine keeping it, though.

Canister bitflags are now defined in the file instead of being magic numbers.

Added a stupid Easter egg to the description that happens 1% of the time.
<hr>
</details>

## Why It's Good For The Game

Canisters are some of the oldest stuff in the game, and haven't received significant code changes for over four years. Given how important they are in SS13, I felt it was a good idea to modernize them, as well as adding functionalities to bring them in line with other constructable objects. While this is primarily a backend-facing change, I'm hoping that players can also get some benefit from the new functionalities.

## Did you test it?

Because of the code changes of this PR, I did a full supermatter engine setup (2 full hydrogen canisters in cold loop, one in hot) with this branch active. The goal was to make sure there were no function issues or runtimes. To that end, it seems to have worked correctly - the engine setup went fine and no changes happened in the process except for me slicing apart the canisters once they were empty.

![dreamseeker_BdmaChCguF](https://user-images.githubusercontent.com/47678781/123372170-19644100-d551-11eb-8f31-333ee6b0c3c9.png)

I confess: I wasn't able to get the 1% description thing to happen, so technically the description Easter egg is untested. I can manually alter the probability locally and verify it, though, if that's asked!

## Changelog

:cl:
rscadd: You can now deconstruct nearly-empty or destroyed gas canisters with a welding tool.
rscadd: You can now repair damage to gas canisters with duct tape.
rscadd: Examining a gas canisters now gives a rough idea of how damaged it is.
tweak: Improved the feedback for attacking canisters - it now has a normal attack animation and plays a sound.
tweak: By making canisters rupture at zero health instead of 10, they're technically slightly stronger now!
spellcheck: Updated the codex entry for canisters to reflect new functionalities.
spellcheck: Renamed canisters - now they're `gas canister` instead of `Canister`. Also added a simple examine description.
spellcheck: Helium, Methyl Bromide, and Chlorine canisters now explicitly state what they contain on their label instead of having a chemical formula - this is to bring them in line with other gas canisters.
/:cl: