### PR TITLE
Fixes runtime spam caused by animals with no natural weapon

### DIFF
--- a/code/modules/mob/living/simple_animal/combat.dm
+++ b/code/modules/mob/living/simple_animal/combat.dm
@@ -41,7 +41,7 @@
 		return FALSE
 
 	var/obj/item/natural_weapon/weapon = get_natural_weapon()
-	weapon.resolve_attackby(A, src)
+	weapon?.resolve_attackby(A, src)
 
 	return TRUE
 


### PR DESCRIPTION
## About the Pull Request

Fixes a runtime error caused by simple animals trying to retaliate when they have no natural weapon. No user facing changes.

## Why It's Good For The Game

Runtimes are bad, mmmkay?

## Did you test it?

I did, on several unfortunate opossums. They were the ones mainly causing the error, don't look at me like that!

## Changelog

:cl:
bugfix: Fixed a runtime caused by certain animals trying to retaliate when having no natural weapon.
/:cl:
