### PR TITLE
Hydroponics code improvement - tray modernization

### DIFF
--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -10,7 +10,7 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
-	
+
 	machine_name = "hydroponics tray"
 	machine_desc = "These are waist-high trays that can grow a vast variety of plants in a nutrient bath. Also comes with a sealable lid for plants that don't grow in a surrounding atmosphere. A cornerstone of self-sufficient spaceships across the galaxy."
 
@@ -24,10 +24,10 @@
 	var/weedlevel = 0          // Weeds (max 10)
 
 	// Tray state vars.
-	var/dead = 0               // Is it dead?
-	var/harvest = 0            // Is it ready to harvest?
-	var/age = 0                // Current plant age
-	var/sampled = 0            // Have we taken a sample?
+	var/dead = FALSE               // Is it dead?
+	var/harvest = FALSE            // Is it ready to harvest?
+	var/age = 0                    // Current plant age
+	var/sampled = FALSE            // Have we taken a sample?
 
 	// Harvest/mutation mods.
 	var/yield_mod = 0          // Modifier to yield
@@ -48,117 +48,32 @@
 	// Seed details/line data.
 	var/datum/seed/seed = null // The currently planted seed
 
-	// Reagent information for process(), consider moving this to a controller along
-	// with cycle information under 'mechanical concerns' at some point.
-	var/global/list/toxic_reagents = list(
-		/datum/reagent/dylovene =         -2,
-		/datum/reagent/toxin =             2,
-		/datum/reagent/hydrazine =         2.5,
-		/datum/reagent/acetone =	       1,
-		/datum/reagent/acid =              1.5,
-		/datum/reagent/acid/hydrochloric = 1.5,
-		/datum/reagent/acid/polyacid =     3,
-		/datum/reagent/toxin/plantbgone =  3,
-		/datum/reagent/cryoxadone =       -3,
-		/datum/reagent/radium =            2,
-		/datum/reagent/three_eye =         2
-		)
-	var/global/list/nutrient_reagents = list(
-		/datum/reagent/drink/milk =                     0.1,
-		/datum/reagent/ethanol/beer =                   0.25,
-		/datum/reagent/phosphorus =                     0.1,
-		/datum/reagent/sugar =                          0.1,
-		/datum/reagent/drink/sodawater =                0.1,
-		/datum/reagent/ammonia =                        1,
-		/datum/reagent/diethylamine =                   2,
-		/datum/reagent/nutriment =                      1,
-		/datum/reagent/adminordrazine =                 1,
-		/datum/reagent/toxin/fertilizer/eznutrient =    1,
-		/datum/reagent/toxin/fertilizer/robustharvest = 1,
-		/datum/reagent/toxin/fertilizer/left4zed =      1
-		)
-	var/global/list/weedkiller_reagents = list(
-		/datum/reagent/hydrazine =          -4,
-		/datum/reagent/phosphorus =         -2,
-		/datum/reagent/sugar =               2,
-		/datum/reagent/acid =               -2,
-		/datum/reagent/acid/hydrochloric =  -2,
-		/datum/reagent/acid/polyacid =      -4,
-		/datum/reagent/toxin/plantbgone =   -8,
-		/datum/reagent/adminordrazine =     -5
-		)
-	var/global/list/pestkiller_reagents = list(
-		/datum/reagent/sugar =                 2,
-		/datum/reagent/diethylamine =         -2,
-		/datum/reagent/toxin/bromide =        -2,
-		/datum/reagent/toxin/methyl_bromide = -4,
-		/datum/reagent/adminordrazine =       -5
-		)
-	var/global/list/water_reagents = list(
-		/datum/reagent/water =           1,
-		/datum/reagent/adminordrazine =  1,
-		/datum/reagent/drink/milk =      0.9,
-		/datum/reagent/ethanol/beer =    0.7,
-		/datum/reagent/hydrazine =      -2,
-		/datum/reagent/phosphorus =     -0.5,
-		/datum/reagent/water =           1,
-		/datum/reagent/drink/sodawater = 1,
-		)
-
-	// Beneficial reagents also have values for modifying yield_mod and mut_mod (in that order).
-	var/global/list/beneficial_reagents = list(
-		/datum/reagent/ethanol/beer =                    list( -0.05, 0,   0  ),
-		/datum/reagent/hydrazine =                       list( -2,    0,   0  ),
-		/datum/reagent/phosphorus =                      list( -0.75, 0,   0  ),
-		/datum/reagent/drink/sodawater =                 list(  0.1,  0,   0  ),
-		/datum/reagent/acid =                            list( -1,    0,   0  ),
-		/datum/reagent/acid/hydrochloric =               list( -1,    0,   0  ),
-		/datum/reagent/acid/polyacid =                   list( -2,    0,   0  ),
-		/datum/reagent/toxin/plantbgone =                list( -2,    0,   0.2),
-		/datum/reagent/cryoxadone =                      list(  3,    0,   0  ),
-		/datum/reagent/ammonia =                         list(  0.5,  0,   0  ),
-		/datum/reagent/diethylamine =                    list(  1,    0,   0  ),
-		/datum/reagent/nutriment =                       list(  0.5,  0.1, 0  ),
-		/datum/reagent/radium =                          list( -1.5,  0,   0.2),
-		/datum/reagent/adminordrazine =                  list(  1,    1,   1  ),
-		/datum/reagent/toxin/fertilizer/robustharvest =  list(  0,    0.2, 0  ),
-		/datum/reagent/toxin/fertilizer/left4zed =       list(  0,    0,   0.2),
-		/datum/reagent/three_eye =                       list(  -1  , 0,   0.5)
-		)
-
-	// Mutagen list specifies minimum value for the mutation to take place, rather
-	// than a bound as the lists above specify.
-	var/global/list/mutagenic_reagents = list(
-		/datum/reagent/radium =  8,
-		/datum/reagent/mutagen = 15,
-		/datum/reagent/toxin/fertilizer/left4zed = 30)
-
 /obj/machinery/portable_atmospherics/hydroponics/AltClick()
-	if(mechanical && !usr.incapacitated() && Adjacent(usr))
+	if (mechanical && !usr.incapacitated() && Adjacent(usr))
 		close_lid(usr)
-		return 1
+		return TRUE
 	return ..()
 
-/obj/machinery/portable_atmospherics/hydroponics/attack_ghost(var/mob/observer/ghost/user)
-	if(!(harvest && seed && seed.has_mob_product))
+/obj/machinery/portable_atmospherics/hydroponics/attack_ghost(mob/observer/ghost/user)
+	if (!(harvest && seed && seed.has_mob_product))
 		return
 
-	if(!user.can_admin_interact())
+	if (!user.can_admin_interact())
 		return
 
 	var/response = alert(user, "Are you sure you want to harvest this [seed.display_name]?", "Living plant request", "Yes", "No")
-	if(response == "Yes")
+	if (response == "Yes")
 		harvest()
 
 /obj/machinery/portable_atmospherics/hydroponics/Initialize()
-	if(!mechanical)
+	if (!mechanical)
 		construct_state = null
 	. = ..()
 	temp_chem_holder = new()
 	temp_chem_holder.create_reagents(10)
 	temp_chem_holder.atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 	create_reagents(200)
-	if(mechanical)
+	if (mechanical)
 		connect()
 	update_icon()
 	STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_ALL)
@@ -171,151 +86,144 @@
 
 /obj/machinery/portable_atmospherics/hydroponics/LateInitialize()
 	. = ..()
-	if(locate(/obj/item/seeds) in get_turf(src))
+	if (locate(/obj/item/seeds) in get_turf(src))
 		plant()
 
-/obj/machinery/portable_atmospherics/hydroponics/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/portable_atmospherics/hydroponics/bullet_act(obj/item/projectile/P)
 
 	//Don't act on seeds like dionaea that shouldn't change.
-	if(seed && seed.get_trait(TRAIT_IMMUTABLE) > 0)
+	if (seed && seed.get_trait(TRAIT_IMMUTABLE) > 0)
 		return
 
 	//Override for somatoray projectiles.
-	if(istype(Proj ,/obj/item/projectile/energy/floramut)&& prob(20))
-		if(istype(Proj, /obj/item/projectile/energy/floramut/gene))
-			var/obj/item/projectile/energy/floramut/gene/G = Proj
-			if(seed)
+	if (istype(P, /obj/item/projectile/energy/floramut) && prob(20))
+		if (istype(P, /obj/item/projectile/energy/floramut/gene))
+			var/obj/item/projectile/energy/floramut/gene/G = P
+			if (seed)
 				seed = seed.diverge_mutate_gene(G.gene, get_turf(loc))	//get_turf just in case it's not in a turf.
 		else
 			mutate(prob(75) ? 1 : 2)
 			return
-	else if(istype(Proj ,/obj/item/projectile/energy/florayield) && prob(20))
-		yield_mod = min(10,yield_mod+rand(1,2))
+	else if (istype(P ,/obj/item/projectile/energy/florayield) && prob(20))
+		yield_mod = min(10, yield_mod + rand(1, 2))
 		return
 
 	..()
 
-/obj/machinery/portable_atmospherics/hydroponics/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group || (height==0)) return 1
+/obj/machinery/portable_atmospherics/hydroponics/CanPass(atom/movable/mover, turf/target, height = 0, air_group = 0)
+	if (air_group || !height)
+		return TRUE
 
-	if(istype(mover) && mover.checkpass(PASS_FLAG_TABLE))
-		return 1
+	if (istype(mover) && mover.checkpass(PASS_FLAG_TABLE))
+		return TRUE
 	else
 		return !density
 
-/obj/machinery/portable_atmospherics/hydroponics/proc/check_health(var/icon_update = 1)
-	if(seed && !dead && health <= 0)
+/obj/machinery/portable_atmospherics/hydroponics/proc/check_health(icon_update = TRUE)
+	if (seed && !dead && health <= 0)
 		die()
 	check_level_sanity()
-	if(icon_update)
+	if (icon_update)
 		update_icon()
 
 /obj/machinery/portable_atmospherics/hydroponics/proc/die()
-	dead = 1
+	dead = TRUE
 	mutation_level = 0
-	harvest = 0
+	harvest = FALSE
 	weedlevel += 1 * HYDRO_SPEED_MULTIPLIER
 	pestlevel = 0
 
 //Process reagents being input into the tray.
 /obj/machinery/portable_atmospherics/hydroponics/proc/process_reagents()
-
-	if(!reagents) return
-
-	if(reagents.total_volume <= 0)
+	if (reagents?.total_volume <= 0)
 		return
 
-	reagents.trans_to_obj(temp_chem_holder, min(reagents.total_volume,rand(1,3)))
+	reagents.trans_to_obj(temp_chem_holder, min(reagents.total_volume, rand(1, 3)))
 
-	for(var/datum/reagent/R in temp_chem_holder.reagents.reagent_list)
+	for (var/datum/reagent/R in temp_chem_holder.reagents.reagent_list)
 
 		var/reagent_total = temp_chem_holder.reagents.get_reagent_amount(R.type)
 
-		if(seed && !dead)
+		if (seed && !dead)
 			//Handle some general level adjustments.
-			if(toxic_reagents[R.type])
-				toxins += toxic_reagents[R.type]         * reagent_total
-			if(weedkiller_reagents[R.type])
-				weedlevel += weedkiller_reagents[R.type] * reagent_total
-			if(pestkiller_reagents[R.type])
-				pestlevel += pestkiller_reagents[R.type] * reagent_total
+			toxins += R.plant_toxin * reagent_total
+			weedlevel += R.plant_weedkiller * reagent_total
+			pestlevel += R.plant_pestkiller * reagent_total
 
 			// Beneficial reagents have a few impacts along with health buffs.
-			if(beneficial_reagents[R.type])
-				health += beneficial_reagents[R.type][1]       * reagent_total
-				yield_mod += beneficial_reagents[R.type][2]    * reagent_total
-				mutation_mod += beneficial_reagents[R.type][3] * reagent_total
+			health += R.plant_health_mod * reagent_total
+			yield_mod += R.plant_yield_mod * reagent_total
+			mutation_mod += R.plant_mut_mod * reagent_total
 
 			// Mutagen is distinct from the previous types and mostly has a chance of proccing a mutation.
-			if(mutagenic_reagents[R.type])
-				mutation_level += reagent_total*mutagenic_reagents[R.type]+mutation_mod
+			mutation_level += R.plant_mutagen + mutation_mod & reagent_total
 
 		// Handle nutrient refilling.
-		if(nutrient_reagents[R.type])
-			nutrilevel += nutrient_reagents[R.type]  * reagent_total
+		nutrilevel += R.plant_nutrients * reagent_total
 
 		// Handle water and water refilling.
 		var/water_added = 0
-		if(water_reagents[R.type])
-			var/water_input = water_reagents[R.type] * reagent_total
+		if (R.plant_water != 0)
+			var/water_input = R.plant_water * reagent_total
 			water_added += water_input
 			waterlevel += water_input
 
 		// Water dilutes toxin level.
-		if(water_added > 0)
-			toxins -= round(water_added/4)
+		if (water_added > 0)
+			toxins -= round(water_added / 4)
 
 	temp_chem_holder.reagents.clear_reagents()
 	check_health()
 
 //Harvests the product of a plant.
-/obj/machinery/portable_atmospherics/hydroponics/proc/harvest(var/mob/user)
+/obj/machinery/portable_atmospherics/hydroponics/proc/harvest(mob/user)
 
 	//Harvest the product of the plant,
-	if(!seed || !harvest)
+	if (!seed || !harvest)
 		return
 
-	if(closed_system)
-		if(user) to_chat(user, "You can't harvest from the plant while the lid is shut.")
+	if (closed_system)
+		if (user)
+			to_chat(user, SPAN_WARNING("You can't harvest from the plant while the lid is shut."))
 		return
 
-	if(user)
+	if (user)
 		. = seed.harvest(user,yield_mod)
 	else
-		. = seed.harvest(get_turf(src),yield_mod)
+		. = seed.harvest(get_turf(src), yield_mod)
 	// Reset values.
-	harvest = 0
+	harvest = FALSE
 	lastproduce = age
 
-	if(!seed.get_trait(TRAIT_HARVEST_REPEAT))
+	if (!seed.get_trait(TRAIT_HARVEST_REPEAT))
 		yield_mod = 0
 		seed = null
-		dead = 0
+		dead = FALSE
 		age = 0
-		sampled = 0
+		sampled = FALSE
 		mutation_mod = 0
 
 	check_health()
 
 //Clears out a dead plant.
-/obj/machinery/portable_atmospherics/hydroponics/proc/remove_dead(var/mob/user, var/silent)
-	if(!dead)
+/obj/machinery/portable_atmospherics/hydroponics/proc/remove_dead(mob/user, silent)
+	if (!dead)
 		return
 
-	if(closed_system)
-		if(user)
-			to_chat(user, "You can't remove the dead plant while the lid is shut.")
+	if (closed_system)
+		if (user)
+			to_chat(user, SPAN_WARNING("You can't remove the dead plant while the lid is shut."))
 		return FALSE
 
 	seed = null
-	dead = 0
-	sampled = 0
+	dead = FALSE
+	sampled = FALSE
 	age = 0
 	yield_mod = 0
 	mutation_mod = 0
 
-	if(!silent && user)
-		to_chat(user, "You remove the dead plant.")
+	if (!silent && user)
+		to_chat(user, SPAN_NOTICE("You remove the dead plant."))
 	lastproduce = 0
 	check_health()
 	return TRUE
@@ -324,38 +232,40 @@
 /obj/machinery/portable_atmospherics/hydroponics/proc/weed_invasion()
 
 	//Remove the seed if something is already planted.
-	if(seed) seed = null
+	if (seed)
+		seed = null
 	seed = SSplants.seeds[pick(list("reishi", "nettles", "amanita", "mushrooms", "plumphelmet", "towercap", "harebells", "weeds", "diona"))]
-	if(!seed) return //Weed does not exist, someone fucked up.
+	if (!seed)
+		return //Weed does not exist, someone fucked up.
 
-	dead = 0
+	dead = FALSE
 	age = 0
 	health = seed.get_trait(TRAIT_ENDURANCE)
 	lastcycle = world.time
-	harvest = 0
+	harvest = FALSE
 	weedlevel = 0
 	pestlevel = 0
-	sampled = 0
+	sampled = FALSE
 	update_icon()
-	visible_message("<span class='notice'>[src] has been overtaken by [seed.display_name].</span>")
+	visible_message(SPAN_WARNING("\The [src] has been overtaken by [seed.display_name]!"))
 
 	return
 
-/obj/machinery/portable_atmospherics/hydroponics/proc/mutate(var/severity)
+/obj/machinery/portable_atmospherics/hydroponics/proc/mutate(severity)
 
 	// No seed, no mutations.
-	if(!seed)
+	if (!seed)
 		return
 
 	// Check if we should even bother working on the current seed datum.
-	if(seed.mutants && seed.mutants.len && severity > 1)
+	if (seed.mutants && seed.mutants.len && severity > 1)
 		mutate_species()
 		return
 
 	// We need to make sure we're not modifying one of the global seed datums.
 	// If it's not in the global list, then no products of the line have been
 	// harvested yet and it's safe to assume it's restricted to this tray.
-	if(!isnull(SSplants.seeds[seed.name]))
+	if (!isnull(SSplants.seeds[seed.name]))
 		seed = seed.diverge()
 	seed.mutate(severity,get_turf(src))
 
@@ -366,22 +276,22 @@
 	set category = "Object"
 	set src in view(1)
 
-	if(usr.incapacitated())
+	if (usr.incapacitated())
 		return
-	if(ishuman(usr) || istype(usr, /mob/living/silicon/robot))
+	if (ishuman(usr) || istype(usr, /mob/living/silicon/robot))
 		var/new_light = input("Specify a light level.") as null|anything in list(0,1,2,3,4,5,6,7,8,9,10)
-		if(new_light)
+		if (new_light)
 			tray_light = new_light
 			to_chat(usr, "You set the tray to a light level of [tray_light] lumens.")
 	return
 
 /obj/machinery/portable_atmospherics/hydroponics/proc/check_level_sanity()
 	//Make sure various values are sane.
-	if(seed)
+	if (seed)
 		health =     max(0,min(seed.get_trait(TRAIT_ENDURANCE),health))
 	else
 		health = 0
-		dead = 0
+		dead = FALSE
 
 	mutation_level = max(0,min(mutation_level,100))
 	nutrilevel =     max(0,min(nutrilevel,10))
@@ -394,144 +304,128 @@
 
 	var/previous_plant = seed.display_name
 	var/newseed = seed.get_mutant_variant()
-	if(newseed in SSplants.seeds)
+	if (newseed in SSplants.seeds)
 		seed = SSplants.seeds[newseed]
 	else
 		return
 
-	dead = 0
+	dead = FALSE
 	mutate(1)
 	age = 0
 	health = seed.get_trait(TRAIT_ENDURANCE)
 	lastcycle = world.time
-	harvest = 0
+	harvest = FALSE
 	weedlevel = 0
 
 	update_icon()
-	visible_message("<span class='danger'>The </span><span class='notice'>[previous_plant]</span><span class='danger'> has suddenly mutated into </span><span class='notice'>[seed.display_name]!</span>")
-
+	visible_message(SPAN_DANGER("\The [previous_plant] suddenly mutates into \a [seed.display_name]!"))
 	return
 
-/obj/machinery/portable_atmospherics/hydroponics/attackby(var/obj/item/O, var/mob/user)
+/obj/machinery/portable_atmospherics/hydroponics/attackby(obj/item/O, mob/user)
 
 	if (O.is_open_container())
-		return 0
+		return FALSE
 
-	if(O.edge && O.w_class < ITEM_SIZE_NORMAL && user.a_intent != I_HURT)
+	if (O.edge && O.w_class < ITEM_SIZE_NORMAL && user.a_intent != I_HURT)
 
-		if(!seed)
+		if (!seed)
 			to_chat(user, SPAN_WARNING("There is nothing to take a sample from in \the [src]."))
 			return
 
-		if(sampled)
+		if (sampled)
 			to_chat(user, SPAN_WARNING("There's no bits that can be used for a sampling left."))
 			return
 
-		if(dead)
+		if (dead)
 			to_chat(user, SPAN_WARNING("The plant is dead."))
 			return
 
 		var/needed_skill = seed.mysterious ? SKILL_ADEPT : SKILL_BASIC
-		if(prob(user.skill_fail_chance(SKILL_BOTANY, 90, needed_skill)))
-			to_chat(user, SPAN_WARNING("You failed to get a usable sample."))
+		if (prob(user.skill_fail_chance(SKILL_BOTANY, 90, needed_skill)))
+			to_chat(user, SPAN_WARNING("You fail to get a usable sample."))
 		else
 			// Create a sample.
-			seed.harvest(user,yield_mod,1)
-		health -= (rand(3,5)*10)
+			seed.harvest(user, yield_mod, 1)
+		health -= (rand(3, 5) * 10)
 
-		if(prob(30))
-			sampled = 1
+		if (prob(30))
+			sampled = TRUE
 
 		// Bookkeeping.
 		check_health()
-		force_update = 1
+		force_update = TRUE
 		Process()
 
 		return
 
-	else if(istype(O, /obj/item/reagent_containers/syringe))
-
-		var/obj/item/reagent_containers/syringe/S = O
-
-		if (S.mode == 1)
-			if(seed)
-				return ..()
-			else
-				to_chat(user, "There's no plant to inject.")
-				return 1
-		else
-			if(seed)
-				//Leaving this in in case we want to extract from plants later.
-				to_chat(user, "You can't get any extract out of this plant.")
-			else
-				to_chat(user, "There's nothing to draw something from.")
-			return 1
-
 	else if (istype(O, /obj/item/seeds))
-
 		plant_seed(user, O)
 
 	else if (istype(O, /obj/item/material/minihoe))  // The minihoe
 
-		if(weedlevel > 0)
-			user.visible_message("<span class='notice'>[user] starts uprooting the weeds.</span>", "<span class='notice'>You remove the weeds from the [src].</span>")
+		if (weedlevel > 0)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] uproots the weeds from \the [src]."),
+				SPAN_NOTICE("You remove the weeds from \the [src].")
+			)
 			weedlevel = 0
-			if(seed)
+			if (seed)
 				var/needed_skill = seed.mysterious ? SKILL_ADEPT : SKILL_BASIC
-				if(!user.skill_check(SKILL_BOTANY, needed_skill))
-					health -= rand(40,60)
-					check_health(1)
+				if (!user.skill_check(SKILL_BOTANY, needed_skill))
+					to_chat(user, SPAN_WARNING("You accidentally damage \the [seed.display_name]!"))
+					health -= rand(40, 60)
+			check_health() // force an icon update
 		else
-			to_chat(user, "<span class='notice'>This plot is completely devoid of weeds. It doesn't need uprooting.</span>")
+			to_chat(user, SPAN_NOTICE("This plot is completely devoid of weeds, and doesn't need uprooting."))
 
 	else if (istype(O, /obj/item/storage/plants))
 
 		attack_hand(user)
 
 		var/obj/item/storage/plants/S = O
-		for (var/obj/item/reagent_containers/food/snacks/grown/G in locate(user.x,user.y,user.z))
-			if(!S.can_be_inserted(G, user))
+		for (var/obj/item/reagent_containers/food/snacks/grown/G in locate(user.x, user.y, user.z))
+			if (!S.can_be_inserted(G, user))
 				return
 			S.handle_item_insertion(G, 1)
 
-	else if ( istype(O, /obj/item/plantspray) )
+	else if (istype(O, /obj/item/plantspray))
 
 		var/obj/item/plantspray/spray = O
 		toxins += spray.toxicity
 		pestlevel -= spray.pest_kill_str
 		weedlevel -= spray.weed_kill_str
-		to_chat(user, "You spray [src] with [O].")
-		playsound(loc, 'sound/effects/spray3.ogg', 50, 1, -6)
+		to_chat(user, SPAN_NOTICE("You spray [src] with [O]."))
+		playsound(loc, 'sound/effects/spray3.ogg', 50, TRUE, -6)
 		qdel(O)
 		check_health()
 
-	else if(mechanical && isWrench(O))
+	else if (mechanical && isWrench(O))
 
 		//If there's a connector here, the portable_atmospherics setup can handle it.
-		if(locate(/obj/machinery/atmospherics/portables_connector/) in loc)
+		if (locate(/obj/machinery/atmospherics/portables_connector/) in loc)
 			return ..()
 
-		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
+		playsound(loc, 'sound/items/Ratchet.ogg', 50, TRUE)
 		anchored = !anchored
