### PR TITLE
Actually readds Fleet jackets and polos

### DIFF
--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -9,7 +9,9 @@
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/cmd
+				/obj/item/clothing/gloves/thick/duty/solgov/cmd,
+				/obj/item/clothing/suit/storage/jacket/solgov/fleet/command,
+				/obj/item/clothing/under/solgov/utility/fleet/polopants/command
 			)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
@@ -47,7 +49,9 @@
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/eng
+				/obj/item/clothing/gloves/thick/duty/solgov/eng,
+				/obj/item/clothing/suit/storage/jacket/solgov/fleet,
+				/obj/item/clothing/under/solgov/utility/fleet/polopants
 			)
 
 /decl/hierarchy/mil_uniform/fleet/eng/noncom
@@ -84,7 +88,9 @@
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/eng
+				/obj/item/clothing/gloves/thick/duty/solgov/eng,
+				/obj/item/clothing/suit/storage/jacket/solgov/fleet,
+				/obj/item/clothing/under/solgov/utility/fleet/polopants
 			)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
@@ -126,7 +132,9 @@
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/sec
+				/obj/item/clothing/gloves/thick/duty/solgov/sec,
+				/obj/item/clothing/suit/storage/jacket/solgov/fleet/security,
+				/obj/item/clothing/under/solgov/utility/fleet/polopants/security
 			)
 
 
@@ -168,7 +176,9 @@
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/sec
+				/obj/item/clothing/gloves/thick/duty/solgov/sec,
+				/obj/item/clothing/suit/storage/jacket/solgov/fleet/security,
+				/obj/item/clothing/under/solgov/utility/fleet/polopants/security
 			)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
@@ -207,7 +217,9 @@
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/med
+				/obj/item/clothing/gloves/thick/duty/solgov/med,
+				/obj/item/clothing/suit/storage/jacket/solgov/fleet/medical,
+				/obj/item/clothing/under/solgov/utility/fleet/polopants/medical
 			)
 
 /decl/hierarchy/mil_uniform/fleet/med/noncom
@@ -242,7 +254,9 @@
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/med
+				/obj/item/clothing/gloves/thick/duty/solgov/med,
+				/obj/item/clothing/suit/storage/jacket/solgov/fleet/medical,
+				/obj/item/clothing/under/solgov/utility/fleet/polopants/medical
 			)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
@@ -281,7 +295,9 @@
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/sup
+				/obj/item/clothing/gloves/thick/duty/solgov/sup,
+				/obj/item/clothing/suit/storage/jacket/solgov/fleet/supply,
+				/obj/item/clothing/under/solgov/utility/fleet/polopants/supply
 			)
 
 /decl/hierarchy/mil_uniform/fleet/sup/noncom
@@ -316,7 +332,9 @@
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/sup
+				/obj/item/clothing/gloves/thick/duty/solgov/sup,
+				/obj/item/clothing/suit/storage/jacket/solgov/fleet/supply,
+				/obj/item/clothing/under/solgov/utility/fleet/polopants/supply
 			)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
@@ -359,7 +377,9 @@
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/svc
+				/obj/item/clothing/gloves/thick/duty/solgov/svc,
+				/obj/item/clothing/suit/storage/jacket/solgov/fleet/service,
+				/obj/item/clothing/under/solgov/utility/fleet/polopants/service
 			)
 
 /decl/hierarchy/mil_uniform/fleet/srv/noncom
@@ -395,7 +415,9 @@
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/svc
+				/obj/item/clothing/gloves/thick/duty/solgov/svc,
+				/obj/item/clothing/suit/storage/jacket/solgov/fleet/service,
+				/obj/item/clothing/under/solgov/utility/fleet/polopants/service
 			)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
@@ -416,7 +438,9 @@
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/exp
+				/obj/item/clothing/gloves/thick/duty/solgov/exp,
+				/obj/item/clothing/suit/storage/jacket/solgov/fleet/supply,
+				/obj/item/clothing/under/solgov/utility/fleet/polopants/supply
 			)
 
 /decl/hierarchy/mil_uniform/fleet/exp/noncom
@@ -473,7 +497,9 @@
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/cmd
+				/obj/item/clothing/gloves/thick/duty/solgov/cmd,
+				/obj/item/clothing/suit/storage/jacket/solgov/fleet/command,
+				/obj/item/clothing/under/solgov/utility/fleet/polopants/command
 			)
 
 /decl/hierarchy/mil_uniform/fleet/spt/noncom
@@ -509,7 +535,9 @@
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,
-				/obj/item/clothing/gloves/thick/duty/solgov/cmd
+				/obj/item/clothing/gloves/thick/duty/solgov/cmd,
+				/obj/item/clothing/suit/storage/jacket/solgov/fleet/command,
+				/obj/item/clothing/under/solgov/utility/fleet/polopants/command
 			)
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command


### PR DESCRIPTION
## About the Pull Request

Basically what it says in the title.  Fleet members can grab utility jackets and polo and pants uniforms from the vendors now, instead of them being admin spawn only.

## Why It's Good For The Game

Gives more variety to fleet players, also offers a few more storage slots using the jacket.

## Did you test it?
Yes, with Shuttle Pilot (E-7)

## Changelog

:cl: 
tweak: Adds Fleet Jackets and Polo and Pants back to the uniform vendors.
/:cl: