### PR TITLE
Adds fix-air admin verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -10,7 +10,8 @@ var/list/admin_verbs_default = list(
 	/client/proc/watched_variables,
 	/client/proc/debug_global_variables,//as above but for global variables,
 //	/client/proc/check_antagonists,		//shows all antags,
-	/client/proc/cmd_check_new_players
+	/client/proc/cmd_check_new_players,
+	/client/proc/fix_air				// fix air in certain range,
 //	/client/proc/deadchat				//toggles deadchat on/off,
 	)
 var/list/admin_verbs_admin = list(

--- a/code/modules/admin/verbs/grief_fixers.dm
+++ b/code/modules/admin/verbs/grief_fixers.dm
@@ -1,3 +1,29 @@
+/client/proc/fix_air(turf/simulated/T in world)
+	set name = "Fix Air"
+	set category = "Admin"
+	set desc = "Fixes air in specified radius."
+
+	if(!check_rights(R_ADMIN))
+		return
+	var/range=input("Enter range:","Num",2) as num
+	if(range >= 17)
+		to_chat(usr, SPAN_DANGER("Do not input range above 16! If you need to reset entire ship - use Fix-Atmospherics-Grief verb instead."))
+		return
+	var/list/changed_zones = new() // List of zones that have been already reset
+	for(var/turf/simulated/F in range(range,T))
+		if(F.blocks_air || (F.zone in changed_zones) || !F.initial_gas)
+		//skip turfs that block air, don't have initial_gas or zones that have been updated.
+			continue
+		if(!F.zone || !F.zone.air || !F.zone.air.gas || !F.zone.air.temperature)
+		//all required variables should be in place
+			continue
+		F.zone.air.gas = F.initial_gas.Copy()
+		F.zone.air.temperature = F.temperature
+		SSair.mark_zone_update(F.zone)
+		changed_zones.Add(F.zone)
+	if(changed_zones)
+		log_and_message_admins("[usr] fixed air with range [range] in area [T.loc.name]. [changed_zones.len] [(changed_zones.len) > 1 ? "zones have" : "zone has"] been affected.")
+
 /client/proc/fixatmos()
 	set category = "Admin"
 	set name = "Fix Atmospherics Grief"


### PR DESCRIPTION
## About the Pull Request

Adds "Fix air" verb. It should be used for fixing air problems in a short range, unlike "Fix Atmospherics Grief" which resets entire system.

## Why It's Good For The Game

Easier and less laggy way to fix air in short range.

## Did you test it?

Yes, it works, but I am still not entirely sure if it's the best way to implement this feature.

## Changelog

:cl:
admin: Added admin verb "Fix air".
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
