### PR TITLE
Changes the number of security badges from six to ten

### DIFF
--- a/maps/torch/items/machinery.dm
+++ b/maps/torch/items/machinery.dm
@@ -96,4 +96,4 @@
 		/obj/item/device/holowarrant = 4,
 		/obj/item/reagent_containers/food/snacks/donut/normal = 12,
 		/obj/item/storage/box/evidence = 8,
-		/obj/item/clothing/accessory/badge/solgov/security = 6)
+		/obj/item/clothing/accessory/badge/solgov/security = 10)


### PR DESCRIPTION
## About the Pull Request

Basically what it says in the title.  There are now ten security force badges in the locker room vendor as opposed to six.

## Why It's Good For The Game

Six badges isn't enough for all of security to have one if the CI is Fleet or EC, but everyone in security should be wearing a badge at all times, plus now there's some extras incase somebody cryos.

## Did you test it? Well it compiles and runs and since it only changes one number I can't see aaaany way this goes wrong.

## Changelog

:cl:
tweak: There are now ten security badges in the locker room vendor instead of six.
/:cl: