### PR TITLE
xenobotany and ai fixes

### DIFF
--- a/code/controllers/subsystems/plants.dm
+++ b/code/controllers/subsystems/plants.dm
@@ -81,6 +81,7 @@ PROCESSING_SUBSYSTEM_DEF(plants)
 /datum/controller/subsystem/processing/plants/proc/create_random_seed(var/survive_on_station)
 	var/datum/seed/seed = new()
 	seed.randomize()
+	seed.uid = seeds.len + 1
 	seed.name = "[seed.uid]"
 	seeds[seed.name] = seed
 

--- a/code/modules/ai/ai_holder_combat.dm
+++ b/code/modules/ai/ai_holder_combat.dm
@@ -63,7 +63,7 @@
 			// Nudge them a bit, maybe they can shoot next time.
 			var/turf/T = get_step(holder, pick(GLOB.cardinal))
 			if (T)
-				holder.IMove(get_dir(holder, T)) // IMove() will respect movement cooldown.
+				holder.IMove(get_step_towards(holder, T)) // IMove() will respect movement cooldown.
 				holder.face_atom(target)
 			ai_log("engage_target() : Could not safely fire at target. Exiting.", AI_LOG_DEBUG)
 			return

--- a/code/modules/ai/ai_holder_movement.dm
+++ b/code/modules/ai/ai_holder_movement.dm
@@ -125,7 +125,7 @@
 		var/turf/T = src.path[1]
 		T.overlays -= path_overlay
 
-	if (holder.IMove(get_dir(holder, src.path[1])) != MOVEMENT_ON_COOLDOWN)
+	if (holder.IMove(get_step_towards(holder, src.path[1])) != MOVEMENT_ON_COOLDOWN)
 		if (holder.loc != src.path[1])
 			ai_log("move_once() : Failed step. Exiting.", AI_LOG_TRACE)
 			return MOVEMENT_FAILED
@@ -152,7 +152,7 @@
 			var/moving_to = 0 // Apparently this is required or it always picks 4, according to the previous developer for simplemob AI.
 			moving_to = pick(GLOB.cardinal)
 			holder.set_dir(moving_to)
-			holder.IMove(moving_to)
+			holder.IMove(get_step(holder, moving_to))
 			wander_delay = base_wander_delay
 	ai_log("handle_wander_movement() : Exited.", AI_LOG_TRACE)
 

--- a/code/modules/ai/interfaces.dm
+++ b/code/modules/ai/interfaces.dm
@@ -72,14 +72,12 @@
 
 // Respects move cooldowns as if it had a client.
 // Also tries to avoid being superdumb with moving into certain tiles (unless that's desired).
-/mob/living/proc/IMove(dir, safety = TRUE)
+/mob/living/proc/IMove(turf/newloc, safety = TRUE)
 
-	var/turf/newloc
-	if (istype(dir, /turf))
-		newloc = dir
-		dir = get_dir(src, dir)
-	else
-		newloc = get_step(src, dir)
+	if (!newloc)
+		return MOVEMENT_FAILED
+
+	var/dir = get_dir(src, newloc)
 
 	if (!checkMoveCooldown())
 		return MOVEMENT_ON_COOLDOWN


### PR DESCRIPTION
## About the Pull Request

<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
 bug with xenobotany having limited amounts of seeds is fixes aswell as mobs not breaking through turfs when attacking. xenobotany [pr](https://github.com/Baystation12/Baystation12/pull/31104) 
ai [pr](https://github.com/Baystation12/Baystation12/pull/31109)
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bug fixes are very good indeed. Grug needs their plants and ai being broken is also bad..
## Did you test it?

<!--
Please decribe if you ran local tests to ensure compilation. If that is not the case, please make it abundantly clear so a maintainer knows they need to run local checks.
Note that this can include own balancing/gameplay tests, but does not need to.
-->
runs and compiles
## Changelog

:cl: Mucker, Hubblenaut , Sky
bugfix: Mobs not trying to break through solid turf when attacking
bugfix: Xenobotany can now grow unlimited seeds
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
