### PR TITLE
Roundstart webhook is being called earlier

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -49,6 +49,7 @@ SUBSYSTEM_DEF(ticker)
 			post_game_tick()
 
 /datum/controller/subsystem/ticker/proc/pregame_tick()
+	callHook("roundstart") // As soon as initialization is complete
 	if(start_ASAP)
 		start_now()
 		return
@@ -94,8 +95,6 @@ SUBSYSTEM_DEF(ticker)
 			var/datum/job/job = SSjobs.get_by_title(H.mind.assigned_role)
 			if(job && job.create_record)
 				CreateModularRecord(H)
-
-	callHook("roundstart")
 
 	spawn(0)//Forking here so we dont have to wait for this to finish
 		mode.post_setup() // Drafts antags who don't override jobs.


### PR DESCRIPTION
## About the Pull Request

The roundstart webhook will be called once initialization is complete instead of being called once round started.

## Why It's Good For The Game

Gives players more time to join the fresh round.

## Did you test it?

Alas, I can't. Should work nonetheless.
