### PR TITLE
fixes disposal chute construction always being south + does some general disposal pipe modernization

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -288,6 +288,7 @@
 #include "code\datums\extensions\label.dm"
 #include "code\datums\extensions\local_network.dm"
 #include "code\datums\extensions\penetration.dm"
+#include "code\datums\extensions\play_sound_on_moved.dm"
 #include "code\datums\extensions\appearance\appearance.dm"
 #include "code\datums\extensions\appearance\base_icon_state.dm"
 #include "code\datums\extensions\appearance\cardborg.dm"

--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -114,6 +114,7 @@ What is the naming convention for planes or layers?
 	#define TABLE_LAYER                 2.21
 	#define BELOW_OBJ_LAYER             2.22
 	#define STRUCTURE_LAYER             2.23
+	#define ABOVE_STRUCTURE_LAYER       2.24
 	// OBJ_LAYER                        3
 	#define ABOVE_OBJ_LAYER             3.01
 	#define CLOSED_DOOR_LAYER           3.02

--- a/code/datums/extensions/play_sound_on_moved.dm
+++ b/code/datums/extensions/play_sound_on_moved.dm
@@ -1,0 +1,36 @@
+/// This extension allows a movable atom to play a sound for each tile it is moved.
+/datum/extension/play_sound_on_moved
+	base_type = /datum/extension/play_sound_on_moved
+	expected_type = /atom/movable
+	flags = EXTENSION_FLAG_IMMEDIATE
+
+	/// A reference to the atom affected by this extension.
+	var/atom/movable/atom_holder
+	/// If TRUE, the movement sound will always play. If FALSE, it will only play when dragged over hard surfaces (i.e. not space and carpets).
+	var/always_play = FALSE
+	/// A list of paths to sound files. When `atom_holder` is moved, one of these will play, picked at random.
+	var/list/move_sounds = list(
+		'sound/effects/metalscrape1.ogg',
+		'sound/effects/metalscrape2.ogg',
+		'sound/effects/metalscrape3.ogg'
+	)
+	/// The volume of the sound to be played.
+	var/move_volume = 75
+
+/datum/extension/play_sound_on_moved/New(datum/holder, volume_override, sounds_override)
+	..()
+	atom_holder = holder
+	if (volume_override)
+		move_volume = volume_override
+	if (sounds_override)
+		move_sounds = sounds_override
+	GLOB.moved_event.register(atom_holder, src, .proc/DoMoveSound)
+
+/datum/extension/play_sound_on_moved/Destroy()
+	GLOB.moved_event.unregister(atom_holder, src, .proc/DoMoveSound)
+	..()
+
+/// Plays a random sound from `move_sounds` at volume `move_volume`, centered at the turf of `atom_holder`.
+/datum/extension/play_sound_on_moved/proc/DoMoveSound(atom/movable/inst, old_loc, new_loc)
+	if(always_play || (has_gravity(inst) && !isspace(new_loc) && !istype(new_loc, /turf/simulated/floor/carpet)))
+		playsound(inst, pick(move_sounds), move_volume, TRUE)

--- a/code/game/machinery/pipe/pipe_datums/disposal_pipe_datums.dm
+++ b/code/game/machinery/pipe/pipe_datums/disposal_pipe_datums.dm
@@ -89,7 +89,7 @@
 	desc = "an outlet that ejects things from a disposal network."
 	build_icon = 'icons/obj/pipes/disposal.dmi'
 	build_icon_state = "outlet"
-	build_path = /obj/structure/disposalconstruct/machine/outlet
+	build_path = /obj/structure/disposalconstruct/machine
 	constructed_path = /obj/structure/disposaloutlet
 
 /datum/pipe/disposal_dispenser/device/chute
@@ -97,7 +97,7 @@
 	desc = "A chute to put things into a disposal network."
 	build_icon = 'icons/obj/pipes/disposal.dmi'
 	build_icon_state = "intake"
-	build_path = /obj/structure/disposalconstruct
+	build_path = /obj/structure/disposalconstruct/machine
 	constructed_path = /obj/machinery/disposal/deliveryChute
 
 /datum/pipe/disposal_dispenser/device/sorting

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -1,10 +1,11 @@
 /obj/machinery/pipedispenser
-	name = "Pipe Dispenser"
+	name = "pipe dispenser"
+	desc = "A huge dispenser loaded with an internal stock of compressed matter. It can create a wide selection of pipes and atmospherics machinery."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "pipe_d"
 	density = TRUE
 	anchored = FALSE
-	stat_immune = NOSCREEN//Doesn't need screen, just input for the parts wanted
+	stat_immune = NOSCREEN // Doesn't need a screen, just input for the parts wanted
 
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
@@ -16,48 +17,61 @@
 	machine_name = "pipe dispenser"
 	machine_desc = "A semi-portable dispenser that uses compressed matter to create atmospherics pipes. Vital for repair or construction efforts."
 
+	/// Whether or not this pipe dispenser has color customization for its pipes.
+	var/has_colors = TRUE
+	/// Pipes dispensed by this machine will take on this color.
 	var/pipe_color = "white"
+	/// A list of atom types that this pipe dispenser can consume by being hit by them or having a user drag-drop them onto the dispenser.
+	var/list/consume_types = list(
+		/obj/item/pipe,
+		/obj/item/machine_chassis
+	)
 
-/obj/machinery/pipedispenser/Initialize()//for mapping purposes. Anchor them by map var edit if needed.
+/obj/machinery/pipedispenser/Initialize() //for mapping purposes. Anchor them by map var edit if needed.
 	. = ..()
-	if(anchored)
+	if (anchored)
 		update_use_power(POWER_USE_IDLE)
 
-/obj/machinery/pipedispenser/proc/get_console_data(var/list/pipe_categories, var/color_options = FALSE)
+/obj/machinery/pipedispenser/proc/get_console_data(list/pipe_categories, color_options = FALSE)
 	. = list()
 	. += "<table>"
-	if(color_options)
+	if (color_options)
 		. += "<tr><td>Color</td><td><a href='?src=\ref[src];color=\ref[src]'><font color = '[pipe_color]'>[pipe_color]</font></a></td></tr>"
-	for(var/category in pipe_categories)
+	for (var/category in pipe_categories)
 		var/datum/pipe/cat = category
 		. += "<tr><td><font color = '#517087'><strong>[initial(cat.category)]</strong></font></td></tr>"
-		for(var/datum/pipe/pipe in pipe_categories[category])
+		for (var/datum/pipe/pipe in pipe_categories[category])
 			var/line = "[pipe.name]</td>"
 			. += "<tr><td>[line]<td><a href='?src=\ref[src];build=\ref[pipe]'>Dispense</a></td><td><a href='?src=\ref[src];buildfive=\ref[pipe]'>5x</a></td><td><a href='?src=\ref[src];buildten=\ref[pipe]'>10x</a></td></tr>"
 	.+= "</table>"
 	. = JOINTEXT(.)
 
-/obj/machinery/pipedispenser/proc/build_quantity(var/datum/pipe/P, var/quantity)
-	for(var/I = quantity;I > 0;I -= 1)
+/// Returns an associated list of pipes that this dispenser can create. We can't use globals in compile-time defs, so we do this instead.
+/obj/machinery/pipedispenser/proc/get_pipe_types()
+	return GLOB.all_pipe_datums_by_category
+
+/obj/machinery/pipedispenser/proc/build_quantity(datum/pipe/P, quantity)
+	for (var/I = quantity;I > 0;I -= 1)
 		P.Build(P, loc, pipe_colors[pipe_color])
 		use_power_oneoff(500)
+	playsound(src, 'sound/items/Deconstruct.ogg', 50, TRUE)
 
 /obj/machinery/pipedispenser/Topic(href, href_list)
-	if((. = ..()))
-		return
-	if(href_list["build"])
+	if (..())
+		return TRUE
+	if (href_list["build"])
 		var/datum/pipe/P = locate(href_list["build"])
 		build_quantity(P, 1)
-	if(href_list["buildfive"])
+	if (href_list["buildfive"])
 		var/datum/pipe/P = locate(href_list["buildfive"])
 		build_quantity(P, 5)
-	if(href_list["buildten"])
+	if (href_list["buildten"])
 		var/datum/pipe/P = locate(href_list["buildten"])
 		build_quantity(P, 10)
-	if(href_list["color"])
+	if (href_list["color"])
 		var/choice = input(usr, "What color do you want pipes to have?") as null|anything in pipe_colors
-		if(!choice)
-			return 1
+		if (!choice)
+			return TRUE
 		pipe_color = choice
 		updateUsrDialog()
 
@@ -66,69 +80,69 @@
 	return TRUE
 
 /obj/machinery/pipedispenser/interact(mob/user)
-	var/datum/browser/popup = new (user, "Pipe List", "[src] Control Panel")
-	popup.set_content(get_console_data(GLOB.all_pipe_datums_by_category, TRUE))
+	var/datum/browser/popup = new (user, "Pipe List", "[name]")
+	popup.set_content(get_console_data(get_pipe_types(), has_colors))
 	popup.open()
 
-/obj/machinery/pipedispenser/attackby(var/obj/item/W as obj, var/mob/user as mob)
-	if (istype(W, /obj/item/pipe) || istype(W, /obj/item/machine_chassis))
-		if(!user.unEquip(W))
+/obj/machinery/pipedispenser/attackby(obj/item/W, mob/user)
+	if (is_type_in_list(W, consume_types))
+		if (!user.unEquip(W))
 			return
-		to_chat(user, "<span class='notice'>You put \the [W] back into \the [src].</span>")
+		to_chat(user, SPAN_NOTICE("You dump \the [W] into \the [src] for recycling."))
 		add_fingerprint(user)
 		qdel(W)
 		return
-	if(!panel_open)
-		if(isWrench(W))
+	if (!panel_open)
+		if (isWrench(W))
 			add_fingerprint(user)
