### PR TITLE
Fixes wrong forum link on the hub

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -541,7 +541,7 @@ GLOBAL_VAR_INIT(world_topic_last, world.timeofday)
 
 	s += "<b>[station_name()]</b>";
 	s += " ("
-	s += "<a href=\"https://forums.baystation12.net/\">" //Change this to wherever you want the hub to link to.
+	s += "<a href=\"https://forum.tegustation.com/index.php\">" //Change this to wherever you want the hub to link to.
 	s += "Forums"  //Replace this with something else. Or ever better, delete it and uncomment the game version.
 	s += "</a>"
 	s += ")"


### PR DESCRIPTION
## About the Pull Request

The forum link for Tegu now properly links to the right forums, instead of the Bay forums.

## Why It's Good For The Game

Right now, we're sending people to the wrong forum. This one must have slipped through; it's my fault for missing it.

## Did you test it?

I can't properly test this due to it needing hub visibility, which in of itself I believe needs a database set up. I leave it to the judgement of folks smarter than me whether or not this will work.