### PR TITLE
Quick-equip now works for backpacks/storage items.

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -107,6 +107,34 @@ var/list/slot_equipment_priority = list( \
 			newitem.forceMove(S)
 			return S
 
+// This proc is for inserting items when game is active, as opposed to proc above, which I think is used for outfits.
+/mob/proc/equip_to_storage_active(obj/item/I)
+	// Try put it in their backpack
+	if(istype(src.back,/obj/item/storage))
+		var/obj/item/storage/backpack = src.back
+		if(backpack.can_be_inserted(I, null, 1))
+			backpack.handle_item_insertion(I)
+			if (backpack.use_sound) // Play sound if item is inserted into the backpack.
+				playsound(backpack.loc, backpack.use_sound, 50, 1, -5)
+			return TRUE
+		// If you can't insert object into the backpack - look for other storage spaces inside of it, like boxes.
+		for(var/obj/item/storage/S in backpack.contents)
+			if(S.can_be_inserted(I, null, 1))
+				S.handle_item_insertion(I)
+				if (S.use_sound)
+					playsound(S.loc, S.use_sound, 50, 1, -5)
+				return TRUE
+
+	// Try to place it in any item that can store stuff, on the mob.
+	for(var/obj/item/storage/S in src.contents)
+		if(S.can_be_inserted(I, null, 1))
+			S.handle_item_insertion(I)
+			if (S.use_sound)
+				playsound(S.loc, S.use_sound, 50, 1, -5)
+			return TRUE
+
+	return FALSE
+
 /mob/proc/equip_to_storage_or_drop(obj/item/newitem)
 	var/stored = equip_to_storage(newitem)
 	if(!stored && newitem)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -21,6 +21,11 @@ This saves us from having to call add_fingerprint() any time something is put in
 				update_inv_l_hand(0)
 			else
 				update_inv_r_hand(0)
+		else if(H.equip_to_storage_active(I))
+			if(hand)
+				update_inv_l_hand(0)
+			else
+				update_inv_r_hand(0)
 		else
 			to_chat(H, "<span class='warning'>You are unable to equip that.</span>")
 


### PR DESCRIPTION
## About the Pull Request

If you press E(quick-equip) and the active item does not have an empty slot for it - it will attempt to be put inside of a backpack.
If that fails - it will search for a storage item within a backpack, like box. If that fails too - it will be put into any other storage item on you, like belt.

## Why It's Good For The Game

Better. Faster.

It's easier to put items into your storage space now, especially if there is a lot of them.

## Did you test it?

Yes, had to test it few times until I got it working.

## Changelog

:cl:
rscadd: Quick-equip hotkey (E) now can put items inside of a backpack or any other storage item.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
