### PR TITLE
Telekinesis buff + mini fix

### DIFF
--- a/code/modules/psionics/equipment/psipower_tk.dm
+++ b/code/modules/psionics/equipment/psipower_tk.dm
@@ -1,6 +1,6 @@
 /obj/item/psychic_power/telekinesis
 	name = "telekinetic grip"
-	maintain_cost = 6
+	maintain_cost = 1
 	icon_state = "telekinesis"
 	var/atom/movable/focus
 
@@ -34,7 +34,9 @@
 		. = attack_self(owner)
 		if(!.)
 			to_chat(owner, SPAN_WARNING("\The [_focus] is too hefty for you to get a mind-grip on."))
-		qdel(src)
+		else
+			owner.visible_message("<span class='notice'>\The [owner] makes a strange gesture.</span>")
+		owner.drop_from_inventory(src)
 		return FALSE
 
 	focus = _focus
@@ -52,11 +54,13 @@
 
 /obj/item/psychic_power/telekinesis/afterattack(var/atom/target, var/mob/living/user, var/proximity)
 
-	if(!target || !user || (isobj(target) && !isturf(target.loc)) || !user.psi || !user.psi.can_use() || !user.psi.spend_power(8))
+	if(!target || !user || (isobj(target) && !isturf(target.loc)) || !user.psi || !user.psi.can_use() || !user.psi.spend_power(5))
 		return
 
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN * 2)
-	user.psi.set_cooldown(8)
+	var/user_rank = owner.psi.get_rank(PSI_PSYCHOKINESIS) // Can only be above/equal to 4
+
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN * (8 / user_rank))
+	user.psi.set_cooldown((32 / user_rank))
 
 	var/user_psi_leech = user.do_psionics_check(5, user)
 	if(user_psi_leech)
@@ -79,16 +83,19 @@
 		sparkle()
 		if(!istype(target, /turf) && istype(focus,/obj/item) && target.Adjacent(focus))
 			var/obj/item/I = focus
-			var/resolved = target.attackby(I, user, user:get_organ_target())
+			var/resolved = target.attackby(I, user, user.get_organ_target())
 			if(!resolved && target && I)
 				I.afterattack(target,user,1) // for splashing with beakers
 		else
 			if(!focus.anchored)
-				var/user_rank = owner.psi.get_rank(PSI_PSYCHOKINESIS)
-				focus.throw_at(target, user_rank*2, user_rank*3, owner)
+				focus.throw_at(target, min(user_rank, 10), min(user_rank*2, 20), owner)
 			sleep(1)
 			sparkle()
-		owner.drop_from_inventory(src)
+		if(user_rank < PSI_RANK_PARAMOUNT) // Memes
+			owner.drop_from_inventory(src)
+
+	if(!user.psi.spend_power(2)) // So you can't spam-click kill everything that moves
+		return FALSE
 
 /obj/item/psychic_power/telekinesis/proc/sparkle()
 	set waitfor = 0

--- a/code/modules/psionics/faculties/psychokinesis.dm
+++ b/code/modules/psionics/faculties/psychokinesis.dm
@@ -78,15 +78,4 @@
 				tk.sparkle()
 				user.visible_message("<span class='notice'>\The [user] reaches out.</span>")
 				return tk
-		else if(istype(target, /obj/structure))
-			user.visible_message("<span class='notice'>\The [user] makes a strange gesture.</span>")
-			var/obj/O = target
-			O.attack_hand(user)
-			return TRUE
-		else if(istype(target, /obj/machinery))
-			for(var/mtype in valid_machine_types)
-				if(istype(target, mtype))
-					var/obj/machinery/machine = target
-					machine.attack_hand(user)
-					return TRUE
 	return FALSE

--- a/code/modules/psionics/mob/mob_assay.dm
+++ b/code/modules/psionics/mob/mob_assay.dm
@@ -49,7 +49,10 @@
 					rating_descriptor = "This indicates the presence of significant psi capabilities of the Grandmaster rank or higher."
 				if(5)
 					use_rating = "<font color = '#FF0000'>[effective_rating]-Alpha</font>"
-					rating_descriptor = "This indicates the presence of major psi capabilities of the Paramount Grandmaster rank or higher."
+					rating_descriptor = "This indicates the presence of major psi capabilities of the Paramount Grandmaster rank."
+				if(6 to INFINITY)
+					use_rating = "<font color = '#FF0000'><b>[effective_rating]-Omega</b></font>"
+					rating_descriptor = "This indicates an abnormal presence of psi capabilities outside of any recorded spectrum, far beyond that of Paramount rank. Approach with care."
 				else
 					use_rating = "[effective_rating]-Lambda"
 					rating_descriptor = "This indicates the presence of trace latent psi capabilities."
@@ -65,7 +68,10 @@
 			for(var/faculty_id in psi.ranks)
 				var/decl/psionic_faculty/faculty = SSpsi.get_faculty(faculty_id)
 				if(psi.ranks[faculty.id] > 0)
-					dat += "[use_He_is] assayed at the rank of <b>[GLOB.psychic_ranks_to_strings[psi.ranks[faculty.id]]]</b> for the <b>[faculty.name] faculty</b>.<br>"
+					if(psi.ranks[faculty.id] < 6) // Within normal levels
+						dat += "[use_He_is] assayed at the rank of <b>[GLOB.psychic_ranks_to_strings[psi.ranks[faculty.id]]]</b> for the <b>[faculty.name] faculty</b>.<br>"
+					else // If someone wants to have a funny adminbus with level 99 psionics
+						dat += "[use_He_is] assayed at the rank of <b>Supreme Master ([psi.ranks[faculty.id]])</b> for the <b>[faculty.name] faculty</b>.<br>"
 				else
 					dat += "[use_He_has] no notable power within the <b>[faculty.name] faculty</b>.<br>"
 			dat += "<hr>"


### PR DESCRIPTION
## About the Pull Request

- Telekinesis cooldown and overall power scales with your level of psychokinesis faculty.
- Maintaining telekinetic grab takes much less stamina.
- Throwing items/mobs with telekinesis now takes 2 stamina.
- The speed and range of telekinesis throw is nerfed.
- mob_assay will now work for admin-edited faculty levels (anything above paramount).
- Removed checks for machinery and structures that weren't called anyway.

## Why It's Good For The Game

- You can now roleplay as sans (Undertale) :trollface:
- On a more serious note - makes more difference between faculty levels for this specific faculty.
- No more spam-click insta-kills with telekinesis.
- See above. You can't easily destroy someone anymore.
- Fixes bug.
- Cleaner code.

## Did you test it?

Yes, level 32 psychokinesis is really fun.
If anyone is concerned about balance - at level 5 it isn't *much* stronger than 4, except you get to keep your grasp after throwing.

## Changelog

:cl:
tweak: Telekinesis powers scale with your psychokinesis level. At paramount - you won't release a grasp on item/mob after throw as well.
tweak: Telekinesis throws are overall less damaging and take more stamina to perform.
fix: Admin-edited psy levels won't break your information screen for psionics.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
