### PR TITLE
reformatted exoplanet scan reports, changes exoplanet name generation, and gives more detailed descriptions for exoplanet classes

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2534,7 +2534,7 @@
 #include "code\modules\overmap\exoplanets\planet_types\barren.dm"
 #include "code\modules\overmap\exoplanets\planet_types\chlorine.dm"
 #include "code\modules\overmap\exoplanets\planet_types\desert.dm"
-#include "code\modules\overmap\exoplanets\planet_types\grass.dm"
+#include "code\modules\overmap\exoplanets\planet_types\lush.dm"
 #include "code\modules\overmap\exoplanets\planet_types\shrouded.dm"
 #include "code\modules\overmap\exoplanets\planet_types\snow.dm"
 #include "code\modules\overmap\exoplanets\planet_types\volcanic.dm"

--- a/code/_helpers/names.dm
+++ b/code/_helpers/names.dm
@@ -1,11 +1,14 @@
 /proc/generate_system_name()
 	return "[pick("Gilese","GSC", "Luyten", "GJ", "HD", "SCGECO")][prob(10) ? " Eridani" : ""] [rand(100,999)]"
 
+/**
+ * Returns a planet name equal to (system name) (lowercase letter in order) based on the number of planetoids - for instance, "GSC 103 b" is the second planetoid in a system.
+ * If too many planetoids are present to assign a letter, it'll use (random last name)-(greek letter) instead, such as "Caldwell-Theta".
+ */
 /proc/generate_planet_name()
-	return "[capitalize(pick(GLOB.last_names))]-[pick(GLOB.greek_letters)]"
-
-/proc/generate_planet_type()
-	return pick("terrestial planet", "ice planet", "dwarf planet", "desert planet", "ocean planet", "lava planet", "gas giant", "forest planet")
+	if (GLOB.number_of_planetoids > 26) // We should absolutely never have this many planetoids, but it's best to future-proof just in case
+		return "[capitalize(pick(GLOB.last_names))]-[pick(GLOB.greek_letters)]"
+	return "[GLOB.using_map.system_name] [ascii2text(Clamp(96 + GLOB.number_of_planetoids, 97, 122))]"
 
 /proc/station_name()
 	if(!GLOB.using_map)

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -1,4 +1,6 @@
 GLOBAL_VAR(planet_repopulation_disabled)
+/// The number of planetary bodies in this sector, usually exoplanets. We use this when generating names for planets and some away sites.
+GLOBAL_VAR_INIT(number_of_planetoids, 0)
 
 /obj/effect/overmap/visitable/sector/exoplanet
 	name = "exoplanet"
@@ -82,6 +84,7 @@ GLOBAL_VAR(planet_repopulation_disabled)
 	maxx = max_x ? max_x : world.maxx
 	maxy = max_y ? max_y : world.maxy
 
+	GLOB.number_of_planetoids++
 	var/planet_name = generate_planet_name()
 	name = "[planet_name], \a [name]"
 
@@ -265,35 +268,66 @@ GLOBAL_VAR(planet_repopulation_disabled)
 		new new_type(T)
 
 /obj/effect/overmap/visitable/sector/exoplanet/get_scan_data(mob/user)
-	. = ..()
-	var/list/extra_data = list("<hr>")
-	if (atmosphere)
-		if (user.skill_check(SKILL_SCIENCE, SKILL_TRAINED))
-			var/list/gases = list()
-			for (var/g in atmosphere.gas)
-				if (atmosphere.gas[g] > atmosphere.total_moles * 0.05)
-					gases += gas_data.name[g]
-			extra_data += "Atmosphere composition: [english_list(gases)]"
-			var/inaccuracy = rand(8,12)/10
-			extra_data += "Atmosphere pressure [atmosphere.return_pressure()*inaccuracy] kPa, temperature [atmosphere.temperature*inaccuracy] K"
-		else if (user.skill_check(SKILL_SCIENCE, SKILL_BASIC))
-			extra_data += "Atmosphere present"
-		extra_data += "<hr>"
+	var/list/extra_data = list("<b>Target:</b> [name]")
+	var/user_skill = user.get_skill_value(SKILL_SCIENCE)
+	// Show a detailed scan summary if we have it
+	if (scan_summary)
+		extra_data += "<br><b>Analysis:</b> [scan_summary]"
+		if (scan_assessment)
+			extra_data += "<br><b>Assessment:</b> [scan_assessment]"
+	// Otherwise, just use the description
+	else
+		extra_data += "<br><b>Description:</b> [desc]"
+	extra_data += "<br><hr>"
 
