### PR TITLE
Toxin rework

### DIFF
--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -7,7 +7,7 @@
 	layer = ABOVE_PROJECTILE_LAYER
 	time_to_live = 300
 	pass_flags = PASS_FLAG_TABLE | PASS_FLAG_GRILLE | PASS_FLAG_GLASS //PASS_FLAG_GLASS is fine here, it's just so the visual effect can "flow" around glass
-	var/splash_amount = 10 //atoms moving through a smoke cloud get splashed with up to 10 units of reagent
+	var/splash_amount = 5 //atoms moving through a smoke cloud get splashed with up to 5 units of reagent
 	var/turf/destination
 
 /obj/effect/effect/smoke/chem/New(var/newloc, smoke_duration, turf/dest_turf = null, icon/cached_icon = null)
@@ -84,6 +84,7 @@
 	var/list/targetTurfs
 	var/list/wallList
 	var/density
+	var/smokeVolume
 	var/show_log = 1
 
 /datum/effect/effect/system/smoke_spread/chem/spores
@@ -110,6 +111,7 @@
 	range = n * 0.3
 	cardinals = c
 	carry.trans_to_obj(chemholder, carry.total_volume, copy = 1)
+	smokeVolume = n
 
 	if(istype(loca, /turf/))
 		location = loca
@@ -179,7 +181,7 @@
 		I = icon('icons/effects/96x96.dmi', "smoke")
 
 	//Calculate smoke duration
-	var/smoke_duration = 150
+	var/smoke_duration = smokeVolume * 1.5 SECONDS
 
 	var/pressure = 0
 	var/datum/gas_mixture/environment = location.return_air()
@@ -192,7 +194,7 @@
 		var/radius = i * 1.5
 		if(!radius)
 			spawn(0)
-				spawnSmoke(location, I, 1, 1)
+				spawnSmoke(location, I, smoke_duration, 1)
 			continue
 
 		var/offset = 0
@@ -211,7 +213,7 @@
 				continue
 			if(T in targetTurfs)
 				spawn(0)
-					spawnSmoke(T, I, range)
+					spawnSmoke(T, smoke_duration, range)
 
 //------------------------------------------
 // Randomizes and spawns the smoke effect.
@@ -223,7 +225,7 @@
 	if(passed_smoke)
 		smoke = passed_smoke
 	else
-		smoke = new /obj/effect/effect/smoke/chem(location, smoke_duration + rand(0, 20), T, I)
+		smoke = new /obj/effect/effect/smoke/chem(location, smoke_duration + rand(1.5 SECONDS, 3 SECONDS), T, I)
 
 	if(chemholder.reagents.reagent_list.len)
 		chemholder.reagents.trans_to_obj(smoke, chemholder.reagents.total_volume / dist, copy = 1) //copy reagents to the smoke so mob/breathe() can handle inhaling the reagents

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -315,15 +315,21 @@
 	M.take_organ_damage(0, removed * power)
 
 /datum/reagent/acid/affect_touch(var/mob/living/carbon/M, var/alien, var/removed) // This is the most interesting
+
+	M.visible_message(
+		SPAN_WARNING("\The [M]'s skin sizzles and burns on contact with the liquid!"),
+		SPAN_DANGER("Your skin sizzles and burns!.")
+		)
+
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.head)
 			if(H.head.unacidable)
-				to_chat(H, "<span class='danger'>Your [H.head] protects you from the acid.</span>")
+				to_chat(H, SPAN_WARNING("Your [H.head] protects you from the liquid."))
 				remove_self(volume)
 				return
 			else if(removed > meltdose)
-				to_chat(H, "<span class='danger'>Your [H.head] melts away!</span>")
+				to_chat(H, SPAN_DANGER("Your [H.head] melts away!"))
 				qdel(H.head)
 				H.update_inv_head(1)
 				H.update_hair(1)
@@ -333,11 +339,11 @@
 
 		if(H.wear_mask)
 			if(H.wear_mask.unacidable)
-				to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid.</span>")
+				to_chat(H, SPAN_DANGER("Your [H.wear_mask] protects you from the acid."))
 				remove_self(volume)
 				return
 			else if(removed > meltdose)
-				to_chat(H, "<span class='danger'>Your [H.wear_mask] melts away!</span>")
+				to_chat(H, SPAN_DANGER("Your [H.wear_mask] melts away!"))
 				qdel(H.wear_mask)
 				H.update_inv_wear_mask(1)
 				H.update_hair(1)
@@ -347,10 +353,10 @@
 
 		if(H.glasses)
 			if(H.glasses.unacidable)
-				to_chat(H, "<span class='danger'>Your [H.glasses] partially protect you from the acid!</span>")
+				to_chat(H, SPAN_WARNING("Your [H.glasses] partially protect you from the liquid!"))
 				removed /= 2
 			else if(removed > meltdose)
-				to_chat(H, "<span class='danger'>Your [H.glasses] melt away!</span>")
+				to_chat(H, SPAN_DANGER("Your [H.glasses] melt away!"))
 				qdel(H.glasses)
 				H.update_inv_glasses(1)
 				removed -= meltdose / 2

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -59,13 +59,55 @@
 	heating_point = null
 	heating_products = null
 
-/datum/reagent/toxin/amatoxin
+/datum/reagent/toxin/amatoxin // Delayed action poison, very dangerous but takes a while before doing anything.
 	name = "Amatoxin"
 	description = "A powerful poison derived from certain species of mushroom."
 	taste_description = "mushroom"
 	reagent_state = LIQUID
+	metabolism = REM * 0.5
 	color = "#792300"
 	strength = 10
+
+/datum/reagent/toxin/amatoxin/affect_blood(mob/living/carbon/M, alien, removed)
+	if(alien == IS_DIONA)
+		return
+	M.reagents.add_reagent(/datum/reagent/toxin/amaspores, 2 * removed)
+
+/datum/reagent/toxin/amaspores
+	name = "Amaspores"
+	description = "The secondary component to amatoxin poisoning, remaining dormant for a time before causing rapid organ and tissue decay."
+	taste_description = "dusty dirt"
+	reagent_state = LIQUID
+	metabolism = REM * 4 // Extremely quick to act once the amatoxin has left the body
+	color = "#330e00"
+	strength = 30
+
+/datum/reagent/toxin/amaspores/affect_blood(mob/living/carbon/M, alien, removed)
+	if(alien == IS_DIONA)
+		return
+
+	if(M.chem_doses[/datum/reagent/toxin/amatoxin] > 0)
+		M.reagents.add_reagent(/datum/reagent/toxin/amaspores, metabolism) // The spores lay dormant for as long as any traces of amatoxin remain
+		if (prob(5))
+			to_chat(M, SPAN_DANGER("Everything itches, how uncomfortable!"))
+		if (prob(10))
+			to_chat(M, SPAN_WARNING("Your eyes are watering, it's hard to see!"))
+			M.eye_blurry = max(M.eye_blurry, 10)
+		if (prob(10))
+			to_chat(M, SPAN_DANGER("Your throat itches uncomfortably!"))
+			M.custom_emote(2, "coughs!")
+		return
+
+	M.add_chemical_effect(CE_SLOWDOWN, 1)
+
+	if (prob(15))
+		M.Weaken(5)
+		M.add_chemical_effect(CE_VOICELOSS, 5)
+	if (prob(30))
+		M.eye_blurry = max(M.eye_blurry, 10)
+
+	M.take_organ_damage(3 * removed, 0, ORGAN_DAMAGE_FLESH_ONLY)
+	M.adjustToxLoss(5 * removed, 0, ORGAN_DAMAGE_FLESH_ONLY)
 
 /datum/reagent/toxin/carpotoxin
 	name = "Carpotoxin"
@@ -75,6 +117,19 @@
 	color = "#003333"
 	target_organ = BP_BRAIN
 	strength = 10
+
+/datum/reagent/toxin/carpotoxin/affect_blood(mob/living/carbon/M, alien, removed)
+	if(alien == IS_DIONA)
+		return
+
+	var/effectiveness = 1
+	var/effective_dose = 2
+
+	if(M.chem_doses[type] < effective_dose)
+		effectiveness = M.chem_doses[type]/effective_dose
+	else if(volume < effective_dose)
+		effectiveness = volume/effective_dose
+	M.add_chemical_effect(CE_BLOCKAGE, (80 * effectiveness)/100)
 
 /datum/reagent/toxin/venom
 	name = "Spider Venom"
@@ -334,20 +389,49 @@
 	taste_description = "acid"
 	reagent_state = LIQUID
 	color = "#c8a5dc"
+	metabolism = REM * 0.5
 	overdose = REAGENTS_OVERDOSE
 	value = 2.4
 
-/datum/reagent/lexorin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA)
+/datum/reagent/lexorin/affect_blood(mob/living/carbon/M, alien, removed)
+	if(alien == IS_DIONA || alien == IS_VOX) // Lexorin now focuses on removing oxygen from the blood, it wouldn't make sense that these two races are affected
 		return
 	if(alien == IS_SKRELL)
-		M.take_organ_damage(2.4 * removed, 0, ORGAN_DAMAGE_FLESH_ONLY)
-		if(M.losebreath < 22.5)
+		M.take_organ_damage(8 * removed, 0, ORGAN_DAMAGE_FLESH_ONLY)
+		if (prob(10))
+			M.visible_message(
+				SPAN_WARNING("\The [M]'s skin fizzles and flakes away!"),
+				SPAN_DANGER("Your skin fizzles and flakes away!")
+			)
+		if(M.losebreath < 45)
 			M.losebreath++
 	else
-		M.take_organ_damage(3 * removed, 0, ORGAN_DAMAGE_FLESH_ONLY)
-		if(M.losebreath < 15)
+		M.take_organ_damage(10 * removed, 0, ORGAN_DAMAGE_FLESH_ONLY)
+		if (prob(10))
+			M.visible_message(
+				SPAN_WARNING("\The [M]'s skin fizzles and flakes away!"),
+				SPAN_DANGER("Your skin fizzles and flakes away!")
+			)
+		if(M.losebreath < 30)
 			M.losebreath++
+	M.adjustOxyLoss(15 * removed)
+
+/datum/reagent/lexorin/affect_touch(mob/living/carbon/M, alien, removed)
+	if (alien == IS_VOX || alien == IS_DIONA) // Vox & Diona shouldn't be effected by skin permeable chemicals
+		return
+
+	touch_met = volume // immediately permiates the skin, also avoids bugs with chemical duplication.
+
+	// The warning messages should only display once per splash, all of the chemicals upon the skin should be absorbed in one tick.
+	M.visible_message(
+		SPAN_WARNING("\The [M]'s skin fizzles and flakes on contact with the liquid!"),
+		SPAN_DANGER("You feel a painful fizzling and your skin begins to flake!.")
+	)
+
+	if(alien == IS_SKRELL) // Skrell breathe through their skin, seems logical that this would be more effective
+		M.reagents.add_reagent(/datum/reagent/lexorin, 0.75 * removed)
+	else
+		M.reagents.add_reagent(/datum/reagent/lexorin, 0.5 * removed)
 
 /datum/reagent/mutagen
 	name = "Unstable mutagen"
@@ -586,7 +670,7 @@
 	M.make_dizzy(drug_strength)
 	M.confused = max(M.confused, drug_strength * 5)
 
-/datum/reagent/impedrezene
+/datum/reagent/impedrezene // Impairs mental function correctly, takes an overwhelming dose to kill.
 	name = "Impedrezene"
 	description = "Impedrezene is a narcotic that impedes one's ability by slowing down the higher brain cell functions."
 	taste_description = "numbness"
@@ -595,16 +679,24 @@
 	overdose = REAGENTS_OVERDOSE
 	value = 1.8
 
-/datum/reagent/impedrezene/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/impedrezene/affect_blood(mob/living/carbon/M, alien, removed)
 	if(alien == IS_DIONA)
 		return
 	M.jitteriness = max(M.jitteriness - 5, 0)
+	M.add_chemical_effect(M.add_chemical_effect(CE_SLOWDOWN, 1))
+
 	if(prob(80))
-		M.adjustBrainLoss(5.25 * removed)
+		M.confused = max(M.confused, 10)
 	if(prob(50))
 		M.drowsyness = max(M.drowsyness, 3)
 	if(prob(10))
 		M.emote("drool")
+		M.apply_effect(STUTTER, 3)
+
+	if (M.getBrainLoss() < 60)
+		M.adjustBrainLoss(14 * removed)
+	else
+		M.adjustBrainLoss(7 * removed)
 
 /datum/reagent/mindbreaker
 	name = "Mindbreaker Toxin"


### PR DESCRIPTION
## About the Pull Request

directly ported from [Bay](https://github.com/Baystation12/Baystation12/pull/30855) with the permission from the original author. reworks the way some toxins work aswell as smoke. allowing for toxins to be more impactful. See original pr for in deph paragraphs about what exactly is changed

## Why It's Good For The Game
This PR allows for more uses for toxins. many previous toxins were extremely weak, also gives a use for smoke clouds as before they were unreliable and useless.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Did you test it?

It compiles and runs

## Changelog

:cl: Yvesza , Sky
balance: Improved the effects of Amatoxin, Lexorin, Carpotoxin and Impedrezene.
balance: Vox are no longer effected by Lexorin.
balance: Chemical smoke duration now scales with the amount of reagents used to create it.
balance: Chemical smoke splashes less reagents on touch (10 -> 5)
tweak: Characters being coated with harmful chemicals will receive warning messages, along with anyone close enough to bear witness.
tweak: Being sprayed with acid while wearing protective gear no longer automatically identifies it as acid.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
