### PR TITLE
Removes intercoms processing

### DIFF
--- a/code/game/area/area_power.dm
+++ b/code/game/area/area_power.dm
@@ -25,6 +25,8 @@
 /area/proc/power_change()
 	for(var/obj/machinery/M in src)	// for each machine in the area
 		M.power_change()			// reverify power status (to update icons etc.)
+	for(var/obj/item/device/radio/intercom/I in src) // better than processing hundreds of those each tick
+		I.power_change()
 	if (fire || eject || party)
 		update_icon()
 

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -88,11 +88,6 @@
 	frequency = ENT_FREQ
 	canhear_range = 4
 
-/obj/item/device/radio/intercom/Initialize()
-	. = ..()
-	START_PROCESSING(SSobj, src)
-	update_icon()
-
 /obj/item/device/radio/intercom/department/medbay/Initialize()
 	. = ..()
 	internal_channels = GLOB.default_medbay_channels.Copy()
@@ -134,10 +129,6 @@
 	. = ..()
 	internal_channels[num2text(RAID_FREQ)] = list(access_syndicate)
 
-/obj/item/device/radio/intercom/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	return ..()
-
 /obj/item/device/radio/intercom/attack_ai(mob/user)
 	add_fingerprint(user)
 	attack_self(user)
@@ -161,22 +152,16 @@
 
 	return canhear_range
 
-/obj/item/device/radio/intercom/Process()
-	if(((world.timeofday - last_tick) > 30) || ((world.timeofday - last_tick) < 0))
-		last_tick = world.timeofday
-		var/old_on = on
-
-		if(!src.loc)
+/obj/item/device/radio/intercom/proc/power_change()
+	if(!src.loc)
+		on = 0
+	else
+		var/area/A = get_area(src)
+		if(!A)
 			on = 0
 		else
-			var/area/A = get_area(src)
-			if(!A)
-				on = 0
-			else
-				on = A.powered(EQUIP) // set "on" to the power status
-
-		if (on != old_on)
-			update_icon()
+			on = A.powered(EQUIP) // set "on" to the power status
+	update_icon()
 
 /obj/item/device/radio/intercom/on_update_icon()
 	if(!on)


### PR DESCRIPTION
## About the Pull Request

Ports ChaoticOnyx/OnyxBay/pull/3701
Intercoms won't be processed anymore.
Instead, the process functionality is put in power_change() proc.

## Why It's Good For The Game

Less useless calls.

## Did you test it?

Yes, I did. Works as intended.

## Changelog

Not a player-facing change.

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