-	if (seeds.len && user.skill_check(SKILL_SCIENCE, SKILL_BASIC))
-		extra_data += "Xenoflora detected"
+	// Atmosphere
+	if (user_skill >= SKILL_BASIC)
+		if (atmosphere)
+			if (user_skill >= SKILL_TRAINED)
+				var/list/gases = list()
+				for (var/g in atmosphere.gas)
+					if (atmosphere.gas[g] > atmosphere.total_moles * 0.05)
+						gases += gas_data.name[g]
+				extra_data += "<b>Atmosphere composition:</b> [english_list(gases)]"
+				var/inaccuracy = rand(8, 12) / 10
+				extra_data += "<b>Surface pressure:</b> ~[atmosphere.return_pressure() * inaccuracy] kPa"
+				extra_data += "<b>Temperature:</b> ~[atmosphere.temperature * inaccuracy] K"
+			else
+				extra_data += "Atmosphere present. Unable to determine surface conditions."
+		else
+			extra_data += "No atmosphere present."
+		extra_data += "<br><hr>"
 
-	if (animals.len && user.skill_check(SKILL_SCIENCE, SKILL_BASIC))
-		extra_data += "Life traces detected"
+	if (user_skill >= SKILL_BASIC)
+		// Mineral content
+		var/mineral_string = "Normal."
+		for (var/V in map_generators)
+			if (ispath(V, /datum/random_map/noise/ore))
+				var/datum/random_map/noise/ore/O = V
+				mineral_string = initial(O.scan_info)
+				break // we should only ever have one of these, so use the first one we find
+		extra_data += "<b>Mineral content:</b> [mineral_string]"
 
-	if (LAZYLEN(spawned_features) && user.skill_check(SKILL_SCIENCE, SKILL_TRAINED))
+		// Xenoflora and xenofauna
+		var/has_flora = small_flora_types.len || big_flora_types.len
+		if (!has_flora && !animals.len)
+			extra_data += "No life signs detected."
+		else
+			if (has_flora)
+				extra_data += "Plant life detected."
+			if (animals.len)
+				extra_data += "Animal life detected."
+
+	// Artificial ruins
+	if (LAZYLEN(spawned_features) && user_skill >= SKILL_TRAINED)
 		var/ruin_num = 0
 		for (var/datum/map_template/ruin/exoplanet/R in spawned_features)
 			if (!(R.ruin_tags & RUIN_NATURAL))
 				ruin_num++
 		if (ruin_num)
-			extra_data += "<hr>[ruin_num] possible artificial structure\s detected."
+			extra_data += "[ruin_num] notable structure\s detected."
 
+	// Any data from exoplanet themes
 	for (var/datum/exoplanet_theme/T in themes)
 		if (T.get_sensor_data())
 			extra_data += T.get_sensor_data()

--- a/code/modules/overmap/exoplanets/planet_themes/radiation_bombing.dm
+++ b/code/modules/overmap/exoplanets/planet_themes/radiation_bombing.dm
@@ -8,7 +8,7 @@
 		E.atmosphere.update_values()
 
 /datum/exoplanet_theme/radiation_bombing/get_sensor_data()
-	return "Hotspots of radiation detected."
+	return "Hotspots of surface radiation detected."
 
 /datum/exoplanet_theme/radiation_bombing/after_map_generation(obj/effect/overmap/visitable/sector/exoplanet/E)
 	var/radiation_power = rand(10, 37.5)

--- a/code/modules/overmap/exoplanets/planet_types/barren.dm
+++ b/code/modules/overmap/exoplanets/planet_types/barren.dm
@@ -1,6 +1,8 @@
 /obj/effect/overmap/visitable/sector/exoplanet/barren
 	name = "barren exoplanet"
 	desc = "An exoplanet that couldn't hold its atmosphere."
+	scan_summary = "Rocky exoplanet with an extremely thin atmosphere and no magnetosphere. Surface temperatures are very low. No surface water is present outside of the planet's ice caps, and climate models predict that the planet's only weather comes in the form of periodic dust storms."
+	scan_assessment = "Surface climate completely uninhabitable, requiring pressure protection and internals."
 	color = "#6c6c6c"
 	planetary_area = /area/exoplanet/barren
 	rock_colors = list(COLOR_BEIGE, COLOR_GRAY80, COLOR_BROWN)

--- a/code/modules/overmap/exoplanets/planet_types/chlorine.dm
+++ b/code/modules/overmap/exoplanets/planet_types/chlorine.dm
@@ -1,6 +1,8 @@
 /obj/effect/overmap/visitable/sector/exoplanet/chlorine
 	name = "chlorine exoplanet"
 	desc = "An exoplanet with a chlorine based ecosystem. Large quantities of liquid chlorine are present."
+	scan_summary = "Warm, wet exoplanet characterized by an atmosphere containing high amounts of liquid chlorine. Complex life has developed, presumably utilizing chorine as a biological solvent instead of water; several distinct species of flora and fauna are present."
+	scan_assessment = "Hostile atmosphere necessitates use of internals and possibly pressure suits."
 	color = "#c9df9f"
 	planetary_area = /area/exoplanet/chlorine
 	rock_colors = list(COLOR_GRAY80, COLOR_PALE_GREEN_GRAY, COLOR_PALE_BTL_GREEN)

--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -1,6 +1,8 @@
 /obj/effect/overmap/visitable/sector/exoplanet/desert
 	name = "desert exoplanet"
 	desc = "An arid exoplanet with sparse biological resources but rich mineral deposits underground."
+	scan_summary = "Hot, dry exoplanet located near the inner boundary of the system's habitable zone, close to its primary star. Surface water is present, and primarily exists in the form of shallow marshes, mud, and pockets of liquefacted soil."
+	scan_assessment = "Quicksand is posited as a likely hazard to away crews."
 	color = "#a08444"
 	planetary_area = /area/exoplanet/desert
 	rock_colors = list(COLOR_BEIGE, COLOR_PALE_YELLOW, COLOR_GRAY80, COLOR_BROWN)

--- a/code/modules/overmap/exoplanets/planet_types/lush.dm
+++ b/code/modules/overmap/exoplanets/planet_types/lush.dm
@@ -1,32 +1,34 @@
-/obj/effect/overmap/visitable/sector/exoplanet/grass
+/obj/effect/overmap/visitable/sector/exoplanet/lush
 	name = "lush exoplanet"
 	desc = "Planet with abundant flora and fauna."
+	scan_summary = "Humid, temperate world with a warm atmosphere. Continental landmasses are dominated by dense vegetation. Liquid water and complex life are highly abundant."
+	scan_assessment = "Use caution when interacting with local life."
 	color = "#407c40"
 	planetary_area = /area/exoplanet/grass
 	rock_colors = list(COLOR_ASTEROID_ROCK, COLOR_GRAY80, COLOR_BROWN)
 	plant_colors = list("#0e1e14","#1a3e38","#5a7467","#9eab88","#6e7248", "RANDOM")
-	map_generators = list(/datum/random_map/noise/exoplanet/grass)
+	map_generators = list(/datum/random_map/noise/exoplanet/lush)
 	habitability_distribution = list(HABITABILITY_IDEAL = 70, HABITABILITY_OKAY = 20, HABITABILITY_BAD = 5)
 	has_trees = TRUE
 	flora_diversity = 7
 	fauna_types = list(/mob/living/simple_animal/yithian, /mob/living/simple_animal/tindalos, /mob/living/simple_animal/hostile/retaliate/jelly)
 	megafauna_types = list(/mob/living/simple_animal/hostile/retaliate/parrot/space/megafauna, /mob/living/simple_animal/hostile/retaliate/goose/dire)
 
-/obj/effect/overmap/visitable/sector/exoplanet/grass/generate_map()
+/obj/effect/overmap/visitable/sector/exoplanet/lush/generate_map()
 	if(prob(40))
 		lightlevel = rand(1,7)/10	//give a chance of twilight jungle
 	..()
 
-/obj/effect/overmap/visitable/sector/exoplanet/grass/generate_atmosphere()
+/obj/effect/overmap/visitable/sector/exoplanet/lush/generate_atmosphere()
 	..()
 	if(atmosphere)
 		atmosphere.temperature = T20C + rand(10, 30)
 		atmosphere.update_values()
 
-/obj/effect/overmap/visitable/sector/exoplanet/grass/get_surface_color()
+/obj/effect/overmap/visitable/sector/exoplanet/lush/get_surface_color()
 	return grass_color
 
-/obj/effect/overmap/visitable/sector/exoplanet/grass/adapt_seed(var/datum/seed/S)
+/obj/effect/overmap/visitable/sector/exoplanet/lush/adapt_seed(var/datum/seed/S)
 	..()
 	var/carnivore_prob = rand(100)
 	if(carnivore_prob < 30)
@@ -60,8 +62,8 @@
 		L.client.ambience_playing = TRUE
 		L.playsound_local(get_turf(L),sound('sound/ambience/jungle.ogg', repeat = 1, wait = 0, volume = 25, channel = GLOB.ambience_sound_channel))
 
-/datum/random_map/noise/exoplanet/grass
-	descriptor = "grass exoplanet"
+/datum/random_map/noise/exoplanet/lush
+	descriptor = "lush exoplanet"
 	smoothing_iterations = 2
 	land_type = /turf/simulated/floor/exoplanet/grass
 	water_type = /turf/simulated/floor/exoplanet/water/shallow
@@ -70,14 +72,16 @@
 	grass_prob = 50
 	large_flora_prob = 30
 
-/obj/effect/overmap/visitable/sector/exoplanet/grass/terraformed
-	name = "life seeded exoplanet"
+/obj/effect/overmap/visitable/sector/exoplanet/lush/lifeseeded
+	name = "life-seeded exoplanet"
 	desc = "Planet with abundant flora and fauna. Shows signs of human terraformation."
+	scan_summary = "Temperate world with a nitrogen-oxygen atmosphere. Abundant flora and fauna are present, seeded from Earth species, and accompanied by an active and stable hydrosphere."
+	scan_assessment = "High probability of human terraforming."
 	color = "#58aa8b"
 	planetary_area = /area/exoplanet/grass
 	rock_colors = list(COLOR_ASTEROID_ROCK, COLOR_GRAY80, COLOR_BROWN)
 	plant_colors = list("#2f573e","#24574e","#6e9280","#9eab88","#868b58", "#84be7c", "RANDOM")
-	map_generators = list(/datum/random_map/noise/exoplanet/grass/terraformed)
+	map_generators = list(/datum/random_map/noise/exoplanet/lush/terraformed)
 	lightlevel = 0.5
 	has_trees = TRUE
 	flora_diversity = 8
@@ -89,18 +93,18 @@
 					/mob/living/simple_animal/friendly/chicken 				  = "wild chicken",
 					/mob/living/simple_animal/friendly/mouse 				  = "mouse",
 					/mob/living/simple_animal/friendly/opossum 				  =	"opossum",
-					/mob/living/simple_animal/hostile/retaliate/goat  = "wild goat",
-					/mob/living/simple_animal/hostile/retaliate/goose = "goose",
+					/mob/living/simple_animal/hostile/retaliate/goat		  = "wild goat",
+					/mob/living/simple_animal/hostile/retaliate/goose		  = "goose",
 					/mob/living/simple_animal/friendly/cow 					  = "wild cow")
 
-/obj/effect/overmap/visitable/sector/exoplanet/grass/terraformed/generate_habitability()
+/obj/effect/overmap/visitable/sector/exoplanet/lush/lifeseeded/generate_habitability()
 	habitability_class = HABITABILITY_IDEAL
 
-/obj/effect/overmap/visitable/sector/exoplanet/grass/generate_map()
+/obj/effect/overmap/visitable/sector/exoplanet/lush/generate_map()
 	lightlevel = rand(0.7,0.9)/10
 	..()
 
-/datum/random_map/noise/exoplanet/grass/terraformed
-	descriptor = "terraformed grass exoplanet"
+/datum/random_map/noise/exoplanet/lush/terraformed
+	descriptor = "life-seeded exoplanet"
 	flora_prob = 15
 	large_flora_prob = 30

--- a/code/modules/overmap/exoplanets/planet_types/shrouded.dm
+++ b/code/modules/overmap/exoplanets/planet_types/shrouded.dm
@@ -1,6 +1,8 @@
 /obj/effect/overmap/visitable/sector/exoplanet/shrouded
 	name = "shrouded exoplanet"
 	desc = "An exoplanet shrouded in a perpetual storm of bizzare, light absorbing particles."
+	scan_summary = "Cold, rocky exoplanet with a dense atmospheric layer of light-absorbing particulates that block all sunlight from reaching the surface. Vast stretches of empty desert are interspersed with warmer, low-elevation valleys and depressions in the surface."
+	scan_assessment = "No surface light. Xenofauna may present a hazard to away teams."
 	color = "#783ca4"
 	planetary_area = /area/exoplanet/shrouded
 	rock_colors = list(COLOR_INDIGO, COLOR_DARK_BLUE_GRAY, COLOR_NAVY_BLUE)

--- a/code/modules/overmap/exoplanets/planet_types/snow.dm
+++ b/code/modules/overmap/exoplanets/planet_types/snow.dm
@@ -1,6 +1,8 @@
 /obj/effect/overmap/visitable/sector/exoplanet/snow
 	name = "snow exoplanet"
 	desc = "Cold planet with limited plant life."
+	scan_summary = "Frigid, mountainous exoplanet with a snowy surface. Large poles are covered in glacial ice, and most of the planet is uninhabitable to known life. Conditions within the planet's warmer equatorial regions may support sparse plant and animal life."
+	scan_assessment = "Pressure suits or other cold protection are required to safely explore the surface."
 	color = "#dcdcdc"
 	planetary_area = /area/exoplanet/snow
 	rock_colors = list(COLOR_DARK_BLUE_GRAY, COLOR_GUNMETAL, COLOR_GRAY80, COLOR_DARK_GRAY)

--- a/code/modules/overmap/exoplanets/planet_types/volcanic.dm
+++ b/code/modules/overmap/exoplanets/planet_types/volcanic.dm
@@ -1,6 +1,8 @@
 /obj/effect/overmap/visitable/sector/exoplanet/volcanic
 	name = "volcanic exoplanet"
 	desc = "A tectonically unstable planet, extremely rich in minerals."
+	scan_summary = "Tectonically unstable planet with an extremely hot atmosphere. Surface predictions indicate many surface lava flows as well as oceans of molten rock, and the atmospheric conditions are dominated by frequent ash storms."
+	scan_assessment = "Surface lava presents an extreme hazard for away crews. Use heavy caution."
 	color = "#9c2020"
 	planetary_area = /area/exoplanet/volcanic
 	rock_colors = list(COLOR_DARK_GRAY)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -109,6 +109,16 @@
 	desc = "Sector with some stuff in it."
 	icon_state = "sector"
 	anchored = TRUE
+	/**
+	 * A detailed summary of this sector based on what a scan report would show.
+	 * These aren't strictly defined, but some things for inspiration might include: topographical scans, energy readings, life signs...
+	 */
+	var/scan_summary = null
+	/**
+	 * This is displayed on sensor scan readouts if non-null, and is used for things like exoplanet classes.
+	 * Keep it brief, with things like "EVA suits required", "high mineral content", etc.
+	 */
+	var/scan_assessment = null
 
 
 /obj/effect/overmap/visitable/sector/Initialize()

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -1,5 +1,7 @@
 /datum/random_map/noise/ore
 	descriptor = "ore distribution map"
+	/// Displayed by running sensor scans over a map template with this distribution type, if available.
+	var/scan_info = null
 	var/deep_val = 0.8              // Threshold for deep metals, set in new as percentage of cell_range.
 	var/rare_val = 0.7              // Threshold for rare metal, set in new as percentage of cell_range.
 	var/chunk_size = 4              // Size each cell represents on map
@@ -104,13 +106,16 @@
 /datum/random_map/noise/ore/filthy_rich
 	deep_val = 0.6
 	rare_val = 0.4
+	scan_info = "Extremely rich."
 
 /datum/random_map/noise/ore/rich
 	deep_val = 0.7
 	rare_val = 0.5
-	
+	scan_info = "High."
+
 /datum/random_map/noise/ore/poor
 	deep_val = 0.8
 	rare_val = 0.7
 	min_rare_ratio = 0.02
 	min_rare_ratio = 0.01
+	scan_info = "Low."


### PR DESCRIPTION
## About the Pull Request

This PR changes the appearance of printed scans for exoplanets by separating them into more distinct sections, and spreading the information out across multiple lines. It also gives much more detailed descriptions for each of the exoplanet classes, with the goal of giving more insight into how they function and where the landing sites might be on them, and includes the mineral content with regards to mining drills.

It also changes exoplanet name generation to be based off of real-life standards for naming exoplanets. Current names are randomly determined by a last name followed by a Greek letter. The new names follow the convention of:

`(system name) (letter)`

Where the system name represents the star system that the round takes place in and the letter is assigned sequentially based on the planet name. Old algorithm generates names such as `Caldwell-Theta` and `Blaine-Phi`; the new algorithm generates names such as `Luyten 307 a` and `GSC Eridani 963 b`.

Both of these things aren't mutually exclusive, so if feedback is negative on one part of the PR, the other can be kept without any consequences.

Finally, I also repathed lush and life-seeded exoplanets to match their types, instead of `/grass` and `/grass/terraformed`, and updated the file name from `grass.dm` to `lush.dm`.

## Why It's Good For The Game

I think that, for the aspiring scientist or explorer, having a more coherent and detailed readout about the way exoplanets function is a lot more immersive. This is partially based on personal experience - I remember being excited to learn more about exoplanets, then discovering that the scans were really barebones. I'm hopeful that the scan bit can change that.

The name update is also made to be more immersive. The Torch is an exploration ship, and giving the exoplanets names that are truer to real-life science feels (to me at least) like a cooler take, and makes alien planets really feel *alien*; paradoxically, I think that that's because the much more nonspecific name gives a stronger impression that this really *is* somewhere far from explored territory.

## Did you test it?

Compiles and runs. I scanned many exoplanets during creation of the PR - both admin-spawned and natural - to verify that things worked correctly on different skill levels.

## Media

<details><summary>Example 1 - shrouded exo</summary>

![image](https://user-images.githubusercontent.com/47678781/131240125-5fd36fce-5a23-4afb-a2dc-bb15ac6ff1d3.png)
![image](https://user-images.githubusercontent.com/47678781/131240127-65aa0713-0dcf-4d92-a84b-7ea2698b6b62.png)

</details>

<details><summary>Example 2 - volcanic exo</summary>

![image](https://user-images.githubusercontent.com/47678781/131240161-4b60420e-c26a-46c7-9398-87a2be47cc91.png)
![image](https://user-images.githubusercontent.com/47678781/131240164-f6eefae1-d987-462e-b721-94a8073e28c8.png)

</details>

<details><summary>Example 3 - life-seeded exo with Basic science skill</summary>

![image](https://user-images.githubusercontent.com/47678781/131240173-2a72518f-7279-4597-b12f-1c5d64dde4d8.png)
![image](https://user-images.githubusercontent.com/47678781/131240186-46e91554-99b9-49fd-bbfe-7178e8d15a20.png)

</details>

## Changelog

:cl:
grammar: Exoplanets are now named based on the system they're in instead of generated based on random names - for instance, a planet might be named "GJ 171 a" instead of "Owens-Epsilon".
grammar: Each exoplanet class has a much more detailed description when scanned.
tweak: Reformatted printed exoplanet scan reports.
tweak: Exoplanet scans now show the estimated amount of minerals on the planet (for mining drills).
/:cl: