### PR TITLE
Add toggle aim mode as a keybind

### DIFF
--- a/code/modules/keybindings/living.dm
+++ b/code/modules/keybindings/living.dm
@@ -36,3 +36,14 @@
 	var/mob/living/L = user.mob
 	L.drop_item()
 	return TRUE
+
+/datum/keybinding/living/aim_mode
+	hotkey_keys = list("N")
+	name = "toggle_aim_mode"
+	full_name = "Toggle Aim Mode"
+	description = "Toggle between hip fire and aiming."
+
+/datum/keybinding/living/aim_mode/down(client/user)
+	var/mob/living/L = user.mob
+	L.aiming.toggle_active()
+	return TRUE


### PR DESCRIPTION
## About the Pull Request

You can now toggle aim mode (between snapshot and active aiming) with a keybind, defaulting to N.

## Why It's Good For The Game

With the new PR you had to click the icon instead which was significantly smelly. This makes it easier for players who use that featurel.

## Did you test it?

Yes

## Changelog

:cl:
tweak: New keybind: Toggle Aim Mode. This will swap between snapshot and active aiming modes; default key is N.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