-			if(anchored)
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-				to_chat(user, "<span class='notice'>You begin to unfasten \the [src] from the floor...</span>")
-				if (do_after(user, 40, src))
-					user.visible_message( \
-						"<span class='notice'>\The [user] unfastens \the [src].</span>", \
-						"<span class='notice'>You have unfastened \the [src]. Now it can be pulled somewhere else.</span>", \
-						"You hear ratchet.")
-					anchored = FALSE
-					stat |= MAINT
-					update_use_power(POWER_USE_OFF)
-					if(user.machine==src)
-						close_browser(user, "window=pipedispenser")
+			playsound(src, 'sound/items/Ratchet.ogg', 50, TRUE)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] starts [anchored ? "un" : ""]securing \the [src]."),
+				SPAN_NOTICE("You start [anchored ? "un" : ""]fastening \the [src]."),
+				SPAN_ITALIC("You hear bolts being turned.")
+			)
+			if (!do_after(user, 3 SECONDS, src))
+				return
+			user.visible_message(
+				SPAN_NOTICE("\The [user] [anchored ? "un" : ""]secures \the [src]."),
+				SPAN_NOTICE("You [anchored ? "undo \the [src]\'s securing bolts" : "fasten \the [src] to the floor"]."),
+				SPAN_ITALIC("You hear bolts being turned.")
+			)
+			playsound(src, 'sound/items/Deconstruct.ogg', 50, TRUE)
+			anchored = !anchored
+			if (!anchored)
+				stat |= MAINT
+				update_use_power(POWER_USE_OFF)
+				if (user.machine == src)
+					close_browser(user, "window=pipedispenser")
 			else
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-				to_chat(user, "<span class='notice'>You begin to fasten \the [src] to the floor...</span>")
-				if (do_after(user, 20, src))
-					user.visible_message( \
-						"<span class='notice'>\The [user] fastens \the [src].</span>", \
-						"<span class='notice'>You have fastened \the [src]. Now it can dispense pipes.</span>", \
-						"You hear ratchet.")
-					anchored = TRUE
-					stat &= ~MAINT
-					update_use_power(POWER_USE_IDLE)
+				stat &= ~MAINT
+				update_use_power(POWER_USE_IDLE)
 			return
-	return ..()
+	. = ..()
+
+/obj/machinery/pipedispenser/MouseDrop_T(obj/O, mob/user)
+	if (!CanPhysicallyInteract(user))
+		return
+
+	if (!is_type_in_list(O, consume_types) || O.anchored)
+		return
+
+	if (user.pulling == O)
+		user.stop_pulling()
+	to_chat(user, SPAN_NOTICE("You dump \the [O] into \the [src] for recycling."))
+	qdel(O)
 
 /obj/machinery/pipedispenser/disposal
-	name = "Disposal Pipe Dispenser"
+	name = "disposal pipe dispenser"
+	desc = "This pipe dispenser is configured for the huge, bulky metal pipes and machines used in constructing a disposals network."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "pipe_d"
 	machine_name = "disposal pipe dispenser"
-	machine_desc = "Similar to a normal pipe dispenser, but calibrated for the heavy, dense metal tubes used in disposals networks."
+	machine_desc = "Similar to a normal pipe dispenser, but calibrated for tubes used in disposals networks."
 
-//Allow you to drag-drop disposal pipes into it
-/obj/machinery/pipedispenser/disposal/MouseDrop_T(var/obj/structure/disposalconstruct/pipe as obj, mob/user as mob)
-	if(!CanPhysicallyInteract(user))
-		return
+	has_colors = FALSE
+	consume_types = list(/obj/structure/disposalconstruct)
 
-	if (!istype(pipe) || get_dist(src,pipe) > 1 )
-		return
-
-	if (pipe.anchored)
-		return
-
-	qdel(pipe)
-
-/obj/machinery/pipedispenser/disposal/interact(mob/user)
-	var/datum/browser/popup = new (user, "Disposal Pipe List", "[src] Control Panel")
-	popup.set_content(get_console_data(GLOB.all_disposal_pipe_datums_by_category))
-	popup.open()
+/obj/machinery/pipedispenser/disposal/get_pipe_types()
+	return GLOB.all_disposal_pipe_datums_by_category

--- a/code/game/objects/munition.dm
+++ b/code/game/objects/munition.dm
@@ -3,19 +3,10 @@
 	icon = 'icons/obj/munitions.dmi'
 	w_class = ITEM_SIZE_GARGANTUAN
 	density = TRUE
-	var/list/move_sounds = list( // some nasty sounds to make when moving the board
-		'sound/effects/metalscrape1.ogg',
-		'sound/effects/metalscrape2.ogg',
-		'sound/effects/metalscrape3.ogg'
-	)
 
-// make a screeching noise to drive people mad
-/obj/structure/ship_munition/Move()
+/obj/structure/ship_munition/Initialize()
 	. = ..()
-	if(.)
-		var/turf/T = get_turf(src)
-		if(!isspace(T) && !istype(T, /turf/simulated/floor/carpet))
-			playsound(T, pick(move_sounds), 75, 1)
+	set_extension(src, /datum/extension/play_sound_on_moved)
 
 /obj/structure/ship_munition/md_slug
 	name = "mass driver slug"

--- a/code/game/objects/structures/ironing_board.dm
+++ b/code/game/objects/structures/ironing_board.dm
@@ -7,11 +7,10 @@
 
 	var/obj/item/clothing/cloth // the clothing on the ironing board
 	var/obj/item/ironingiron/holding // ironing iron on the board
-	var/list/move_sounds = list( // some nasty sounds to make when moving the board
-		'sound/effects/metalscrape1.ogg',
-		'sound/effects/metalscrape2.ogg',
-		'sound/effects/metalscrape3.ogg'
-	)
+
+/obj/structure/bed/roller/ironingboard/Initialize()
+	. = ..()
+	set_extension(src, /datum/extension/play_sound_on_moved)
 
 /obj/structure/bed/roller/ironingboard/Destroy()
 	var/turf/T = get_turf(src)
@@ -32,15 +31,6 @@
 
 	update_icon()
 	GLOB.destroyed_event.unregister(I, src, /obj/structure/bed/roller/ironingboard/proc/remove_item)
-
-// make a screeching noise to drive people mad
-/obj/structure/bed/roller/ironingboard/Move()
-	var/turf/T = get_turf(src)
-	if(isspace(T) || istype(T, /turf/simulated/floor/carpet))
-		return
-	playsound(T, pick(move_sounds), 75, 1)
-
-	. = ..()
 
 /obj/structure/bed/roller/ironingboard/examine(mob/user)
 	. = ..()
@@ -103,7 +93,7 @@
 				holding = R
 				GLOB.destroyed_event.register(I, src, /obj/structure/bed/roller/ironingboard/proc/remove_item)
 				update_icon()
-				return	
+				return
 			to_chat(user, "<span class='notice'>There isn't anything on the ironing board.</span>")
 			return
 

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -9,6 +9,7 @@
 	anchored = FALSE
 	density = FALSE
 	matter = list(MATERIAL_STEEL = 1850)
+	layer = ABOVE_STRUCTURE_LAYER
 	level = 2
 	obj_flags = OBJ_FLAG_ROTATABLE
 	var/sort_type = ""
@@ -17,10 +18,11 @@
 	var/constructed_path = /obj/structure/disposalpipe
 	var/built_icon_state
 
-/obj/structure/disposalconstruct/New(loc, var/P = null)
+/obj/structure/disposalconstruct/Initialize(loc, P = null)
 	. = ..()
-	if(P)
-		if(istype(P, /obj/structure/disposalpipe))//Unfortunately a necessary evil since some things are machines and other things are structures
+	set_extension(src, /datum/extension/play_sound_on_moved, 50)
+	if (P)
+		if (istype(P, /obj/structure/disposalpipe))//Unfortunately a necessary evil since some things are machines and other things are structures
 			var/obj/structure/disposalpipe/D = P
 			SetName(D.name)
 			desc = D.desc
@@ -33,7 +35,7 @@
 			dpdir = D.dpdir
 			constructed_path = D.type
 			set_dir(D.dir) // Needs to be set after turn and possibly other state.
-		if(istype(P, /obj/machinery/disposal))
+		else if (istype(P, /obj/machinery/disposal))
 			var/obj/machinery/disposal/D = P
 			SetName(D.name)
 			desc = D.desc
@@ -45,20 +47,17 @@
 			constructed_path = D.type
 			set_dir(D.dir)
 	update_icon()
-
-/obj/structure/disposalconstruct/Initialize()
 	update_verbs()
-	. = ..()
 
 /obj/structure/disposalconstruct/proc/update_verbs()
-	if(anchored)
+	if (anchored)
 		verbs -= /obj/structure/disposalconstruct/proc/flip
 	else
 		verbs += /obj/structure/disposalconstruct/proc/flip
 
 // update iconstate and dpdir due to dir and type
 /obj/structure/disposalconstruct/proc/update()
-	if(invisibility)      // if invisible, fade icon
+	if (invisibility)      // if invisible, fade icon
 		alpha = 128
 	else
 		alpha = 255
@@ -74,16 +73,16 @@
 	set category = "Object"
 	set name = "Flip Pipe"
 	set src in view(1)
-	if(usr.incapacitated())
+	if (usr.incapacitated())
 		return
 
-	if(anchored)
+	if (anchored)
 		to_chat(usr, "You must unfasten the pipe before flipping it.")
 		return
 
-	if(ispath(constructed_path, /obj/structure/disposalpipe))
+	if (ispath(constructed_path, /obj/structure/disposalpipe))
 		var/obj/structure/disposalpipe/fake_pipe = constructed_path
-		if(initial(fake_pipe.flipped_state))
+		if (initial(fake_pipe.flipped_state))
 			constructed_path = initial(fake_pipe.flipped_state)
 			fake_pipe = constructed_path
 			turn = initial(fake_pipe.turn)
@@ -94,108 +93,123 @@
 	set_dir(turn(dir, 180))
 
 /obj/structure/disposalconstruct/on_update_icon()
-	if("con[built_icon_state]" in icon_states(icon))
+	if ("con[built_icon_state]" in icon_states(icon))
 		icon_state = "con[built_icon_state]"
 	else
 		icon_state = built_icon_state
 
 /obj/structure/disposalconstruct/proc/flip_dirs(var/flipvalue)
 	. = dir
-	if(flipvalue & DISPOSAL_FLIP_FLIP)
-		. |= turn(dir,180)
-	if(flipvalue & DISPOSAL_FLIP_LEFT)
-		. |= turn(dir,90)
-	if(flipvalue & DISPOSAL_FLIP_RIGHT)
-		. |= turn(dir,-90)
+	if (flipvalue & DISPOSAL_FLIP_FLIP)
+		. |= turn(dir, 180)
+	if (flipvalue & DISPOSAL_FLIP_LEFT)
+		. |= turn(dir, 90)
+	if (flipvalue & DISPOSAL_FLIP_RIGHT)
+		. |= turn(dir, -90)
 
 /obj/structure/disposalconstruct/set_dir(new_dir)
 	. = ..()
 	dpdir = flip_dirs(turn) //does the flipping stuff
 	update()
 
-/obj/structure/disposalconstruct/Move()
-	var/old_dir = dir
-	. = ..()
-	set_dir(old_dir)
-
 // attackby item
 // wrench: (un)anchor
 // weldingtool: convert to real pipe
 /obj/structure/disposalconstruct/attackby(var/obj/item/I, var/mob/user)
 	var/turf/T = loc
-	if(!istype(T))
+	if (!istype(T))
 		return
-	if(!T.is_plating())
-		to_chat(user, "You can only manipulate \the [src] if the floor plating is removed.")
+	if (!T.is_plating())
+		to_chat(user, SPAN_WARNING("You can only manipulate \the [src] if the floor plating is removed."))
 		return
 
 	var/obj/structure/disposalpipe/CP = locate() in T
 
-	if(isWrench(I))
-		if(anchored)
+	if (isWrench(I))
+		if (anchored)
 			anchored = FALSE
 			wrench_down(FALSE)
-			to_chat(user, "You detach \the [src] from the underfloor.")
+			user.visible_message(
+				SPAN_NOTICE("\The [user] detaches \the [src] from the underfloor."),
+				SPAN_NOTICE("You detach \the [src] from the underfloor."),
+				SPAN_ITALIC("You hear bolts being turned.")
+			)
 		else
-			if(!check_buildability(CP, user))
+			if (!check_buildability(CP, user))
 				return
 			wrench_down(TRUE)
-			to_chat(user, "You attach \the [src] to the underfloor.")
-		playsound(loc, 'sound/items/Ratchet.ogg', 100, 1)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] attahces \the [src] to the underfloor."),
+				SPAN_NOTICE("You wrench \the [src] firmly into place."),
+				SPAN_ITALIC("You hear bolts being turned.")
+			)
+		playsound(src, 'sound/items/Ratchet.ogg', 50, TRUE)
 		update()
 		update_verbs()
 
-	else if(istype(I, /obj/item/weldingtool))
-		if(anchored)
+	else if (istype(I, /obj/item/weldingtool))
+		if (anchored)
 			var/obj/item/weldingtool/W = I
-			if(W.remove_fuel(0,user))
-				playsound(src.loc, 'sound/items/Welder2.ogg', 100, 1)
-				to_chat(user, "Welding \the [src] in place.")
-				if(do_after(user, 20, src))
-					if(!src || !W.isOn()) return
-					to_chat(user, "\The [src] has been welded in place!")
-					build(CP)
-					qdel(src)
+			if (!W.isOn())
+				to_chat(user, SPAN_WARNING("Turn \the [W] on first."))
+				return
+			else if (W.remove_fuel(0, user))
+				playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
+				user.visible_message(
+					SPAN_NOTICE("\The [user] starts welding \the [src] to the underfloor."),
+					SPAN_NOTICE("You start welding \the [src] into place."),
+					SPAN_ITALIC("You hear the sound of welding.")
+				)
+				if (!do_after(user, 2 SECONDS, src))
 					return
+				playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
+				user.visible_message(
+					SPAN_NOTICE("\The [user] firmly secures \the [src] to the underfloor."),
+					SPAN_NOTICE("You tightly weld \the [src] to the floor, and set up its connectors."),
+					SPAN_ITALIC("You hear metal being welded into place.")
+				)
+				build(CP)
+				qdel(src)
+				return
 			else
