### PR TITLE
Ghosts can view the contents of backpacks and other storage items.

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -155,7 +155,7 @@
 	//Bypassing storage procedures when not using help intent for labeler/forensic tools.
 	if((istype(W, /obj/item/hand_labeler) || istype(W, /obj/item/forensics)) && user.a_intent != I_HELP)
 		return FALSE
-	
+
 	// Don't allow insertion of unsafed compressed matter implants
 	// Since they are sucking something up now, their afterattack will delete the storage
 	if(istype(W, /obj/item/implanter/compressed))
@@ -303,6 +303,10 @@
 			storage_ui.on_hand_attack(user)
 	src.add_fingerprint(user)
 	return
+
+/obj/item/storage/attack_ghost(mob/user)
+	if(user.client)
+		show_to(user)
 
 /obj/item/storage/proc/gather_all(var/turf/T, var/mob/user)
 	var/success = 0


### PR DESCRIPTION
## About the Pull Request

Ghosts will see the contents of the storage item by clicking on it. That's all.

## Why It's Good For The Game

Ghosts could already see what's inside lockers and such. Following same logic - I don't see why ghosts shouldn't be able to look into backpacks on the ground.

## Did you test it?

Yes.

## Changelog

:cl:
tweak: Ghosts can click on backpacks/boxes/other storage devices to see their contents.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
