### PR TITLE
Ice is now visible in drinks and water no longer makes noise

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -91,12 +91,12 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 
 		if(LAZYLEN(R.chilling_products) && temperature <= R.chilling_point)
 			replace_self_with = R.chilling_products
-			replace_message =   "\The [lowertext(R.name)] [R.chilling_message]"
+			replace_message =   R.chilling_message ? "\The [lowertext(R.name)] [R.chilling_message]" : null
 			replace_sound =     R.chilling_sound
 
 		else if(LAZYLEN(R.heating_products) && temperature >= R.heating_point)
 			replace_self_with = R.heating_products
-			replace_message =   "\The [lowertext(R.name)] [R.heating_message]"
+			replace_message =   R.heating_message ? "\The [lowertext(R.name)] [R.heating_message]" : null
 			replace_sound =     R.heating_sound
 
 		// If it is, handle replacing it with the decay product.

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -90,8 +90,12 @@
 	glass_desc = "The father of all refreshments."
 	chilling_products = list(/datum/reagent/drink/ice)
 	chilling_point = T0C
+	chilling_message = null
+	chilling_sound = null
 	heating_products = list(/datum/reagent/water/boiling)
 	heating_point = T100C
+	heating_message = null
+	heating_sound = null
 	value = 0
 
 /datum/reagent/water/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -194,7 +198,7 @@
 	glass_desc = "Generally, you're supposed to put something else in there too..."
 	glass_icon = DRINK_ICON_NOISY
 
-	heating_message = "cracks and melts."
+	heating_message = null
 	heating_products = list(/datum/reagent/water)
 	heating_point = 299 // This is about 26C, higher than the actual melting point of ice but allows drinks to be made properly without weird workarounds.
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -226,15 +226,20 @@
 	else
 		return ..()
 
-/obj/item/reagent_containers/examine(mob/user)
+/obj/item/reagent_containers/examine(mob/user, distance)
 	. = ..()
 	if(!reagents)
 		return
+	if(distance < 2 && is_open_container() && reagents.has_reagent(/datum/reagent/drink/ice))
+		if(reagents.get_reagent_amount(/datum/reagent/drink/ice) == reagents.total_volume)
+			to_chat(user, SPAN_NOTICE("It's completely frozen.")) //If ice volume = total volume, then there is only ice in here
+		else
+			to_chat(user, SPAN_NOTICE("You see some ice floating around in it."))
 	if(hasHUD(user, HUD_SCIENCE))
 		var/prec = user.skill_fail_chance(SKILL_CHEMISTRY, 10)
-		to_chat(user, "<span class='notice'>The [src] contains: [reagents.get_reagents(precision = prec)].</span>")
+		to_chat(user, SPAN_NOTICE("The [src] contains: [reagents.get_reagents(precision = prec)]."))
 	else if((loc == user) && user.skill_check(SKILL_CHEMISTRY, SKILL_EXPERIENCED))
-		to_chat(user, "<span class='notice'>Using your chemistry knowledge, you identify the following reagents in \the [src]: [reagents.get_reagents(!user.skill_check(SKILL_CHEMISTRY, SKILL_MASTER), 5)].</span>")
+		to_chat(user, SPAN_NOTICE("Using your chemistry knowledge, you identify the following reagents in \the [src]: [reagents.get_reagents(!user.skill_check(SKILL_CHEMISTRY, SKILL_MASTER), 5)]."))
 
 /obj/item/reagent_containers/ex_act(severity)
 	if(reagents)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -51,11 +51,11 @@
 		return
 
 	if(reagents && reagents.reagent_list.len)
-		to_chat(user, "<span class='notice'>It contains [reagents.total_volume] units of liquid.</span>")
+		to_chat(user, SPAN_NOTICE("It contains [reagents.total_volume] units of liquid."))
 	else
-		to_chat(user, "<span class='notice'>It is empty.</span>")
+		to_chat(user, SPAN_NOTICE("It is empty."))
 	if(!is_open_container())
-		to_chat(user, "<span class='notice'>The airtight lid seals it completely.</span>")
+		to_chat(user, SPAN_NOTICE("The airtight lid seals it completely."))
 
 /obj/item/reagent_containers/glass/attack_self()
 	..()


### PR DESCRIPTION
## About the Pull Request

When examining drinks when adjacent, you can now see if they either contain ice or are completely made up of ice. The latter is mostly designed for water bottles.

This coincides with a change where water (and ice) no longer make sounds or messages when changing their state due to freezing/melting. (Water will still make a sound when it boils.)

Alternative to #209.

![image](https://user-images.githubusercontent.com/25853190/144318586-f3329b57-d9cc-46b0-abfa-95c23a9493ad.png)

## Why It's Good For The Game

Puts an end to the dreaded ration crate water bottle sfx permanently and also lets people see at a glance if there is ice in their drink. Which you shouldn't need a PhD in chemistry to know.

## Did you test it?

Yes.

## Changelog

:cl:
tweak: You can now see if a drink contains ice or is completely ice when examining it while close by.
tweak: Water no longer makes a sound or plays a message when freezing, and ice no longer makes a sound or plays a message when melting.
bugfix: Because of the above, water bottles will no longer invade your ears or your chat when opening/closing freezers containing them.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