-				to_chat(user, "You need more welding fuel to complete this task.")
+				to_chat(user, SPAN_WARNING("You need more fuel to weld \the [src] in place."))
 				return
 		else
-			to_chat(user, "You need to attach it to the plating first!")
+			to_chat(user, SPAN_WARNING("You need to attach \the [src] to the plating first!"))
 			return
 
 /obj/structure/disposalconstruct/hides_under_flooring()
 	return anchored
 
 /obj/structure/disposalconstruct/proc/check_buildability(obj/structure/disposalpipe/CP, mob/user)
-	if(!CP)
+	if (!CP)
 		return TRUE
 	var/pdir = CP.dpdir
-	if(istype(CP, /obj/structure/disposalpipe/broken))
+	if (istype(CP, /obj/structure/disposalpipe/broken))
 		pdir = CP.dir
-	if(pdir & dpdir)
-		to_chat(user, "There is already a disposals pipe at that location.")
+	if (pdir & dpdir)
+		to_chat(user, SPAN_WARNING("There is already a disposals pipe at that location."))
 		return FALSE
 	return TRUE
 
 /obj/structure/disposalconstruct/proc/wrench_down(anchor)
-	if(anchor)
+	if (anchor)
 		anchored = TRUE
 		level = 1 // We don't want disposal bins to disappear under the floors
-		set_density(0)
+		set_density(FALSE)
 	else
 		anchored = FALSE
 		level = 2
-		set_density(1)
+		set_density(TRUE)
 
 /obj/structure/disposalconstruct/machine/check_buildability(obj/structure/disposalpipe/CP, mob/user)
-	if(CP) // There's something there
-		if(!istype(CP,/obj/structure/disposalpipe/trunk))
-			to_chat(user, "\The [src] requires a trunk underneath it in order to work.")
+	if (CP) // There's something there
+		if (!istype(CP,/obj/structure/disposalpipe/trunk))
+			to_chat(user, SPAN_WARNING("\The [src] requires a trunk underneath it in order to work."))
 			return FALSE
 		return TRUE
 	// Nothing under, fuck.
-	to_chat(user, "\The [src] requires a trunk underneath it in order to work.")
+	to_chat(user, SPAN_WARNING("\The [src] requires a trunk underneath it in order to work."))
 	return FALSE
 
 /obj/structure/disposalconstruct/proc/build()
@@ -210,32 +224,22 @@
 
 // Subtypes
 
-/obj/structure/disposalconstruct/machine
-	obj_flags = 0 // No rotating
-
-/obj/structure/disposalconstruct/machine/update_verbs()
-	return // No flipping
-
 /obj/structure/disposalconstruct/machine/wrench_down(anchor)
 	anchored = anchor
-	set_density(1) // We don't want disposal bins or outlets to go density 0
+	set_density(TRUE) // We don't want disposal bins or outlets to go density 0
 	update_icon()
 
 /obj/structure/disposalconstruct/machine/build(obj/structure/disposalpipe/CP)
-	var/obj/machinery/disposal/P = new /obj/machinery/disposal(src.loc)
+	var/obj/machinery/disposal/P = new constructed_path(src.loc)
 	transfer_fingerprints_to(P)
 	P.set_dir(dir)
 	P.mode = 0 // start with pump off
+	var/obj/structure/disposalpipe/trunk/trunk = CP
+	if (trunk)
+		trunk.linked = P
 
 /obj/structure/disposalconstruct/machine/on_update_icon()
-	if(anchored)
+	if (anchored)
 		icon_state = built_icon_state
 	else
 		..()
-
-/obj/structure/disposalconstruct/machine/outlet/build(obj/structure/disposalpipe/CP)
-	var/obj/structure/disposaloutlet/P = new constructed_path(loc)
-	transfer_fingerprints_to(P)
-	P.set_dir(dir)
-	var/obj/structure/disposalpipe/trunk/Trunk = CP
-	Trunk.linked = P

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -629,7 +629,7 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 			if(do_after(user,20, src))
 				if(!src || !W.isOn()) return
 				to_chat(user, "You sliced the floorweld off the disposal outlet.")
-				var/obj/structure/disposalconstruct/machine/outlet/C = new (loc, src)
+				var/obj/structure/disposalconstruct/machine/C = new (loc, src)
 				src.transfer_fingerprints_to(C)
 				C.anchored = TRUE
 				C.set_density(1)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -387,7 +387,7 @@
 		openwindow(user)
 
 /obj/machinery/disposal/deliveryChute
-	name = "Delivery chute"
+	name = "delivery chute"
 	desc = "A chute for big and small packages alike!"
 	density = TRUE
 	icon_state = "intake"
@@ -418,7 +418,7 @@
 			if(AM.loc.y != src.loc.y-1) return
 		if(WEST)
 			if(AM.loc.x != src.loc.x-1) return
-			
+
 	var/mob/living/L = AM
 	if (istype(L) && L.ckey)
 		log_and_message_admins("has flushed themselves down \the [src].", L)


### PR DESCRIPTION
## About the Pull Request

There are two major user-facing changes this has. One is the thing in the title - when you build a disposals chute, it currently always faces south, regardless of what direction it's rotated, and this fixes that. The second one is that disposals bins and chutes can now be rotated with alt-click, like other disposals tubes.

The backend is a good bit more:
* Pipe dispensers have a description, and have logic put onto the base type instead of overriden on subtypes.
* You can now correctly drop unconstructed disposal tubes and machines onto the disposals pipe dispenser to destroy them.
* Playing a scrape sound on movement is now an extension, `/datum/extension/play_sound_on_move`. It has several variables that control its behavior. OFD charges and ironing boards now use this extension. This was done becaaaause...
* ...disposals pipes now play a scrape sound on move. It's quite quiet, and is purely for effect.
* You can now examine disposals pipes to see if they're damaged, instead of just getting no indication at all.
* Replaced a `sleep()` call with a `do_after()`.
* Added visible messages and spans for certain disposals construction steps.

Wow wow ***WOW*** disposals code is awful! Like, *really* awful. This is just one step, but after seeing it, I feel a personal urge to wring the life out of current disposals code and instate new code in its place. I may do this.

## Why It's Good For The Game

Fixing bugs is always nice. It isn't obvious to me why you can't rotate disposal bins and chutes, but it makes them clunky to work with - with any luck, I hope they'll feel significantly better to construct after this. The rest is modernization, and brings old code up to newer standards and gameplay expectations.

## Did you test it?

Yes indeed. It compiles fine, and I jumped into my local server and did some playing with tubes, including making a disposals loop to see if it works on this codebase (it does, rip my passenger.) I toyed with pipe dispensers, both the ones in engineering and with some admin-spawned ones. OFD charges and ironing boards still sound the exact same.

## Changelog

:cl:
rscadd: You can now examine disposals pipes to see if they're damaged.
rscadd: Disposals pipes now play a quiet scraping sound as they're moved.
rscadd: Modernized some messages and sounds related to disposals construction.
bugfix: Disposals chutes no longer always face south when you construct them.
bugfix: You can properly destroy unused disposal pipes and machines by click-dragging them onto the disposals pipe dispenser.
bugfix: Disposals pipes no longer render underneath their dispenser.
tweak: Modernized some messages and sounds related to disposals construction.
/:cl: