### PR TITLE
Add confirmation alert for joining as a job with no preferences

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -170,7 +170,19 @@
 
 		var/datum/species/S = all_species[client.prefs.species]
 		if(!check_species_allowed(S))
-			return 0
+			return FALSE
+
+		var/should_warn = TRUE
+		if(client.prefs.job_high == job.title)
+			should_warn = FALSE
+		else if(job.title in client.prefs.job_medium)
+			should_warn = FALSE
+		else if(job.title in client.prefs.job_low)
+			should_warn = FALSE
+
+		if(should_warn)
+			if(alert(client, "You don't have any preferences set for [job.title]. Are you sure you want to join as it?", "Confirm Job Selection", "Yes", "No") == "No")
+				return FALSE
 
 		AttemptLateSpawn(job, client.prefs.spawnpoint)
 		return


### PR DESCRIPTION
## About the Pull Request

This PR will give you an alert if you try to join as a job that you don't have low/medium/high preferences for, in an attempt to avoid misclicks.

## Why It's Good For The Game

We've all done it, let's make sure it doesn't happen again.

## Did you test it?

Yes

## Changelog

:cl:
rscadd: You will now be asked to confirm to join as a job for which you don't have any preferences set.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
