### PR TITLE
Autofire is pixel-precise

### DIFF
--- a/code/_onclick/MouseDrag.dm
+++ b/code/_onclick/MouseDrag.dm
@@ -11,13 +11,13 @@
 	var/obj/item/gun/gun = get_active_hand()
 	var/list/click_params = params2list(params)
 	if(istype(over_object) && (isturf(over_object) || isturf(over_object.loc)) && !incapacitated() && istype(gun) && !click_params["shift"])
-		gun.set_autofire(over_object, src)
+		gun.set_autofire(over_object, src, params)
 
 /mob/proc/OnMouseDown(atom/object, location, control, params)
 	var/obj/item/gun/gun = get_active_hand()
 	var/list/click_params = params2list(params)
 	if(istype(object) && (isturf(object) || isturf(object.loc)) && !incapacitated() && istype(gun) && !click_params["shift"])
-		gun.set_autofire(object, src)
+		gun.set_autofire(object, src, params)
 
 /mob/proc/OnMouseUp(atom/object, location, control, params)
 	var/obj/item/gun/gun = get_active_hand()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -105,6 +105,7 @@
 	var/atom/autofiring_at
 	var/mob/autofiring_by
 	var/autofiring_timer
+	var/autofiring_params
 
 /obj/item/gun/Initialize()
 	. = ..()
@@ -121,9 +122,10 @@
 	// autofire timer is automatically cleaned up
 	autofiring_at = null
 	autofiring_by = null
+	autofiring_params = null
 	. = ..()
 
-/obj/item/gun/proc/set_autofire(var/atom/fire_at, var/mob/fire_by)
+/obj/item/gun/proc/set_autofire(var/atom/fire_at, var/mob/fire_by, var/params)
 	. = TRUE
 	if(!istype(fire_at) || !istype(fire_by))
 		. = FALSE
@@ -134,6 +136,7 @@
 	if(.)
 		autofiring_at = fire_at
 		autofiring_by = fire_by
+		autofiring_params = params
 		if(!autofiring_timer)
 			autofiring_timer = addtimer(CALLBACK(src, .proc/handle_autofire), burst_delay, (TIMER_STOPPABLE | TIMER_LOOP | TIMER_UNIQUE | TIMER_OVERRIDE))
 	else
@@ -142,6 +145,7 @@
 /obj/item/gun/proc/clear_autofire()
 	autofiring_at = null
 	autofiring_by = null
+	autofiring_params = null
 	if(autofiring_timer)
 		deltimer(autofiring_timer)
 		autofiring_timer = null
@@ -159,7 +163,7 @@
 		clear_autofire()
 	else if(can_autofire())
 		autofiring_by.set_dir(get_dir(src, autofiring_at))
-		Fire(autofiring_at, autofiring_by, null, (get_dist(autofiring_at, autofiring_by) <= 1), FALSE, FALSE)
+		Fire(autofiring_at, autofiring_by, autofiring_params, (get_dist(autofiring_at, autofiring_by) <= 1), FALSE, FALSE)
 
 /obj/item/gun/update_twohanding()
 	if(one_hand_penalty)


### PR DESCRIPTION
## About the Pull Request

An attempt to make autofire pixel-precise (as in - consider click parameters).
This attempt works but isn't the best.

## Why It's Good For The Game

The last(?) remnant of stupid non-precise projectiles will be gone.

## Did you test it?

I tested it with a few full-auto guns and there is only one problem: The parameters are updated when the mouse is dragged onto a new tile/atom.
If anyone knows how to make it update on mouse movement instead - I'd like to hear your ideas.

## Changelog

:cl:
tweak: Full-auto fire mode is now pixel-precise.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
