### PR TITLE
Re-add the AI core

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -4594,16 +4594,18 @@
 	c_tag = "Cyborg Upload";
 	dir = 4
 	},
-/obj/machinery/recharger,
+/obj/machinery/computer/upload/ai{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/synth/borg_upload)
 "jC" = (
 /obj/structure/table/standard,
-/obj/random/maintenance/solgov,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/synth/borg_upload)
 "jD" = (

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -734,6 +734,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
+"bz" = (
+/obj/item/device/radio/intercom/locked/ai_private{
+	pixel_y = 22
+	},
+/obj/machinery/camera/all/command{
+	c_tag = "AI Core - Aft Starboard";
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 21
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "bB" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -2528,6 +2542,27 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
+"eA" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloor_edges"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/power/apc/super/critical{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai_foyer)
 "eB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2994,6 +3029,18 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8;
 	icon_state = "warningcorner"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"fq" = (
+/obj/machinery/computer/modular/preset/aislot/research{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
+"ft" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -3607,6 +3654,14 @@
 "gz" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/aftstarboard)
+"gD" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall/hull,
+/area/turret_protected/ai_outer_chamber)
 "gJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3777,6 +3832,15 @@
 /obj/vehicle/bike/gyroscooter,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
+"hk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "hn" = (
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -3886,6 +3950,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
 "hK" = (
@@ -3989,6 +4058,23 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/heads/office/cl/backroom)
+"hX" = (
+/obj/machinery/airlock_sensor{
+	id_tag = "ai_core_sensor";
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1;
+	icon_state = "warningcorner"
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+	dir = 1;
+	id_tag = "ai_core_pump";
+	pixel_x = -1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/turret_protected/ai_foyer)
 "id" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -4259,6 +4345,29 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
+"iC" = (
+/obj/item/device/radio/intercom/locked/ai_private{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
+"iE" = (
+/obj/item/device/radio/intercom/locked/ai_private{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "iI" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -4313,6 +4422,12 @@
 /obj/random_multi/single_item/memo_engineering,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
+"iT" = (
+/obj/machinery/door/airlock/vault/bolted{
+	name = "AI Core External Access"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai_outer_chamber)
 "iU" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -4490,6 +4605,42 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/passenger)
+"jn" = (
+/obj/machinery/porta_turret,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
+"jo" = (
+/obj/machinery/flasher{
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/obj/item/device/radio/intercom/locked/ai_private{
+	pixel_y = 22
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
+"jt" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "jw" = (
 /obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled/dark,
@@ -4571,6 +4722,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
+"jJ" = (
+/obj/machinery/power/smes/buildable{
+	charge = 5e+006;
+	input_attempt = 1;
+	input_level = 125000;
+	output_attempt = 1;
+	output_level = 100000
+	},
+/obj/machinery/camera/all/command{
+	c_tag = "AI Core - Aft";
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
 "jM" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -4603,6 +4772,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room)
+"jP" = (
+/obj/machinery/computer/modular/preset/cardslot/command{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
 "jR" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -4691,6 +4866,11 @@
 	id_tag = "bridge_eva_inner";
 	locked = 1;
 	name = "Bridge EVA Internal Access"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
@@ -4801,6 +4981,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/passenger)
+"kl" = (
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
+"ku" = (
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "kv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4957,6 +5146,11 @@
 "kS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "kT" = (
@@ -5028,6 +5222,46 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
+"kY" = (
+/obj/machinery/porta_turret,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
+"ld" = (
+/obj/machinery/porta_turret,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai_foyer)
+"lk" = (
+/obj/machinery/door/airlock/highsecurity{
+	icon_state = "closed";
+	name = "AI Core Access"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
 "lm" = (
 /obj/machinery/hologram/holopad/longrange,
 /obj/effect/landmark{
@@ -5114,6 +5348,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
+"lz" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
 "lA" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 8;
@@ -5261,6 +5499,11 @@
 /obj/effect/floor_decal/corner/blue/half{
 	dir = 4;
 	icon_state = "bordercolorhalf"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
@@ -5438,6 +5681,15 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
+"mr" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "mx" = (
 /obj/effect/paint/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -5446,6 +5698,15 @@
 	},
 /turf/simulated/wall/titanium,
 /area/aquila/medical)
+"my" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "mz" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -5554,6 +5815,12 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
+"mK" = (
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/industrial/outline/orange,
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "mN" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -5731,6 +5998,23 @@
 /obj/machinery/computer/ship/sensors,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
+"ng" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "closed";
+	id_tag = "ai_core_outer";
+	locked = 1;
+	name = "AI Core Internal Access"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/turret_protected/ai_foyer)
 "ni" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/camera/network/aquila{
@@ -5883,6 +6167,22 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/heads/office/cl/backroom)
+"nB" = (
+/obj/machinery/shield_diffuser,
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "closed";
+	id_tag = "bridge_eva_outer";
+	locked = 1;
+	name = "Bridge EVA External Access"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/bridge/aft)
 "nE" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1;
@@ -6120,6 +6420,34 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/bridge/aftport)
+"oj" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/item/device/radio/intercom/locked/ai_private{
+	pixel_y = 22
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/all/command{
+	c_tag = "AI Core -Auxillary Access";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/turret_protected/ai_outer_chamber)
 "ol" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable/green{
@@ -6128,9 +6456,44 @@
 	},
 /turf/simulated/floor/plating,
 /area/aux_eva)
+"om" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/porta_turret,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
 "on" = (
 /turf/simulated/wall/prepainted,
 /area/aux_eva)
+"op" = (
+/obj/machinery/porta_turret,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai_foyer)
 "ox" = (
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -6240,6 +6603,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/bridgecheck)
+"oN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "oO" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/cable/green{
@@ -6415,6 +6788,20 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/aquila/medical)
+"pr" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "py" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
@@ -6569,6 +6956,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/aquila/storage)
+"pV" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/turret_protected/ai_foyer)
 "pW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6935,6 +7333,15 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
+"qC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "qD" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/crew,
@@ -6978,6 +7385,10 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/aquila/medical)
+"qM" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "qO" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge/storage)
@@ -7148,6 +7559,12 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
+"rj" = (
+/obj/item/device/radio/intercom/locked/ai_private{
+	pixel_y = 22
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "rk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7201,6 +7618,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
+"ro" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/camera/all/command{
+	c_tag = "AI Core - Entry";
+	dir = 1
+	},
+/obj/machinery/turretid/stun{
+	pixel_y = -33
+	},
+/obj/structure/closet/crate/internals,
+/obj/item/tank/oxygen/yellow,
+/obj/item/tank/oxygen/yellow,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/turret_protected/ai_foyer)
 "rp" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -7224,6 +7662,18 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
+"ru" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "rv" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/crew,
@@ -7651,6 +8101,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea)
+"sA" = (
+/obj/machinery/door/airlock/vault{
+	name = "AI Core Backup Access"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "AIcore";
+	name = "AI Security blast door"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai_foyer)
 "sB" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/sea)
@@ -7933,6 +8404,35 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/bridge)
+"tq" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 4;
+	target_pressure = 200
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	name = "interior access button";
+	pixel_x = 24;
+	pixel_y = -24;
+	req_access = list("ACCESS_AI_UPLOAD")
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/turret_protected/ai_foyer)
 "ts" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -8084,6 +8584,22 @@
 /obj/item/storage/firstaid/surgery,
 /turf/simulated/floor/tiled/white/monotile,
 /area/aquila/medical)
+"tQ" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/sign/warning/lethal_turrets{
+	pixel_y = 32
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/turret_protected/ai_foyer)
 "tR" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/walnut,
@@ -8170,6 +8686,21 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/bridge)
+"ue" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
+"uf" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "ug" = (
 /obj/structure/cable/green,
 /obj/effect/wallframe_spawn/reinforced/polarized{
@@ -8554,6 +9085,23 @@
 "uX" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/auxsolarbridge)
+"uY" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/power/apc/super/critical{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/machinery/turretid/stun{
+	pixel_y = -32
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/turret_protected/ai_outer_chamber)
 "uZ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -8741,6 +9289,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/space)
+"vB" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "vE" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/down{
@@ -8795,6 +9352,15 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"vN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "vO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -8829,6 +9395,35 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea)
+"vR" = (
+/obj/effect/landmark/start{
+	name = "AI"
+	},
+/obj/item/device/radio/intercom{
+	frequency = 1485;
+	pixel_y = 22
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	frequency = 1475;
+	pixel_y = -22
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/machinery/turretid/stun{
+	check_synth = 1;
+	name = "AI Chamber turret control";
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/turf/simulated/floor/greengrid,
+/area/turret_protected/ai)
 "vS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -8977,6 +9572,20 @@
 /obj/structure/table/woodentable_reinforced/walnut,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"wi" = (
+/obj/item/device/radio/intercom/locked/ai_private{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "wj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -9303,6 +9912,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room/deliberation)
+"wK" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "wL" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 1;
@@ -9414,6 +10036,13 @@
 /obj/structure/railing/mapped,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
+"wZ" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "xb" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/solgov,
@@ -9423,6 +10052,20 @@
 "xc" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/bridge/foreport)
+"xd" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "xe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -9441,6 +10084,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/bridge/foreport)
+"xf" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "xg" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
 	dir = 4;
@@ -9708,6 +10360,20 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/foreport)
+"xH" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "xJ" = (
 /obj/structure/ladder,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -9917,6 +10583,46 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/aquila/medical)
+"ym" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "closed";
+	id_tag = "ai_core_inner";
+	locked = 1;
+	name = "AI Internal Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/turret_protected/ai_foyer)
+"yn" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - AI Subgrid";
+	name_tag = "AI Subgrid"
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "yp" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -9931,6 +10637,14 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea)
+"yq" = (
+/obj/machinery/computer/modular/preset/civilian,
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
+"yr" = (
+/obj/machinery/light,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "yw" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
@@ -9981,6 +10695,16 @@
 "yD" = (
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
+"yE" = (
+/obj/machinery/computer/modular/preset/security{
+	dir = 1
+	},
+/obj/machinery/camera/all/command{
+	c_tag = "AI Core - Port";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
 "yI" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10126,6 +10850,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
+"zr" = (
+/obj/machinery/camera/all/command{
+	c_tag = "AI Core - Fore";
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "zx" = (
 /obj/structure/catwalk,
 /obj/machinery/pointdefense{
@@ -10216,6 +10947,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"zO" = (
+/obj/machinery/flasher{
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "AIcore";
+	name = "AI Security blast door button";
+	pixel_x = -6;
+	pixel_y = 25
+	},
+/obj/machinery/light_switch{
+	pixel_x = 23;
+	pixel_y = 24
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "zP" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
@@ -10616,6 +11364,22 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
+"Bv" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/flasher{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/item/device/radio/intercom/locked/ai_private{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "Bw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10633,6 +11397,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
+"Bx" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/ai_status_display,
+/turf/simulated/wall/r_wall/hull,
+/area/turret_protected/ai_outer_chamber)
+"BC" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "BE" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue/mono,
@@ -10647,6 +11429,9 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
+"BF" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/turret_protected/ai)
 "BG" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10687,6 +11472,16 @@
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/secure_storage)
+"BP" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "BR" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -10742,6 +11537,14 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"BZ" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/turret_protected/ai_foyer)
 "Cb" = (
 /obj/effect/shuttle_landmark/torch/deck1/aquila{
 	name = "B-Deck, Fore Starboard"
@@ -10874,6 +11677,23 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/cobed)
+"Cm" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+	id_tag = "ai_core_pump"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/turret_protected/ai_foyer)
 "Cn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10892,6 +11712,11 @@
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
+"Co" = (
+/obj/machinery/porta_turret,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "Cr" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
@@ -10996,6 +11821,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
+"CS" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "CU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11071,6 +11910,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
+"Df" = (
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "Dg" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11124,6 +11970,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"Ds" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "Dt" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -11141,6 +11995,15 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
+"Dv" = (
+/obj/item/device/radio/intercom/locked/ai_private{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "Dw" = (
 /turf/simulated/floor/tiled/dark,
 /area/aquila/airlock)
@@ -11317,6 +12180,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
+"Ew" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "Ey" = (
 /obj/machinery/light,
 /obj/machinery/disposal,
@@ -11352,6 +12229,13 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/airlock)
+"EF" = (
+/obj/item/device/radio/intercom/locked/ai_private{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "EJ" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1;
@@ -11371,6 +12255,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
+"EO" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/item/device/radio/intercom/locked/ai_private{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "EP" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/closet/secure_closet/CMO_torch,
@@ -11398,6 +12298,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"EZ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "Fb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11456,6 +12365,15 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
+"Fh" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "Fi" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -11486,6 +12404,16 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
+"Fm" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "Fn" = (
 /obj/effect/floor_decal/scglogo{
 	dir = 4;
@@ -11535,6 +12463,15 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
+"FI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "FK" = (
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
@@ -11545,6 +12482,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
+"FN" = (
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
+"FP" = (
+/obj/machinery/camera/all/command{
+	c_tag = "AI Core - Fore Port Access";
+	dir = 4
+	},
+/obj/item/device/radio/intercom/locked/ai_private{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "FS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11692,6 +12643,16 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
+"Gu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "Gy" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -11910,6 +12871,26 @@
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
+"Hj" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/porta_turret,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techmaint,
+/area/turret_protected/ai_foyer)
 "Ho" = (
 /obj/machinery/door/airlock/sol{
 	id_tag = "hopdoor";
@@ -12149,6 +13130,16 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
+"HR" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "HS" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -12294,6 +13285,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/bridge)
+"Im" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "In" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10;
@@ -12414,6 +13411,15 @@
 /obj/item/book/manual/military_law,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
+"ID" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "IE" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -12652,6 +13658,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/aquila/storage)
+"JC" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "JE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -12789,6 +13813,16 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
+"Kw" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/porta_turret,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
 "Kx" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
@@ -13004,6 +14038,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
+"Lo" = (
+/obj/item/device/radio/intercom/locked/ai_private{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "Lr" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13074,6 +14120,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"LB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
+"LG" = (
+/obj/item/device/radio/intercom/locked/ai_private{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/camera/all/command{
+	c_tag = "AI Core - Aft Port";
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 21
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "LJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
@@ -13134,6 +14200,10 @@
 /obj/item/storage/box/large/union_cards,
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/heads/office/cl/backroom)
+"LS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/wall/r_wall/prepainted,
+/area/turret_protected/ai_foyer)
 "LY" = (
 /obj/structure/sign/double/solgovflag/right{
 	dir = 4;
@@ -13141,6 +14211,15 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
+"LZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "Ma" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -13272,6 +14351,24 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
+"MH" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/flasher{
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
+"MM" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "MU" = (
 /obj/machinery/light{
 	dir = 4
@@ -13411,6 +14508,12 @@
 /obj/effect/floor_decal/industrial/shutoff,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"Nl" = (
+/obj/item/device/radio/intercom/locked/ai_private{
+	pixel_y = 22
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "Nn" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -13454,6 +14557,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
+"Nu" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "Nw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
@@ -13528,6 +14635,24 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
+"NR" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "ai_core_airlock";
+	name = "exterior access button";
+	pixel_x = -24;
+	req_access = list("ACCESS_AI_UPLOAD")
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
+"NV" = (
+/obj/structure/sign/warning/lethal_turrets,
+/turf/simulated/wall/r_wall/hull,
+/area/turret_protected/ai_outer_chamber)
 "NW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
@@ -13535,6 +14660,22 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/foreport)
+"NX" = (
+/obj/item/device/radio/intercom/locked/ai_private{
+	pixel_y = 22
+	},
+/obj/machinery/camera/all/command{
+	c_tag = "AI Core - Fore Starboard Access";
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
+"NZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "Ob" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Crew Area"
@@ -13750,6 +14891,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/cl)
+"OH" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "OK" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftport)
@@ -13771,6 +14922,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
+"OP" = (
+/obj/machinery/computer/modular/preset/engineering,
+/obj/machinery/camera/all/command{
+	c_tag = "AI Core - Starboard"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
 "OS" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -13901,6 +15059,11 @@
 "Pt" = (
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
+"Pu" = (
+/obj/machinery/porta_turret,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai_foyer)
 "Py" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 4;
@@ -14129,6 +15292,31 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
+"Qq" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/turret_protected/ai_foyer)
+"Qu" = (
+/turf/simulated/wall/r_wall/hull,
+/area/turret_protected/ai_outer_chamber)
 "Qv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -14242,6 +15430,31 @@
 /obj/item/book/manual/solgov_law,
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
+"QT" = (
+/obj/machinery/tele_pad,
+/obj/item/device/radio/intercom/locked/ai_private{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/turret_protected/ai_foyer)
+"QU" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloor_edges"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai_foyer)
 "QW" = (
 /obj/machinery/computer/ship/engines{
 	dir = 4;
@@ -14455,6 +15668,16 @@
 /obj/item/storage/secure/briefcase,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
+"Rx" = (
+/obj/item/device/radio/intercom/locked/ai_private{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "Rz" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -14537,6 +15760,16 @@
 /obj/structure/flora/pottedplant/unusual,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
+"RR" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "RT" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -14661,6 +15894,9 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
+"Sl" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/turret_protected/ai_outer_chamber)
 "Sn" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -14680,6 +15916,15 @@
 /obj/machinery/cryopod,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/passenger)
+"Sy" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "SA" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
@@ -14730,6 +15975,15 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
+"SI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "SJ" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 10;
@@ -14761,6 +16015,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
+"SP" = (
+/obj/machinery/tele_projector{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/kiddieplaque{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/turret_protected/ai_foyer)
 "SQ" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
@@ -14924,6 +16192,17 @@
 /obj/structure/closet/secure_closet/RD_torch,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
+"Tk" = (
+/obj/machinery/computer/teleporter{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/turret_protected/ai_foyer)
 "Tl" = (
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
@@ -14979,6 +16258,11 @@
 "TB" = (
 /turf/simulated/floor/reinforced/airless,
 /area/bridge/storage)
+"TD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "TI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -15029,6 +16313,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"TN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/device/radio/intercom/locked/ai_private{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/turret_protected/ai_foyer)
 "TP" = (
 /obj/structure/curtain/open/bed,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15079,6 +16378,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/maintenance)
+"Uc" = (
+/obj/machinery/porta_turret,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "Uf" = (
 /obj/structure/bed/chair/padded/beige,
 /obj/effect/floor_decal/corner/blue/mono,
@@ -15170,6 +16481,14 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
+"Ux" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "Uy" = (
 /obj/structure/table/glass,
 /obj/structure/cable/green{
@@ -15222,6 +16541,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
+"UO" = (
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/turret_protected/ai_outer_chamber)
 "UU" = (
 /obj/effect/shuttle_landmark/ert/deck1{
 	name = "B-Deck, Fore"
@@ -15388,6 +16713,18 @@
 	},
 /turf/simulated/floor/airless,
 /area/aquila/secure_storage)
+"Vt" = (
+/obj/machinery/power/terminal{
+	dir = 1;
+	icon_state = "term"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
 "Vw" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -15431,6 +16768,31 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
+"VD" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloor_edges"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/bluespace_beacon,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai_foyer)
 "VF" = (
 /obj/item/reagent_containers/food/drinks/flask/barflask{
 	pixel_x = -4;
@@ -15473,6 +16835,18 @@
 /obj/item/bedsheet/captain,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/cobed)
+"VX" = (
+/obj/machinery/flasher{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "VY" = (
 /obj/machinery/button/alternate/door/bolts{
 	id_tag = "bridgesafe_front";
@@ -15601,6 +16975,16 @@
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
+"Wm" = (
+/obj/machinery/porta_turret,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
 "Wr" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
@@ -15620,6 +17004,26 @@
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/maintenance)
+"WB" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"WI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "WK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -15779,6 +17183,29 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
+"Xw" = (
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	id_tag = "ai_core_airlock";
+	name = "AI Core Airlock Console";
+	pixel_x = 27;
+	req_access = list("ACCESS_AI_UPLOAD");
+	tag_airpump = "ai_core_pump";
+	tag_chamber_sensor = "ai_core_sensor";
+	tag_exterior_door = "ai_core_outer";
+	tag_interior_door = "ai_core_inner"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/turret_protected/ai_foyer)
 "Xx" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/door/airlock/medical{
@@ -15818,6 +17245,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"XD" = (
+/obj/machinery/ai_status_display,
+/turf/simulated/wall/r_wall/hull,
+/area/turret_protected/ai_outer_chamber)
 "XI" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/effect/paint/hull,
@@ -15836,6 +17267,22 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
+"XK" = (
+/obj/machinery/power/apc/super/critical{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "XN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -15896,6 +17343,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
+"XY" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "Yb" = (
 /obj/structure/catwalk,
 /obj/machinery/alarm{
@@ -15986,6 +17445,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
+"Yi" = (
+/obj/machinery/computer/modular/preset/medical,
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
 "Yj" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16005,6 +17468,45 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"Yl" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/solar/bridge)
+"Ym" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
+"Yo" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai_foyer)
 "Ys" = (
 /obj/random_multi/single_item/poppy,
 /turf/simulated/floor/plating,
@@ -16050,6 +17552,9 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
+"YD" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/turret_protected/ai_foyer)
 "YI" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/forestarboard)
@@ -16081,6 +17586,14 @@
 	},
 /turf/simulated/open,
 /area/maintenance/bridge/forestarboard)
+"YM" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Outer Ring Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai_outer_chamber)
 "YN" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Disciplinary Board Room Maintenance Access"
@@ -16088,6 +17601,19 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/disciplinary_board_room)
+"YR" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	icon_state = "closed";
+	name = "AI Core Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/turret_protected/ai)
 "YS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -16162,6 +17688,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
+"Zf" = (
+/obj/machinery/porta_turret,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techmaint,
+/area/turret_protected/ai_outer_chamber)
 "Zg" = (
 /obj/effect/floor_decal/scglogo{
 	icon_state = "center-right"
@@ -16218,6 +17750,28 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/aquila/head)
+"Zk" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
+"Zm" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/turret_protected/ai_outer_chamber)
 "Zs" = (
 /obj/machinery/computer/account_database,
 /obj/machinery/recharger/wallcharger{
@@ -16259,6 +17813,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
+"Zz" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "ZA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16334,6 +17896,9 @@
 /mob/living/simple_animal/friendly/corgi/Ian,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
+"ZW" = (
+/turf/simulated/wall/r_wall/hull,
+/area/turret_protected/ai_foyer)
 "ZX" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/bed/chair/padded/teal,
@@ -32589,10 +34154,10 @@ cN
 bD
 bD
 gz
-ad
-ad
-ad
-gV
+mr
+xf
+xf
+nB
 hJ
 hJ
 hJ
@@ -32791,7 +34356,7 @@ bD
 bD
 bD
 ad
-ad
+BC
 Oc
 ad
 gX
@@ -32993,7 +34558,7 @@ bD
 bD
 ad
 ad
-ad
+BC
 ad
 DN
 DN
@@ -33195,7 +34760,7 @@ cO
 ad
 ad
 ad
-ad
+BC
 ad
 DN
 DN
@@ -33397,7 +34962,7 @@ cP
 ad
 ad
 ad
-ad
+BC
 ad
 DN
 DN
@@ -33599,7 +35164,7 @@ cP
 ad
 ad
 ad
-ad
+BC
 ad
 ad
 fj
@@ -33801,7 +35366,7 @@ cP
 ad
 ad
 ad
-ad
+BC
 ad
 ad
 gY
@@ -34000,10 +35565,10 @@ ah
 av
 aI
 cP
-ad
-ad
-ad
-ad
+mr
+xf
+xf
+vB
 ad
 ad
 gY
@@ -34202,7 +35767,7 @@ ah
 av
 aI
 cP
-ad
+BC
 ad
 ad
 ad
@@ -34404,7 +35969,7 @@ ah
 av
 aI
 cP
-ad
+BC
 ad
 ad
 fj
@@ -34606,7 +36171,7 @@ ah
 av
 aI
 cP
-fj
+HR
 eb
 eb
 fk
@@ -34808,7 +36373,7 @@ ah
 av
 aI
 cP
-gY
+RR
 ec
 SA
 SA
@@ -35010,7 +36575,7 @@ ah
 av
 aI
 cP
-gY
+RR
 Ib
 eH
 fm
@@ -35212,7 +36777,7 @@ ah
 av
 aI
 cP
-gY
+RR
 Ib
 eI
 fn
@@ -35414,7 +36979,7 @@ ah
 av
 aI
 cP
-gY
+RR
 Ib
 eJ
 fm
@@ -35616,7 +37181,7 @@ ah
 av
 aI
 cP
-gY
+RR
 ec
 SA
 SA
@@ -35818,7 +37383,7 @@ ah
 av
 aI
 cP
-fp
+wK
 eg
 eg
 nr
@@ -36020,7 +37585,7 @@ ah
 av
 aI
 cP
-ad
+BC
 ad
 ad
 fp
@@ -36222,7 +37787,7 @@ ah
 av
 aI
 cP
-ad
+BC
 ad
 ad
 ad
@@ -36424,7 +37989,7 @@ ah
 av
 aI
 cP
-ad
+BC
 ad
 ad
 ad
@@ -36626,7 +38191,7 @@ ah
 av
 aI
 cP
-ad
+BC
 ad
 ad
 ad
@@ -36828,7 +38393,7 @@ ah
 av
 aI
 cP
-ad
+BC
 ad
 ad
 ad
@@ -37030,7 +38595,7 @@ ah
 av
 aI
 cP
-ad
+BC
 ad
 ad
 ad
@@ -37232,7 +38797,7 @@ ah
 av
 aI
 cQ
-aH
+Yl
 aH
 aH
 aH
@@ -37434,7 +38999,7 @@ ah
 av
 aI
 ad
-ad
+BC
 ad
 ad
 ad
@@ -37636,19 +39201,19 @@ ah
 av
 aI
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+my
+xf
+xf
+xf
+xf
+xf
+xf
+xf
+xf
+xf
+xf
+xf
+Sy
 ad
 ad
 ad
@@ -37848,11 +39413,11 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+Bx
+Qu
+Qu
 ad
 ad
 ad
@@ -38045,21 +39610,21 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
+gD
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
 ad
 ad
 ad
@@ -38246,23 +39811,23 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
+ZW
+QT
+SP
+Tk
+ZW
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
 ad
 ad
 ad
@@ -38447,25 +40012,25 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+Qu
+ku
+ku
+ku
+mK
+LS
+eA
+VD
+QU
+LS
+Ux
+ku
+ku
+ku
+Qu
+Qu
+Qu
 ad
 ad
 ad
@@ -38648,27 +40213,27 @@ aI
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+Qu
+Nl
+ku
+Sl
+Sl
+Sl
+YD
+tQ
+tq
+ro
+YD
+Sl
+Sl
+Sl
+ku
+EF
+Qu
+Qu
+Qu
 ad
 ad
 ad
@@ -38849,29 +40414,29 @@ av
 aI
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+Qu
+ku
+ku
+Sl
+Sl
+YD
+YD
+YD
+BZ
+ym
+YD
+YD
+YD
+YD
+Sl
+Sl
+ku
+ku
+Qu
+Qu
+Qu
 ad
 ad
 ah
@@ -39051,29 +40616,29 @@ av
 aI
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+Co
+ku
+Sl
+Sl
+YD
+Pu
+NR
+YD
+Cm
+Qq
+hX
+YD
+NR
+Pu
+YD
+Sl
+Sl
+ku
+Co
+Qu
+Qu
 ad
 ad
 ah
@@ -39253,29 +40818,29 @@ av
 aI
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+ku
+Sl
+Sl
+YD
+NX
+Ew
+OH
+ng
+Xw
+Hj
+TN
+pV
+BP
+WI
+FP
+YD
+Sl
+Sl
+ku
+Qu
+Qu
 ad
 ad
 ah
@@ -39455,29 +41020,29 @@ av
 aI
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+ku
+Sl
+YD
+Pu
+FN
+xd
+BF
+BF
+BF
+BF
+BF
+BF
+BF
+Yo
+FN
+Pu
+YD
+Sl
+ku
+Qu
+Qu
 ad
 ad
 ah
@@ -39657,29 +41222,29 @@ av
 aI
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+ku
+Sl
+YD
+MM
+Ew
+op
+lk
+iC
+Ym
+zr
+Nu
+EO
+YR
+ld
+hk
+yr
+YD
+Sl
+ku
+Qu
+Qu
 ad
 ad
 ah
@@ -39859,29 +41424,29 @@ av
 aI
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+wZ
+Sl
+YD
+Df
+ru
+BF
+BF
+Wm
+BF
+BF
+BF
+Kw
+BF
+BF
+ID
+Fm
+YD
+Sl
+UO
+Qu
+Qu
 ad
 ad
 ah
@@ -40061,29 +41626,29 @@ av
 aI
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+uf
+Sl
+YD
+Pu
+xd
+BF
+yq
+VX
+BF
+vR
+BF
+MH
+jP
+BF
+FI
+Pu
+YD
+Sl
+uf
+Qu
+Qu
 ad
 ad
 ah
@@ -40263,29 +41828,29 @@ av
 aI
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+XD
+Qu
+Dv
+Sl
+YD
+rj
+JC
+BF
+OP
+Ds
+BF
+zO
+BF
+Zz
+yE
+BF
+jt
+iE
+YD
+Sl
+Rx
+Qu
+XD
 ad
 ad
 ah
@@ -40465,29 +42030,29 @@ aw
 aI
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+EZ
+Sl
+YD
+Pu
+xd
+BF
+Yi
+Wm
+BF
+kl
+BF
+Kw
+fq
+BF
+FI
+Pu
+YD
+Sl
+EZ
+Qu
+Qu
 ad
 ad
 ah
@@ -40667,29 +42232,29 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+vN
+Sl
+YD
+qM
+XY
+BF
+BF
+jo
+XK
+yn
+Zk
+Bv
+BF
+BF
+Fh
+NZ
+YD
+Sl
+vN
+Qu
+Qu
 ad
 ad
 ad
@@ -40869,29 +42434,29 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+vN
+Sl
+YD
+MM
+xH
+pr
+BF
+jn
+lz
+jJ
+Vt
+om
+BF
+SI
+oN
+yr
+YD
+Sl
+vN
+Qu
+Qu
 ad
 ad
 ad
@@ -41071,29 +42636,29 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+vN
+Sl
+YD
+Pu
+FN
+xd
+BF
+BF
+BF
+BF
+BF
+BF
+BF
+FI
+FN
+Pu
+YD
+Sl
+vN
+Qu
+Qu
 ad
 ad
 ad
@@ -41273,29 +42838,29 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+vN
+Sl
+Sl
+YD
+bz
+xH
+OH
+OH
+OH
+CS
+LB
+LB
+LB
+oN
+LG
+YD
+Sl
+Sl
+vN
+Qu
+Qu
 ad
 ad
 ad
@@ -41475,29 +43040,29 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+kY
+qC
+Sl
+Sl
+YD
+Pu
+Im
+FN
+Pu
+xd
+Pu
+FN
+Im
+Pu
+YD
+Sl
+Sl
+LZ
+Uc
+Qu
+Qu
 ad
 ad
 ad
@@ -41677,29 +43242,29 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+Qu
+ue
+qC
+Sl
+Sl
+YD
+YD
+YD
+YD
+sA
+YD
+YD
+YD
+YD
+Sl
+Sl
+LZ
+Gu
+Qu
+Qu
+Qu
 ad
 ad
 ad
@@ -41880,27 +43445,27 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+Qu
+Lo
+qC
+Sl
+Sl
+Sl
+Sl
+Sl
+oj
+Sl
+Sl
+Sl
+Sl
+Sl
+LZ
+wi
+Qu
+Qu
+Qu
 ad
 ad
 ad
@@ -42083,25 +43648,25 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+Qu
+ue
+TD
+TD
+TD
+YM
+Zf
+Zm
+Zf
+YM
+TD
+TD
+TD
+Gu
+Qu
+Qu
+Qu
 ad
 ad
 ad
@@ -42286,23 +43851,23 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
+uY
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
 ad
 ad
 ad
@@ -42489,21 +44054,21 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
+NV
+iT
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
+Qu
 ad
 ad
 ad
@@ -42697,9 +44262,9 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
+WB
+ft
+nE
 ad
 ad
 ad

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -1069,6 +1069,26 @@
 	name = "\improper Fourth Deck Security Checkpoint"
 	icon_state = "checkpoint"
 
+// AI
+
+/area/turret_protected/ai_foyer
+	name = "\improper AI Chamber Foyer"
+	icon_state = "ai_foyer"
+	sound_env = SMALL_ENCLOSED
+	req_access = list(access_ai_upload)
+
+/area/turret_protected/ai_outer_chamber
+	name = "\improper Outer AI Chamber"
+	icon_state = "ai_chamber"
+	sound_env = SMALL_ENCLOSED
+	req_access = list(access_ai_upload)
+
+/area/turret_protected/ai
+	name = "\improper AI Chamber"
+	icon_state = "ai_chamber"
+	ambience = list('sound/ambience/ambimalf.ogg')
+	req_access = list(access_ai_upload)
+
 // Medbay
 
 /area/medical/equipstorage


### PR DESCRIPTION
## About the Pull Request

Adds back the AI core with a few minor changes, most notably rewiring the core slightly, and adding a suit storage unit and oxygen tanks in place of the suit rack.

 I've also **added an AI upload console to the cyborg upload room**, and added some AI-related rooms back into the areas file.
 ![AI core](https://user-images.githubusercontent.com/40336142/130539488-c97520dc-387b-4181-a3cc-3130ae5f7a9f.PNG)

## Why It's Good For The Game

I've done this at Cupa#3998's request (albeit, 20 days late). AI is still admin-only whitelisted at the time of me making this! And, I personally think people would enjoy/wouldn't mind having AI come back. 

## Did you test it?

It compiled successfully on my computer, and nothing seem amiss when I observed it in-game. AI spawned in successfully, and power was functional. 

## Changelog

 :cl:
 maptweak: Re-adds the AI core, replaces space suit rack with suit storage unit and oxygen tank crate, adds AI upload console to cyborg upload.
/ :cl:

