### PR TITLE
Singularity tweaks

### DIFF
--- a/code/modules/power/singularity/act.dm
+++ b/code/modules/power/singularity/act.dm
@@ -12,6 +12,8 @@
 	return 20
 
 /mob/living/singularity_pull(S, current_size)
+	if(Check_Shoegrip()) // Magboots prevent it from happening
+		return
 	step_towards(src, S)
 	apply_damage(current_size * 3, IRRADIATE, damage_flags = DAM_DISPERSED)
 
@@ -78,7 +80,7 @@
 	log_and_message_admins("New super singularity made by eating a SM crystal [prints]. Last touched by [src.fingerprintslast].")
 	src.forceMove(null)
 	qdel(src)
-	return 50000
+	return 500000 // Exactly enough for final stage
 
 /obj/item/projectile/beam/emitter/singularity_pull()
 	return


### PR DESCRIPTION
## About the Pull Request

Singularity at later stages can now travel between z-levels.
Stages now require more energy. More so for the final stage.
"Toxmob" event is replaced with simply irradiating area because it basically does the same thing while also considering radiation protection.
EMP range changes between stages from tiny 5 range on the first stage, to gigantic 13 range on the last.
Singularity will fail to pull mobs that wear magboots(and other stuff, probably).

## Why It's Good For The Game

Singularity is now a real threat, given that before this PR - singulo would've only traveled on one z-level.
Before this PR - singularity could progress from stage 1 to stage 5 almost instantly. The final "supermatter" stage now requires 500000 energy because why tf would it normally appear without eating supermatter?
Toxmob was basically a hack that ignored radiation protection so it's replaced.
EMP range scaling with stage will make containing smaller singularities much easier.
Wearing (active) magboots now makes sense near singularity, as it should be.

## Did you test it?

Yes, works as expected.

## Changelog

:cl:
tweak: Singularity can now travel between z-levels.
tweak: Singularity now takes more energy to progress stages.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
