### PR TITLE
Spider leap attack check

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/hunter.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/hunter.dm
@@ -38,6 +38,12 @@
 	return ..()
 
 
+/mob/living/simple_animal/hostile/giant_spider/hunter/can_special_attack(atom/A)
+	. = ..()
+	if(.)
+		return check_solid_ground()
+	return FALSE
+
 // The actual leaping attack.
 /mob/living/simple_animal/hostile/giant_spider/hunter/do_special_attack(atom/A)
 	set waitfor = FALSE


### PR DESCRIPTION
## About the Pull Request

Fixes #227 

Spider hunter won't be able to leap in space/without gravity.

## Why It's Good For The Game

It makes no sense for spiders to be able to jump in area where they'd normally be unable to move.

## Did you test it?

Yes.

## Changelog

:cl:
fix: Giant spiders can't leap in space anymore.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
