### PR TITLE
Biomods for more subspecies

### DIFF
--- a/code/modules/sprite_accessories/accessory_booster.dm
+++ b/code/modules/sprite_accessories/accessory_booster.dm
@@ -1,6 +1,6 @@
 /datum/sprite_accessory/marking/booster
 	species_allowed = list(SPECIES_HUMAN)
-	subspecies_allowed = list(SPECIES_HUMAN)
+	subspecies_allowed = list(SPECIES_HUMAN, SPECIES_VATGROWN, SPECIES_GRAVWORLDER, SPECIES_TRITONIAN, SPECIES_SPACER)
 	icon = 'icons/mob/human_races/species/human/subspecies/booster_mods.dmi'
 
 /datum/sprite_accessory/marking/booster/ears


### PR DESCRIPTION
## About the Pull Request

All species aside from Mules can have biomods

## Why It's Good For The Game

From what I understand anyways this is a common sentiment from many vat human players aswell as subspecies in general, they wish they could have biomods. With little reason given as to why they arent allowed I dont see the point in restricting it. To double check this lorewise I had asked Rowtree and they said it would be fine as long as I exclude mules. 

## Did you test it?
Hell yeah brother!
![image](https://user-images.githubusercontent.com/80948198/126613337-5c72c9f6-101d-47fe-9162-f992a9f13b09.png)

<!--
Please decribe if you ran local tests to ensure compilation. If that is not the case, please make it abundantly clear so a maintainer knows they need to run local checks.
Note that this can include own balancing/gameplay tests, but does not need to.
-->

## Changelog

:cl: Sky
tweak: All human subspecies aside from mules can have biomods
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