-		to_chat(user, "You [anchored ? "wrench" : "unwrench"] \the [src].")
+		to_chat(user, SPAN_NOTICE("You [anchored ? "drop \the [src]'s securing bolts" : "free \the [src] from the floor"]."))
 
-	else if(O.force && seed)
+	else if (O.force && seed)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		user.visible_message("<span class='danger'>\The [seed.display_name] has been attacked by [user] with \the [O]!</span>")
-		playsound(get_turf(src), O.hitsound, 100, 1)
-		if(!dead)
+		user.visible_message(SPAN_DANGER("\The [seed.display_name] has been attacked by [user] with \the [O]!"))
+		playsound(get_turf(src), O.hitsound, 100, TRUE)
+		if (!dead)
 			health -= O.force
 			check_health()
-	else if(mechanical)
+	else if (mechanical)
 		return component_attackby(O, user)
 
-/obj/machinery/portable_atmospherics/hydroponics/proc/plant_seed(var/mob/user, var/obj/item/seeds/S)
+/obj/machinery/portable_atmospherics/hydroponics/proc/plant_seed(mob/user, obj/item/seeds/S)
 
-	if(seed)
-		to_chat(user, "<span class='warning'>\The [src] already has seeds in it!</span>")
+	if (seed)
+		to_chat(user, SPAN_WARNING("\The [src] already has seeds in it!"))
 		return
 
-	if(!S.seed)
+	if (!S.seed)
 		to_chat(user, "The packet seems to be empty. You throw it away.")
 		qdel(S)
 		return
@@ -539,7 +433,7 @@
 	to_chat(user, "You plant the [S.seed.seed_name] [S.seed.seed_noun].")
 	lastproduce = 0
 	seed = S.seed //Grab the seed datum.
-	dead = 0
+	dead = FALSE
 	age = 1
 
 	//Snowflakey, maybe move this to the seed datum
@@ -547,8 +441,8 @@
 	lastcycle = world.time
 
 	var/needed_skill = seed.mysterious ? SKILL_ADEPT : SKILL_BASIC
-	if(prob(user.skill_fail_chance(SKILL_BOTANY, 40, needed_skill)))
-		dead = 1
+	if (prob(user.skill_fail_chance(SKILL_BOTANY, 40, needed_skill)))
+		dead = TRUE
 		health = 0
 
 	qdel(S)
@@ -558,71 +452,149 @@
 	return FALSE // no hands
 
 /obj/machinery/portable_atmospherics/hydroponics/physical_attack_hand(mob/user)
-	if(harvest)
+	if (harvest)
 		harvest(user)
 		return TRUE
-	if(dead)
+	else if (dead)
 		remove_dead(user)
 		return TRUE
+	else if (operable())
+		if (mechanical)
+			to_chat(user, SPAN_NOTICE("You take a look at \the [initial(name)]'s status panel..."))
+		else
+			to_chat(user, SPAN_NOTICE("You closely inspect \the [initial(name)]..."))
+		to_chat(user, get_plant_diagnostics(user))
 
 /obj/machinery/portable_atmospherics/hydroponics/examine(mob/user)
 	. = ..(user)
-	if(!seed)
+	if (!seed)
 		to_chat(user, "\The [src] is empty.")
 		return
 
-	to_chat(user, "<span class='notice'>\An [seed.display_name] plant is growing here.</span>")
+	to_chat(user, SPAN_NOTICE("\An [seed.display_name] plant is growing here."))
 
-	if(user.skill_check(SKILL_BOTANY, SKILL_BASIC))
-		if(weedlevel >= 5)
-			to_chat(user, "\The [src] is <span class='danger'>infested with weeds</span>!")
-		if(pestlevel >= 5)
-			to_chat(user, "\The [src] is <span class='danger'>infested with tiny worms</span>!")
+	if (user.skill_check(SKILL_BOTANY, SKILL_BASIC))
+		if (weedlevel >= 5)
+			to_chat(user, SPAN_DANGER("\The [src] is infested with weeds!"))
+		if (pestlevel >= 5)
+			to_chat(user, SPAN_DANGER("\The [src] is infested with tiny worms!"))
 
-		if(dead)
-			to_chat(user, "<span class='danger'>The [seed.display_name] plant is dead.</span>")
-		else if(health <= (seed.get_trait(TRAIT_ENDURANCE)/ 2))
-			to_chat(user, "The [seed.display_name] plant looks <span class='danger'>unhealthy</span>.")
+		if (dead)
+			to_chat(user, SPAN_DANGER("\The [seed.display_name] plant is dead."))
+		else if (health <= (seed.get_trait(TRAIT_ENDURANCE)/ 2))
+			to_chat(user, SPAN_WARNING("The [seed.display_name] plant looks unhealthy."))
+	else if (seed || weedlevel >= 5)
+		to_chat(user, "There's something growing here, but you don't know anything more about it.")
 
-	if(mechanical && Adjacent(user))
+	if (mechanical && Adjacent(user))
 		var/turf/T = loc
 		var/datum/gas_mixture/environment
 
-		if(closed_system && (connected_port || holding))
+		if (closed_system && (connected_port || holding))
 			environment = air_contents
 
-		if(!environment)
-			if(istype(T))
+		if (!environment)
+			if (istype(T))
 				environment = T.return_air()
 
-		if(!environment) //We're in a crate or nullspace, bail out.
+		if (!environment) //We're in a crate or nullspace, bail out.
 			return
 
 		var/light_string
-		if(closed_system && mechanical)
+		if (closed_system && mechanical)
 			light_string = "that the internal lights are set to [tray_light] lumens"
 		else
 			var/light_available = T.get_lumcount() * 5
 			light_string = "a light level of [light_available] lumens"
 
-		to_chat(user, "Water: [round(waterlevel,0.1)]/100")
-		to_chat(user, "Nutrient: [round(nutrilevel,0.1)]/10")
+		to_chat(user, "Water: [round(waterlevel, 0.1)]/100")
+		to_chat(user, "Nutrients: [round(nutrilevel, 0.1)]/10")
 		to_chat(user, "The tray's sensor suite is reporting [light_string] and a temperature of [environment.temperature]K.")
+
+/// Returns a chat string that gives a diagnostic about the contents of this tray and the health of the plant.
+/obj/machinery/portable_atmospherics/hydroponics/proc/get_plant_diagnostics(mob/user)
+	if (isobserver(user) || !user.skill_check(SKILL_BOTANY, SKILL_BASIC))
+		if (mechanical)
+			return "\The [src] has a detailed status panel, but you don't know what any of it means."
+		else
+			return "You can't gauge anything about the state of \the [src]."
+	var/list/dat = list()
+
+	// Get info about reagents queued up to be added to the tray
+	var/stored_water = 0
+	var/stored_nutrients = 0
+	for (var/datum/reagent/R in reagents.reagent_list)
+		stored_water += R.plant_water * R.volume
+		stored_nutrients += R.plant_nutrients * R.volume
+
+	// Get a string representation of weeds and pests
+	var/weed_string = "Weed level: <b>"
+	var/pest_string = "Pest level: <b>"
+	switch (weedlevel)
+		if (0 to 1)
+			weed_string += "None"
+		if (1 to 5)
+			weed_string += "Low"
+		else
+			weed_string += SPAN_DANGER("High")
+	switch (pestlevel)
+		if (0 to 1)
+			pest_string += "None"
+		if (1 to 5)
+			pest_string += "Low"
+		else
+			pest_string += SPAN_DANGER("High")
+	weed_string += "</b>"
+	pest_string += "</b>"
+
+	// Simple stuff about the seeds
+	if (!seed)
+		dat += "No seeds planted."
+	else
+		dat += "This [initial(name)] is growing <b>[seed.display_name]</b>."
+
+	// For hydroponics trays or master botanists, obtain a detailed readout including exact numbers for health, water, nutrients, and so on
+	if (mechanical || user.skill_check(SKILL_BOTANY, SKILL_PROF))
+		if (seed)
+			if (!dead)
+				dat += "Plant health: <b>[health]/[seed.get_trait(TRAIT_ENDURANCE)]</b>"
+			else
+				dat += "Plant health: [SPAN_DANGER("DEAD")]"
+		dat += "Water level: <b>[waterlevel]/100</b>"
+		dat += "Nutrient level: <b>[nutrilevel]/10</b>"
+		dat += weed_string
+		dat += pest_string
+		dat += "There is <b>[stored_water] units</b> of water and <b>[stored_nutrients] units</b> of nutrients soaking into the plant."
+
+	// Simple trays (like soil patches) just give a rough representation of how things appear
+	else
+		if (seed)
+			if (!dead)
+				dat += "Plant health: <b>[health >= seed.get_trait(TRAIT_ENDURANCE) / 2 ? "Healthy" : SPAN_DANGER("Unhealthy")]</b>"
+			else
+				dat += "Plant health: [SPAN_DANGER("DEAD")]"
+		dat += "Water level: <b>[waterlevel > 10 ? "High" : SPAN_DANGER("Low")]</b>"
+		dat += "Nutrient level: <b>[nutrilevel > 2 ? "High" : SPAN_DANGER("Low")]</b>"
+		dat += weed_string
+		dat += pest_string
+		dat += "The soil is <b>[stored_water + stored_nutrients > 1 ? "damp" : "dry"]</b>."
+
+	return jointext(dat, "<br>")
 
 /obj/machinery/portable_atmospherics/hydroponics/verb/close_lid_verb()
 	set name = "Toggle Tray Lid"
 	set category = "Object"
 	set src in view(1)
-	if(usr.incapacitated())
+	if (usr.incapacitated())
 		return
 
-	if(ishuman(usr) || istype(usr, /mob/living/silicon/robot))
+	if (ishuman(usr) || istype(usr, /mob/living/silicon/robot))
 		close_lid(usr)
 	return
 
-/obj/machinery/portable_atmospherics/hydroponics/proc/close_lid(var/mob/living/user)
+/obj/machinery/portable_atmospherics/hydroponics/proc/close_lid(mob/living/user)
 	closed_system = !closed_system
-	to_chat(user, "You [closed_system ? "close" : "open"] the tray's lid.")
+	to_chat(user, SPAN_NOTICE("You [closed_system ? "close" : "open"] the tray's lid."))
 	update_icon()
 
 //proc for trays to spawn pre-planted
@@ -630,17 +602,16 @@
 	var/obj/item/seeds/S = locate() in get_turf(src)
 	seed = S.seed
 	lastproduce = 0
-	dead = 0
+	dead = FALSE
 	age = 1
 	health = (istype(S, /obj/item/seeds/cutting) ? round(seed.get_trait(TRAIT_ENDURANCE)/rand(2,5)) : seed.get_trait(TRAIT_ENDURANCE))
 	lastcycle = world.time
 	qdel(S)
 	check_health()
 
-/obj/machinery/portable_atmospherics/hydroponics/do_simple_ranged_interaction(var/mob/user)
-	if(dead)
+/obj/machinery/portable_atmospherics/hydroponics/do_simple_ranged_interaction(mob/user)
+	if (dead)
 		remove_dead()
-	else if(harvest)
+	else if (harvest)
 		harvest()
 	return TRUE
-

--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -1,8 +1,8 @@
 /obj/machinery/portable_atmospherics/hydroponics/Process()
 
 	// Handle nearby smoke if any.
-	for(var/obj/effect/effect/smoke/chem/smoke in view(1, src))
-		if(smoke.reagents.total_volume)
+	for (var/obj/effect/effect/smoke/chem/smoke in view(1, src))
+		if (smoke.reagents.total_volume)
 			smoke.reagents.trans_to_obj(src, 5, copy = 1)
 
 	//Do this even if we're not ready for a plant cycle.
@@ -10,9 +10,9 @@
 	var/needs_icon_update = 0
 
 	// Update values every cycle rather than every process() tick.
-	if(force_update)
+	if (force_update)
 		force_update = 0
-	else if(world.time < (lastcycle + cycledelay))
+	else if (world.time < (lastcycle + cycledelay))
 		return
 	lastcycle = world.time
 
@@ -21,54 +21,54 @@
 
 	// Weeds like water and nutrients, there's a chance the weed population will increase.
 	// Bonus chance if the tray is unoccupied.
-	if(waterlevel > 10 && nutrilevel > 2 && prob(isnull(seed) ? 5 : 1))
+	if (waterlevel > 10 && nutrilevel > 2 && prob(isnull(seed) ? 5 : 1))
 		weedlevel += 1 * HYDRO_SPEED_MULTIPLIER
 
 	// There's a chance for a weed explosion to happen if the weeds take over.
 	// Plants that are themselves weeds (weed_tolerance > 10) are unaffected.
 	if (weedlevel >= 10 && prob(10))
-		if(!seed || weedlevel >= seed.get_trait(TRAIT_WEED_TOLERANCE))
+		if (!seed || weedlevel >= seed.get_trait(TRAIT_WEED_TOLERANCE))
 			weed_invasion()
-			if(mechanical)
+			if (mechanical)
 				needs_icon_update |= 1
 
 	// If there is no seed data (and hence nothing planted),
 	// or the plant is dead, process nothing further.
-	if(!seed || dead)
-		if(mechanical) 
+	if (!seed || dead)
+		if (mechanical)
 			update_icon() //Harvesting would fail to set alert icons properly.
 		return
 
 	// Advance plant age.
 	var/cur_stage = get_overlay_stage()
-	if(prob(30)) 
+	if (prob(30))
 		age += 1 * HYDRO_SPEED_MULTIPLIER
-		if(get_overlay_stage() != cur_stage)
+		if (get_overlay_stage() != cur_stage)
 			needs_icon_update |= 1
 
 	//Highly mutable plants have a chance of mutating every tick.
-	if(seed.get_trait(TRAIT_IMMUTABLE) == -1)
+	if (seed.get_trait(TRAIT_IMMUTABLE) == -1)
 		var/mut_prob = rand(1,100)
-		if(mut_prob <= 5) mutate(mut_prob == 1 ? 2 : 1)
+		if (mut_prob <= 5) mutate(mut_prob == 1 ? 2 : 1)
 
 	// Other plants also mutate if enough mutagenic compounds have been added.
-	if(!seed.get_trait(TRAIT_IMMUTABLE))
-		if(prob(min(mutation_level,100)))
+	if (!seed.get_trait(TRAIT_IMMUTABLE))
+		if (prob(min(mutation_level,100)))
 			mutate((rand(100) < 15) ? 2 : 1)
 			mutation_level = 0
 
 	// Maintain tray nutrient and water levels.
-	if(seed.get_trait(TRAIT_REQUIRES_NUTRIENTS) && seed.get_trait(TRAIT_NUTRIENT_CONSUMPTION) > 0 && nutrilevel > 0 && prob(25))
+	if (seed.get_trait(TRAIT_REQUIRES_NUTRIENTS) && seed.get_trait(TRAIT_NUTRIENT_CONSUMPTION) > 0 && nutrilevel > 0 && prob(25))
 		nutrilevel -= max(0,seed.get_trait(TRAIT_NUTRIENT_CONSUMPTION) * HYDRO_SPEED_MULTIPLIER)
-	if(seed.get_trait(TRAIT_REQUIRES_WATER) && seed.get_trait(TRAIT_WATER_CONSUMPTION) > 0 && waterlevel > 0 && prob(25))
+	if (seed.get_trait(TRAIT_REQUIRES_WATER) && seed.get_trait(TRAIT_WATER_CONSUMPTION) > 0 && waterlevel > 0 && prob(25))
 		waterlevel -= max(0,seed.get_trait(TRAIT_WATER_CONSUMPTION) * HYDRO_SPEED_MULTIPLIER)
 
 	// Make sure the plant is not starving or thirsty. Adequate
 	// water and nutrients will cause a plant to become healthier.
 	var/healthmod = rand(1,3) * HYDRO_SPEED_MULTIPLIER
-	if(seed.get_trait(TRAIT_REQUIRES_NUTRIENTS) && prob(35))
+	if (seed.get_trait(TRAIT_REQUIRES_NUTRIENTS) && prob(35))
 		health += (nutrilevel < 2 ? -healthmod : healthmod)
-	if(seed.get_trait(TRAIT_REQUIRES_WATER) && prob(35))
+	if (seed.get_trait(TRAIT_REQUIRES_WATER) && prob(35))
 		health += (waterlevel < 10 ? -healthmod : healthmod)
 
 	// Check that pressure, heat and light are all within bounds.
@@ -76,14 +76,14 @@
 	var/turf/T = loc
 	var/datum/gas_mixture/environment
 	// If we're closed, take from our internal sources.
-	if(closed_system && (connected_port || holding))
+	if (closed_system && (connected_port || holding))
 		environment = air_contents
 	// If atmos input is not there, grab from turf.
-	if(!environment && istype(T)) environment = T.return_air()
-	if(!environment) return
+	if (!environment && istype(T)) environment = T.return_air()
+	if (!environment) return
 
 	// Seed datum handles gasses, light and pressure.
-	if(mechanical && closed_system)
+	if (mechanical && closed_system)
 		health -= seed.handle_environment(T,environment,tray_light)
 	else
 		health -= seed.handle_environment(T,environment)
@@ -94,24 +94,24 @@
 
 	// Toxin levels beyond the plant's tolerance cause damage, but
 	// toxins are sucked up each tick and slowly reduce over time.
-	if(toxins > 0)
+	if (toxins > 0)
 		var/toxin_uptake = max(1,round(toxins/10))
-		if(toxins > seed.get_trait(TRAIT_TOXINS_TOLERANCE))
+		if (toxins > seed.get_trait(TRAIT_TOXINS_TOLERANCE))
 			health -= toxin_uptake
 		toxins -= toxin_uptake
 
 	// Check for pests and weeds.
 	// Some carnivorous plants happily eat pests.
-	if(pestlevel > 0)
-		if(seed.get_trait(TRAIT_CARNIVOROUS))
+	if (pestlevel > 0)
+		if (seed.get_trait(TRAIT_CARNIVOROUS))
 			health += HYDRO_SPEED_MULTIPLIER
 			pestlevel -= HYDRO_SPEED_MULTIPLIER
 		else if (pestlevel >= seed.get_trait(TRAIT_PEST_TOLERANCE))
 			health -= HYDRO_SPEED_MULTIPLIER
 
 	// Some plants thrive and live off of weeds.
-	if(weedlevel > 0)
-		if(seed.get_trait(TRAIT_PARASITE))
+	if (weedlevel > 0)
+		if (seed.get_trait(TRAIT_PARASITE))
 			health += HYDRO_SPEED_MULTIPLIER
 			weedlevel -= HYDRO_SPEED_MULTIPLIER
 		else if (weedlevel >= seed.get_trait(TRAIT_WEED_TOLERANCE))
@@ -119,29 +119,29 @@
 
 	// Handle life and death.
 	// When the plant dies, weeds thrive and pests die off.
-	check_health(0)
+	check_health()
 
 	// If enough time (in cycles, not ticks) has passed since the plant was harvested, we're ready to harvest again.
-	if((age > seed.get_trait(TRAIT_MATURATION)) && \
+	if ((age > seed.get_trait(TRAIT_MATURATION)) && \
 	 ((age - lastproduce) > seed.get_trait(TRAIT_PRODUCTION)) && \
 	 (!harvest && !dead))
-		harvest = 1
+		harvest = TRUE
 		lastproduce = age
 		needs_icon_update |= 1
 
 	// If we're a vine which is not in a closed tray and is at least half mature, and there's no vine currently on our turf: make one (maybe)
-	if(!closed_system && \
+	if (!closed_system && \
 	 seed.get_trait(TRAIT_SPREAD) == 2 && \
 	 2 * age >= seed.get_trait(TRAIT_MATURATION) && \
 	 !(locate(/obj/effect/vine) in get_turf(src)) && \
 	 prob(2 * seed.get_trait(TRAIT_POTENCY)))
 		new /obj/effect/vine(get_turf(src), seed)
 
-	if(prob(3))  // On each tick, there's a chance the pest population will increase
+	if (prob(3))  // On each tick, there's a chance the pest population will increase
 		pestlevel += 0.1 * HYDRO_SPEED_MULTIPLIER
 
 	// Some seeds will self-harvest if you don't keep a lid on them.
-	if(seed && seed.can_self_harvest && harvest && !closed_system && prob(5))
+	if (seed && seed.can_self_harvest && harvest && !closed_system && prob(5))
 		harvest()
 
 	check_health(needs_icon_update)

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -7,6 +7,8 @@
 	stat_immune = NOINPUT | NOSCREEN | NOPOWER
 	mechanical = 0
 	tray_light = 0
+	machine_name = null
+	machine_desc = null
 
 /obj/machinery/portable_atmospherics/hydroponics/soil/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(istype(O,/obj/item/tank))

--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -158,10 +158,10 @@ GLOBAL_LIST_EMPTY(skills)
 	name = "Botany"
 	desc = "Describes how good a character is at growing and maintaining plants."
 	levels = list( "Unskilled"			= "You know next to nothing about plants. While you can attempt to plant, weed, or harvest, you are just as likely to kill the plant instead.",
-						"Basic"				= "You've done some gardening. You can water, weed, fertilize, plant, and harvest, and you can recognize and deal with pests. You may be a hobby gardener.<br>- You can safely plant and weed normal plants.<br>- You can tell weeds and pests apart from each other.",
+						"Basic"				= "You've done some gardening. You can water, weed, fertilize, plant, and harvest, and you can recognize and deal with pests. You may be a hobby gardener.<br>- You can safely plant and weed normal plants.<br>- You can tell weeds and pests apart from each other.<br>- You can inspect growing plants with an empty hand to see information about their status.",
 						"Trained"			= "You are proficient at botany, and can grow plants for food or oxygen production. Your plants will generally survive and prosper. You know the basics of manipulating plant genes.<br>- You can safely plant and weed exotic plants.<br>- You can operate xenoflora machines. The sample's degradation decreases with skill level.",
 						"Experienced"		= "You're a botanist or farmer, capable of running a facility's hydroponics farms or doing botanical research. You are adept at creating custom hybrids and modified strains.",
-						"Master"		= "You're a specialized botanist. You can care for even the most exotic, fragile, or dangerous plants. You can use gene manipulation machinery with precision, and are often able to avoid the degradation of samples.")
+						"Master"		= "You're a specialized botanist. You can care for even the most exotic, fragile, or dangerous plants. You can use gene manipulation machinery with precision, and are often able to avoid the degradation of samples.<br>- Your exacting eye allows you to see the exact information about soil patches by inspecting them.")
 
 /decl/hierarchy/skill/service/cooking
 	ID = "cooking"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -60,6 +60,27 @@
 	var/scent_descriptor = SCENT_DESC_SMELL
 	var/scent_range = 1
 
+	// Data for how this reagent affects plants being grown in hydroponics trays.
+
+	/// How much water does this reagent provide to hydroponics trays?
+	var/plant_water = 0
+	/// How much nutrients does this reagent provide to hydroponics trays?
+	var/plant_nutrients = 0
+	/// How much does this reagent poison plants in hydroponics trays?
+	var/plant_toxin = 0
+	/// How effective is this reagent as a weed killer? Negative values remove weeds, positive values add.
+	var/plant_weedkiller = 0
+	/// How effective is this reagent as a pest killer? Negative values kill pests, positive values lets them thrive.
+	var/plant_pestkiller = 0
+	/// How much does this reagent mutate plants?
+	var/plant_mutagen = 0
+	/// How much does this reagent modify the health of plants?
+	var/plant_health_mod = 0
+	/// How much does this reagent modify the yield of plants?
+	var/plant_yield_mod = 0
+	/// How much does this reagent modify the mutation chance of plants?
+	var/plant_mut_mod = 0
+
 	var/should_admin_log = FALSE
 
 /datum/reagent/New(var/datum/reagents/holder)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -92,6 +92,7 @@
 	chilling_point = T0C
 	heating_products = list(/datum/reagent/water/boiling)
 	heating_point = T100C
+	plant_water = 1
 	value = 0
 
 /datum/reagent/water/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -7,6 +7,7 @@
 	reagent_state = LIQUID
 	color = "#808080"
 	metabolism = REM * 0.2
+	plant_toxin = 1
 	value = DISPENSER_REAGENT_VALUE
 
 /datum/reagent/acetone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -50,6 +51,8 @@
 	color = "#404030"
 	metabolism = REM * 0.5
 	overdose = 5
+	plant_nutrients = 1
+	plant_health_mod = 0.5
 	value = DISPENSER_REAGENT_VALUE
 
 /datum/reagent/ammonia/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -197,6 +200,10 @@
 	color = "#808080"
 	metabolism = REM * 0.2
 	touch_met = 5
+	plant_water = -2
+	plant_toxin = 2.5
+	plant_weedkiller = -4
+	plant_health_mod = -2
 	value = DISPENSER_REAGENT_VALUE
 
 /datum/reagent/hydrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -260,6 +267,10 @@
 	taste_description = "vinegar"
 	reagent_state = SOLID
 	color = "#832828"
+	plant_water = -0.5
+	plant_nutrients = 0.1
+	plant_weedkiller = -2
+	plant_health_mod = -0.75
 	value = DISPENSER_REAGENT_VALUE
 
 /datum/reagent/potassium
@@ -283,6 +294,10 @@
 	taste_description = "the color blue, and regret"
 	reagent_state = SOLID
 	color = "#c7c7c7"
+	plant_toxin = 2
+	plant_mutagen = 8
+	plant_health_mod = -1.5
+	plant_mut_mod = 0.2
 	value = DISPENSER_REAGENT_VALUE
 	should_admin_log = TRUE
 
@@ -308,6 +323,9 @@
 	var/power = 5
 	var/meltdose = 10 // How much is needed to melt
 	var/max_damage = 40
+	plant_toxin = 1.5
+	plant_weedkiller = -2
+	plant_health_mod = -1
 	value = DISPENSER_REAGENT_VALUE
 	should_admin_log = TRUE
 
@@ -418,6 +436,9 @@
 	reagent_state = SOLID
 	color = "#ffffff"
 	scannable = 1
+	plant_nutrients = 0.1
+	plant_weedkiller = 2
+	plant_pestkiller = 2
 
 	glass_name = "sugar"
 	glass_desc = "The organic compound commonly known as table sugar and sometimes called saccharose. This white, odorless, crystalline powder has a pleasing, sweet taste."

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drinks.dm
@@ -233,6 +233,8 @@
 	description = "An opaque white liquid produced by the mammary glands of mammals."
 	taste_description = "milk"
 	color = "#dfdfdf"
+	plant_water = 0.9
+	plant_nutrients = 0.1
 
 	glass_name = "milk"
 	glass_desc = "White and nutritious goodness!"
@@ -466,6 +468,9 @@
 	adj_dizzy = -5
 	adj_drowsy = -3
 	adj_temp = -5
+	plant_water = 1
+	plant_nutrients = 0.1
+	plant_health_mod = 0.1
 
 	glass_name = "soda water"
 	glass_desc = "Soda water. Why not make a scotch and soda?"
@@ -1418,7 +1423,7 @@
 	color = "#0e0900"
 	glass_name = "skrianhi tea"
 	glass_desc = "A blend of teas from Moghes, commonly drank by Unathi."
-	
+
 ///// new shit /////
 /datum/reagent/drink/tegu/shirley
 	name = "Shirley Temple"
@@ -1434,8 +1439,8 @@
 	name = "Shirley Temple"
 	result = /datum/reagent/drink/tegu/shirley
 	required_reagents = list(/datum/reagent/drink/grenadine = 1, /datum/reagent/drink/juice/orange = 2, /datum/reagent/drink/space_up = 2)
-	result_amount = 5 
-	
+	result_amount = 5
+
 /datum/reagent/drink/milk/goat
 	name = "Goat Milk"
 	description = "An opaque white liquid produced by the mammary glands of goats."

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Ethanol.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Ethanol.dm
@@ -61,6 +61,9 @@
 	color = "#ffd300"
 	strength = 50
 	nutriment_factor = 1
+	plant_water = 0.7
+	plant_nutrients = 0.25
+	plant_health_mod = -0.5
 
 	glass_name = "beer"
 	glass_desc = "A freezing container of beer"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food.dm
@@ -7,6 +7,9 @@
 	var/nutriment_factor = 10 // Per unit
 	var/hydration_factor = 0 // Per unit
 	var/injectable = 0
+	plant_nutrients = 1
+	plant_health_mod = 0.5
+	plant_yield_mod = 0.1
 	color = "#664330"
 	value = 0.1
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -89,6 +89,7 @@
 	color = "#00a000"
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
+	plant_toxin = -2
 	value = 2.1
 	var/remove_generic = 1
 	var/list/remove_toxins = list(
@@ -174,6 +175,8 @@
 	metabolism = REM * 0.5
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
+	plant_toxin = -3
+	plant_health_mod = 3
 	value = 3.9
 
 /datum/reagent/cryoxadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -103,6 +103,13 @@
 	reagent_state = LIQUID
 	color = "#c8a5dc"
 	flags = AFFECTS_DEAD //This can even heal dead people.
+	plant_water = 1
+	plant_nutrients = 1
+	plant_weedkiller = -5
+	plant_pestkiller = -5
+	plant_health_mod = 1
+	plant_yield_mod = 1
+	plant_mut_mod = 1
 
 	glass_name = "liquid gold"
 	glass_desc = "It's magic. We don't have to explain it."
@@ -180,6 +187,9 @@
 	taste_description = "iron"
 	reagent_state = LIQUID
 	color = "#604030"
+	plant_nutrients = 2
+	plant_pestkiller = -2
+	plant_health_mod = 0.1
 	value = 0.9
 
 /datum/reagent/surfactant // Foam precursor
@@ -523,27 +533,27 @@
 /datum/reagent/colored_hair_dye/red
 	name = "Red Hair Dye"
 	color = "#b33636"
-	
+
 /datum/reagent/colored_hair_dye/orange
 	name = "Orange Hair Dye"
 	color = "#b5772f"
-	
+
 /datum/reagent/colored_hair_dye/yellow
 	name = "Yellow Hair Dye"
 	color = "#a6a035"
-		
+
 /datum/reagent/colored_hair_dye/green
 	name = "Green Hair Dye"
 	color = "#61a834"
-	
+
 /datum/reagent/colored_hair_dye/blue
 	name = "Blue Hair Dye"
 	color = "#3470a8"
-	
+
 /datum/reagent/colored_hair_dye/purple
 	name = "Purple Hair Dye"
 	color = "#6d2d91"
-		
+
 /datum/reagent/colored_hair_dye/grey
 	name = "Grey Hair Dye"
 	color = "#696969"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -11,6 +11,7 @@
 	heating_products = list(/datum/reagent/toxin/denatured)
 	heating_point = 100 CELSIUS
 	heating_message = "goes clear."
+	plant_toxin = 2
 	value = 2
 	should_admin_log = TRUE
 
@@ -271,15 +272,19 @@
 	color = "#664330"
 	heating_point = null
 	heating_products = null
+	plant_nutrients = 1
 
 /datum/reagent/toxin/fertilizer/eznutrient
 	name = "EZ Nutrient"
 
 /datum/reagent/toxin/fertilizer/left4zed
 	name = "Left-4-Zed"
+	plant_mutagen = 30
+	plant_mut_mod = 0.2
 
 /datum/reagent/toxin/fertilizer/robustharvest
 	name = "Robust Harvest"
+	plant_yield_mod = 0.2
 
 /datum/reagent/toxin/plantbgone
 	name = "Plant-B-Gone"
@@ -289,6 +294,10 @@
 	color = "#49002e"
 	strength = 4
 	heating_products = list(/datum/reagent/toxin, /datum/reagent/water)
+	plant_toxin = 3
+	plant_weedkiller = -8
+	plant_health_mod = -2
+	plant_mut_mod = 0.2
 
 /datum/reagent/toxin/plantbgone/touch_turf(var/turf/T)
 	if(istype(T, /turf/simulated/wall))
@@ -321,6 +330,9 @@
 	power = 10
 	meltdose = 4
 	max_damage = 60
+	plant_toxin = 3
+	plant_weedkiller = -4
+	plant_health_mod = -2
 
 /datum/reagent/acid/stomach
 	name = "stomach acid"
@@ -356,6 +368,7 @@
 	taste_mult = 0.9
 	reagent_state = LIQUID
 	color = "#13bc5e"
+	plant_mutagen = 15
 	value = 3.1
 
 /datum/reagent/mutagen/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
@@ -681,6 +694,9 @@
 	color = "#ccccff"
 	metabolism = REM
 	overdose = 25
+	plant_toxin = 2
+	plant_health_mod = -1
+	plant_mut_mod = 0.5
 	should_admin_log = TRUE
 
 	// M A X I M U M C H E E S E
@@ -872,6 +888,7 @@
 	strength = 3
 	heating_products = null
 	heating_point = null
+	plant_pestkiller = -2
 
 /datum/reagent/toxin/bromide/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_MANTID)
@@ -896,6 +913,7 @@
 	strength = 5
 	heating_products = null
 	heating_point = null
+	plant_pestkiller = -4
 
 /datum/reagent/toxin/methyl_bromide/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	. = (alien != IS_MANTID && alien != IS_NABBER && ..())


### PR DESCRIPTION
## About the Pull Request

This is an attempt to modernize hydroponics tray code, and is the first of what might turn into several PRs addressing how old their code is. Like a lotta stuff, they function, but are super duper hacky in a lot of ways.

<details><summary>User-facing changes</summary>
<hr>

* You can now click on a hydroponics tray or soil patch with an empty hand to get a more detailed readout about its current status.
* Added spans to a lot of messages from the hydroponics tray.
* Icons for hydroponics trays should update more consistently.
<hr>
</details>

<details><summary>Backend changes</summary>
<hr>

* Replaced a whole lot of magic numbers with bool defines.
* Added spans to many messages that lacked them.
* Rewrote a few messages for grammatical consistency.
* Ran a styling pass for almost the entire `tray.dm` file.
* Hydroponics trays no longer define information about reagent interactions. Instead, these variables have been moved to variables on reagent datums themselves, such as `plant_toxin`, `plant_yield_mod`, etc.
* Added a `get_plant_diagnostics()` proc to hydroponics trays. This is called when a player interacts with a tray using an empty hand, and gives a detailed readout of status, including water, nutrients, weed levels, plant health, and so on. A player needs at least basic Botany skill to comprehend what they're looking at, and soil patches give much less information than hydroponics trays (except with master Botany, at which point the player will get a detailed readout even from soil.)
* Removed unused code for using a syringe on a hydroponics tray to get out extract. It doesn't actually do anything right now! In the event of plant extracts eventually being added, it'd be trivial to add this back in a cleaner way, but for the time being, it's simply really old code that isn't being used.
<hr>
</details>

## Why It's Good For The Game

For the user-facing changes: reagent transfer in hydroponics trays is a timed process, and one that isn't quick. It's my hope that the diagnostic report will be usable to gauge whether or not you've already watered or fed a plant recently, in case you grow many plants at a time and forget which ones you've done. This was spurned by personal experiences, because I do it all the time!

The backend changes allow for logic to be more simply defined on reagents themselves, and prevents hydroponics trays from needing to rely on several huge associative lists for their reagents. The general stylizing pass is made in an attempt to modernize the code further, both to support future changes as well as to bring things closer to a unified standard.

## Did you test it?

I did some brief testing by planting things and using the inspection feature several times with varediting. Water and fertilizer bottles were used to feed and water plants during this time, and appeared to work. I have yet to test it in a "proper" environment where many plants are planted and harvested at once, but I'd like to do that shortly as of the time of writing.

## Changelog

:cl:
rscadd: You can now use a hydroponics tray with an empty hand to get more information about the plant growing there, including water and nutrients that are still processing, as well as weed level, pest level, and so on.
spellcheck: Assigned spans to many messages in hydroponics trays that were missing them.
/:cl: