### PR TITLE
Fixes a bug causing walls to become non-deconstructable if you get interrupted midway through an attempt

### DIFF
--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -262,6 +262,7 @@
 				cut_delay = 0
 
 			if(!do_after(user,cut_delay,src))
+				dismantling = FALSE
 				return
 
 			to_chat(user, "<span class='notice'>You remove the outer plating.</span>")


### PR DESCRIPTION
## About the Pull Request

See title. Right now, if you stop welding/drilling/etc. on a wall, that wall can't be deconstructed ever afterwards. I'm pretty sure that's definitely unintentional, so here's a fix.

## Why It's Good For The Game

Bug fix! Fix bug!

## Did you test it?

Compiles and runs. I tried welding, drilling, and pickaxe-ing the same wall near the auxiliary head several times, and encountered no issues (although my passenger's eyes hurt now.)

## Changelog

:cl:
bugfix: Walls no longer become un-weldable after a deconstruction attempt is interrupted.
/:cl: