### PR TITLE
Quick .dme fix

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3277,7 +3277,6 @@
 #include "maps\random_ruins\exoplanet_ruins\oldlab2\oldlab2.dm"
 #include "maps\random_ruins\exoplanet_ruins\oldpod\oldpod.dm"
 #include "maps\random_ruins\exoplanet_ruins\pizza_shuttle\pizza_shuttle.dm"
-#include "maps\random_ruins\exoplanet_ruins\pizza_shuttle\pizza_shuttle.dmm"
 #include "maps\random_ruins\exoplanet_ruins\playablecolony\playablecolony.dm"
 #include "maps\random_ruins\exoplanet_ruins\playablecolony2\playablecolony2.dm"
 #include "maps\random_ruins\exoplanet_ruins\radshrine\radshrine.dm"


### PR DESCRIPTION
## About the Pull Request

Fixes a tiny issue made in #208 that I didn't notice and removes .dmm from .dme file.

## Why It's Good For The Game

The .dmm file of a ruin shouldn't be loaded on compile.

## Did you test it?

No reasons to test it.

