### PR TITLE
Glide smoothing

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -427,3 +427,5 @@
 #define DO_INCAPACITATED     (-3)
 
 #define FAKE_INVIS_ALPHA_THRESHOLD 127 // If something's alpha var is at or below this number, certain things will pretend it is invisible.
+
+#define ADJUSTED_GLIDE_SIZE(DELAY) (CEILING((WORLD_ICON_SIZE / max((DELAY), world.tick_lag) * world.tick_lag) - world.tick_lag, 1) + (config.glide_size_delay))

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -130,6 +130,7 @@ var/list/gamemode_cache = list()
 	var/skill_sprint_cost_range = 0.8
 	var/minimum_stamina_recovery = 1
 	var/maximum_stamina_recovery = 3
+	var/glide_size_delay = 1
 
 	//Mob specific modifiers. NOTE: These will affect different mob types in different ways
 	var/maximum_mushrooms = 15 //After this amount alive, mushrooms will not boom boom
@@ -806,6 +807,8 @@ var/list/gamemode_cache = list()
 					config.minimum_stamina_recovery = value
 				if("maximum_stamina_recovery")
 					config.maximum_stamina_recovery = value
+				if("glide_size_delay")
+					config.glide_size_delay = value
 
 				if("maximum_mushrooms")
 					config.maximum_mushrooms = value

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -136,9 +136,10 @@
 	var/next_move
 
 /datum/movement_handler/mob/delay/DoMove(var/direction, var/mover, var/is_external)
-	if(is_external)
-		return
-	next_move = world.time + max(1, mob.movement_delay())
+	if(!is_external)
+		var/delay = max(1, mob.movement_delay())
+		next_move = world.time + delay
+		mob.glide_size = ADJUSTED_GLIDE_SIZE(delay)
 
 /datum/movement_handler/mob/delay/MayMove(var/mover, var/is_external)
 	if(IS_NOT_SELF(mover) && is_external)

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -324,6 +324,7 @@
 	return current_grab.ladder_carry
 
 /obj/item/grab/proc/assailant_moved()
+	affecting.glide_size = assailant.glide_size
 	current_grab.assailant_moved(src)
 
 /obj/item/grab/proc/restrains()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -154,6 +154,7 @@ default behaviour is:
 					for(var/obj/structure/window/win in get_step(AM,t))
 						now_pushing = 0
 						return
+				AM.glide_size = glide_size
 				step(AM, t)
 				if (istype(AM, /mob/living))
 					var/mob/living/tmob = AM

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -47,6 +47,9 @@ SKILL_SPRINT_COST_RANGE 0.8
 MINIMUM_STAMINA_RECOVERY 5
 MAXIMUM_STAMINA_RECOVERY 5
 
+## Set this to 0 for perfectly smooth movement gliding, or 1 or more for delayed chess move style movements.
+#GLIDE_SIZE_DELAY 0
+
 ### Miscellaneous ###
 
 ## Config options which, of course, don't fit into previous categories.


### PR DESCRIPTION
## About the Pull Request

Ports NebulaSS13/Nebula/pull/1342

Allows more smooth movement.

## Why It's Good For The Game

As I said - smooth movement simply looks better when you aren't moving like a chess piece.

+ It's a config option which we can disable/enable at any time.

## Did you test it?

I tested it and it works as expected without runtimes.

## Changelog

:cl:
tweak: Smooth movement!
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
