### PR TITLE
creates interact_message proc and does preliminary implementation work on it

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -193,6 +193,8 @@ var/const/NEGATIVE_INFINITY = -1#INF // win: -1.#INF, lin: -inf
 
 #define SPAN_STYLE(style, X) "<span style=\"[style]\">[X]</span>"
 
+#define SPAN_CLASS(class, X) "<span class=\"[class]\">[X]</span>"
+
 #define FONT_COLORED(color, text) "<font color='[color]'>[text]</font>"
 
 #define FONT_SMALL(X) "<font size='1'>[X]</font>"

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -126,11 +126,23 @@
 	if(!flashfail)
 		flick("[initial(icon_state)]_on", src)
 		if(!issilicon(M))
-			user.visible_message("<span class='disarm'>[user] blinds [M] with \the [src]!</span>")
+			M.interact_message(user,
+				SPAN_CLASS("disarm", "\The [user] blinds \the [M] with \the [src]!"),
+				SPAN_CLASS("disarm", "\The [user] blinds you with \the [src]!"),
+				SPAN_CLASS("disarm", "You blind \the [M] with \the [src]!")
+			)
 		else
-			user.visible_message("<span class='notice'>[user] overloads [M]'s sensors with \the [src]!</span>")
+			M.interact_message(user,
+				SPAN_CLASS("disarm", "\The [user] overloads \the [M]'s sensors with \the [src]!"),
+				SPAN_CLASS("disarm", "\The [user] overloads your sensors with \the [src]!"),
+				SPAN_CLASS("disarm", "You overload \the [M]'s sensors with \the [src]!")
+			)
 	else
-		user.visible_message("<span class='notice'>[user] fails to blind [M] with \the [src]!</span>")
+		M.interact_message(user,
+			SPAN_CLASS("disarm", "\The [user] fails to blind \the [M] with \the [src]!"),
+			SPAN_CLASS("disarm", "\The [user] fails to blind you with \the [src]!"),
+			SPAN_CLASS("disarm", "You fail to blind \the [M] with \the [src]!")
+		)
 	return 1
 
 


### PR DESCRIPTION
## About the Pull Request

This is something I've wanted to do for a while. It creates a proc called `interact_message` that takes a few arguments. This differs from visible messages - instead of only featuring a message for observers and a message for the target, this new proc is specifically designed around displaying second-person messages to two individuals (an interactor and their target.)

This allows stuff like:
causer: `You attack Bob!`
target: `Joe attacks you!`
observers; `Joe attacks Bob!`
all in one proc.

Right now, I've implemented this just for the flash item, both as a proof of concept and to keep the scale of this PR small. Once it (hopefully!) gets merged, I can make future PRs extending it to different parts across the game.

Finally, this implements a generic wrapper for defining span classes without having to use direct HTML tags. Its syntax is `SPAN_CLASS(class, text)`, and right now it's used for flashes, which have the `disarm` span. This is so that uncommon spans that aren't used much don't need their own wrapper!

## Why It's Good For The Game

SS13 has a load of text, and a lot of player-on-player interactions. In spite of this, these interactions don't have an elegant way of handling messaging for them - one of the players will always see their message in the third person, even though they're taking part in the interaction, whatever it might be. I'm hopeful that this will be a step towards fixing that.

## Did you test it?

Compiles and runs. I joined as a passenger and then joined as a guest on the same machine, and spawned in a flash. I tried flashing myself, flashing the other mob, and flashing an uncontrolled mob to make sure that messages displayed correctly. They do - these are all paraphrased, but for the causer, I see "you blind X with the flash"; on the victim, I see "Y blinds you with the flash"; and on an observer, I see "X blinds Y with the flash". Messages correctly don't appear when person being affected is unconscious or otherwise unable to perceive.

## Changelog

:cl:
spellcheck: Flashes now display their use messages in second person for both the mob doing the flashing and the mob being flashed. This is the first step towards properly targeted messages!
/:cl: