### PR TITLE
Psionic fixes #1

### DIFF
--- a/code/modules/psionics/complexus/complexus_helpers.dm
+++ b/code/modules/psionics/complexus/complexus_helpers.dm
@@ -1,5 +1,6 @@
-/datum/psi_complexus/proc/cancel()
-	sound_to(owner, sound('sound/effects/psi/power_fail.ogg'))
+/datum/psi_complexus/proc/cancel(var/play_sound = TRUE)
+	if(play_sound)
+		sound_to(owner, sound('sound/effects/psi/power_fail.ogg'))
 	if(LAZYLEN(manifested_items))
 		for(var/thing in manifested_items)
 			owner.drop_from_inventory(thing)
@@ -75,6 +76,9 @@
 	// Can't backblast if you're controlling your power.
 	if(!owner || suppressed)
 		return FALSE
+
+	owner.psi.cancel(FALSE)
+	owner.psi.hide_auras()
 
 	sound_to(owner, sound('sound/effects/psi/power_feedback.ogg'))
 	to_chat(owner, "<span class='danger'><font size=3>Wild energistic feedback blasts across your psyche!</font></span>")

--- a/code/modules/psionics/faculties/energistics.dm
+++ b/code/modules/psionics/faculties/energistics.dm
@@ -60,6 +60,10 @@
 	use_description = "Use this ranged laser attack while on harm intent. Your mastery of Energistics will determine how powerful the laser is. Be wary of overuse, and try not to fry your own brain."
 
 /decl/psionic_power/energistics/zorch/invoke(var/mob/living/user, var/mob/living/target)
+	if(!user || !target)
+		return
+	if(target.z != user.z)
+		return
 	. = ..()
 	if(.)
 		user.visible_message("<span class='danger'>\The [user]'s eyes flare with light!</span>")
@@ -69,18 +73,18 @@
 		var/pew_sound
 
 		switch(user_rank)
-			if(PSI_RANK_PARAMOUNT)
+			if(PSI_RANK_PARAMOUNT to INFINITY) // In case of admin edits to faculty level
 				pew = new /obj/item/projectile/beam/heavylaser(get_turf(user))
 				pew.name = "gigawatt mental laser"
 				pew_sound = 'sound/weapons/lasercannonfire.ogg'
 			if(PSI_RANK_GRANDMASTER)
 				pew = new /obj/item/projectile/beam/midlaser(get_turf(user))
 				pew.name = "megawatt mental laser"
-				pew_sound = 'sound/weapons/Laser.ogg'
+				pew_sound = 'sound/weapons/Laser3.ogg'
 			if(PSI_RANK_MASTER)
-				pew = new /obj/item/projectile/beam/stun(get_turf(user))
+				pew = new /obj/item/projectile/beam/smalllaser(get_turf(user))
 				pew.name = "mental laser"
-				pew_sound = 'sound/weapons/Taser.ogg'
+				pew_sound = 'sound/weapons/Laser.ogg'
 
 		if(istype(pew))
 			playsound(pew.loc, pew_sound, 25, 1)
@@ -88,7 +92,11 @@
 			pew.current = target
 			pew.starting = get_turf(user)
 			pew.shot_from = user
-			pew.launch(target, user.zone_sel.selecting, (target.x-user.x), (target.y-user.y))
+			if(istype(target)) // Target is a mob, so we can shoot directly at them
+				pew.launch(target, user.zone_sel.selecting, user)
+			else
+				var/turf/targloc = get_turf(target)
+				pew.launch(targloc, user.zone_sel.selecting, user)
 			return TRUE
 
 /decl/psionic_power/energistics/spark


### PR DESCRIPTION
## About the Pull Request

- Fixes psionic lasers not working at all.
- Fixes issue with backblast where overlay will remain on the character despite psi powers being suppressed.
- Changes stun laser to a weak laser for consistency.

## Why It's Good For The Game

- Fix!
- Fix!
- Consistency! It didn't make much sense to switch from a stun laser to a damage laser in one level.

## Did you test it?

Yes, it works.

## Changelog

:cl:
fix: Psionic lasers work again, rejoice!
fix: Psionic Users that suffer from backblast won't have their overlays broken anymore.
tweak: Psionic laser on master level of energistics is no longer stun projectile. Now it's a weak damaging laser.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
