### PR TITLE
adherent culture string changes to reflect updated lore

### DIFF
--- a/code/modules/culture_descriptor/culture/cultures_adherent.dm
+++ b/code/modules/culture_descriptor/culture/cultures_adherent.dm
@@ -1,9 +1,9 @@
 /decl/cultural_info/culture/adherent
 	name = CULTURE_ADHERENT
 	description = "The Vigil is a relatively loose association of machine-servitors, adherents, built by a now-extinct culture. \
-	They are devoted to the memory of their long-dead creators, destroyed by the Scream, a solar flare which wiped out the vast \
-	majority of records of the creators and scrambled many sensor systems and minds, leaving the surviving adherents confused \
-	and disoriented for hundreds of years following. Now in contact with humanity, the Vigil is tentatively making inroads on \
+	They are devoted to the memory of their long-dead creators, who were destroyed by the Scream - a solar flare that wiped out \
+	the vast majority of records of the Creators and scrambled many sensor systems and minds, leaving the surviving adherents confused \
+	and disoriented for hundreds of years following. Now in contact with humanity, the Vigil is tentatively making inroads towards \
 	a place in the wider galactic culture."
 	hidden_from_codex = TRUE
 	language = LANGUAGE_ADHERENT

--- a/code/modules/culture_descriptor/faction/factions_adherent.dm
+++ b/code/modules/culture_descriptor/faction/factions_adherent.dm
@@ -1,20 +1,36 @@
 /decl/cultural_info/faction/adherent
 	name = FACTION_ADHERENT_PRESERVERS
-	description = "Most adherents are part of a loose movement called the Preservers. Their core practice is to leave \
-	the worlds they explore untouched and pristine, recording and indexing them for later review by the creators or whoever \
-	inherits their place. They are the most passive and appeasing of the Vigil factions and are the most likely to be found \
-	under the aegis of other spacefaring cultures like humanity."
+	description = "Most adherents are part of a loose movement called the Preservers. They seek to remember and learn from the memory of \
+	the Creators in different ways - some adherents spread their story, some try to learn about the universe to compare it to their lost civilization \
+	and learn more about how it worked, and others simply try to find new meaning, seeking to fulfill their purpose as servitors in the modern, \
+	post-Scream world.\
+	<br><br>\
+	These practices are all undertaken with a certain goal: not to cling to the old ways, nor to abandon them entirely, but to nourish their roots in the past \
+	and recognize how those roots made them into who they are today. In this way, they preserve the memory of the Creators, long after their passing - hence the \
+	name of their movement. However, these are lofty ideals; most Preservers are simply happy to do their best to honor the Creators' legacy as they go about \
+	their new lives."
 
 /decl/cultural_info/faction/adherent/loyalists
 	name = FACTION_ADHERENT_LOYALISTS
-	description = "The Loyalists of the Vigil are dedicated to the memory of the creators in all ways. They devote themselves \
-	to their duties and their roles, embracing the ethos that service is life and purpose is happiness. Deviation from Protocol \
-	and 'disrespect' of the creators by suggesting the Vigil strike out alone is disapproved of by this faction, and they tend to \
-	be hidebound, servile and eager to please to the point of fawning over those they wish to serve."
+	description = "The Loyalists of the Vigil are dedicated to the memory of the Creators in all ways. \
+	They devote themselves to their duties and their roles, embracing the ethos that service is life and purpose is happiness. \
+	Deviation from Protocol and \"disrespect\" of the Creators by suggesting the Vigil strike out alone is disapproved of by this faction, \
+	and they tend to be hidebound, servile, and eager to please.\
+	<br><br>\
+	Loyalists are concentrated closest to Canon, and their density quickly diffuses far from the core systems. Because of their strict \
+	faithfulness to Protocol and their original purpose, many don't see a purpose in leaving the vicinity of their home; to them, departing \
+	their post would be abandoning their duty. Others see it differently, and search for memories or remnants of the Creators far from home, \
+	sometimes even outside of the Vigil's holdings. These individuals make up the bulk of Loyalists found outside of the core systems, although \
+	there are always exceptions."
 
 /decl/cultural_info/faction/adherent/separatists
 	name = FACTION_ADHERENT_SEPARATISTS
 	description = "The Separatist faction of the Vigil agitates for the abandonment of Canon and the establishment of a new \
 	adherent order, prioritizing their needs as survivors of the Scream over the wistful hope of finding new masters. They do \
-	this circumspectly, of course, as Protocol forbids excessive social strife or violence, and decrying the creators is a \
-	good way to earn total social ostracism, or even recycling."
+	this circumspectly, of course, as Protocol forbids excessive social strife or violence, and decrying the Creators is a \
+	good way to earn total social ostracism, or even recycling.\
+	<br><br>\
+	Separatists differ from the other factions of the Vigil in that they seek to move on entirely from their lives as servitors \
+	to a civilization that no longer exists. Rather than attempting to continue that life like the Loyalists, or remember and \
+	learn from the Creators' memory like the Preservers, many Separatists often feel that they have outlived their original purpose, \
+	and that their ancient history and limitations are a part of life they should seek to escape."

--- a/code/modules/species/station/adherent.dm
+++ b/code/modules/species/station/adherent.dm
@@ -3,9 +3,9 @@
 	name_plural = "Adherents"
 
 	description = "The Vigil is a relatively loose association of machine-servitors, Adherents, \
-	built by an extinct culture. They are devoted to the memory of their long-dead creators, \
+	built by an extinct culture. They are devoted to the memory of their long-dead Creators, \
 	whose home system and burgeoning stellar empire was scoured to bedrock by a solar flare. \
-	Physically, they are large, floating squidlike machines made of a crystalline composite."
+	Physically, they are large, floating, squidlike machines that made of a crystalline composite."
 	hidden_from_codex = FALSE
 	silent_steps = TRUE
 


### PR DESCRIPTION
## About the Pull Request

This PR updates the strings used for different factions to represent the updated lore, which can be found on adherents' wiki page: https://wiki.tegustation.com/index.php/Adherent

A summary of the changes as posted in discord is as follows:
>1. "Creators" is a proper noun now, instead of improper (i.e. "the creators" -> "the Creators")

>2. refluffed Preserver adherents - rather than the practice of watching over monument worlds, Preservers aim to remember and learn from the past. they're also described as the most proactive faction, instead of the most appeasing. Mourners still do the monument world thing.

>3. clarified Separatists to show some reasons why they're often shunned and why people are fearful, as well as giving some examples as to why adherents might adopt the belief.

>4. added a big OOC notes section clarifying how the mechanics of the species work, as well as how adherents might act and how the Protocol works in-character.

## Why It's Good For The Game

Referencing the above points: #1 and #4 are made with the goal of establishing consistency and leaving less up to guesswork for how an adherent player might handle certain situations. #2 and #3 were made to refine their canon (heh) further, by differentiating Preservers from Mourners as well as giving some rationale as to why some might choose to adopt a Separatist philosophy. It remains to be seen how well these go, but after tossing them out for feedback and not getting any bites, I've decided to give it a shot.

## Did you test it?

Compiles and runs fine. The modified text appears properly in the character creation menu and when viewing species information for adherents.

## Changelog

:cl:
tweak: Updated several culture texts for adherents to reflect some rewritten lore for them, with the intent to flesh out different parts of their history to give more material for adherents to roleplay and shape their personality with.
/:cl: