### PR TITLE
Fix stethoscope, change unathi heart sounds

### DIFF
--- a/code/modules/clothing/under/accessories/stethoscope.dm
+++ b/code/modules/clothing/under/accessories/stethoscope.dm
@@ -9,7 +9,7 @@
 		if(user.a_intent == I_HELP)
 			var/obj/item/organ/organ = M.get_organ(user.zone_sel.selecting)
 			if(organ)
-				user.visible_message("[user] places [src] against [M]'s [organ.name] and listens attentively.", 
-									 "You place [src] against [M]'s [organ.name]. You hear [english_list(organ.listen())].")
+				user.visible_message("\The [user] places \the [src] against \the [M]'s [organ.name] and listens attentively.",
+									 "You place \the [src] against \the [M]'s [organ.name]. You hear \a [english_list(organ.listen())].")
 				return
 	return ..(M,user)

--- a/code/modules/organs/internal/species/unathi.dm
+++ b/code/modules/organs/internal/species/unathi.dm
@@ -6,3 +6,14 @@
 
 /obj/item/organ/internal/brain/unathi
 	can_use_mmi = FALSE
+
+/obj/item/organ/internal/heart/unathi
+	name = "separated heart"
+	desc = "A heart separated into two organs, each with their own chambers. Both are much larger than your fist."
+
+/obj/item/organ/internal/heart/unathi/listen()
+	. = ..()
+	if(!pulse || (owner.status_flags & FAKEDEATH))
+		return .
+	var/pulsesound = splittext(., " ")[1]
+	return "\proper two [pulsesound] pulses"

--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -85,7 +85,8 @@
 
 	override_organ_types = list(
 		BP_EYES = /obj/item/organ/internal/eyes/unathi,
-		BP_BRAIN = /obj/item/organ/internal/brain/unathi
+		BP_BRAIN = /obj/item/organ/internal/brain/unathi,
+		BP_HEART = /obj/item/organ/internal/heart/unathi
 	)
 
 	descriptors = list(


### PR DESCRIPTION
## About the Pull Request

Listening from a stethoscope now displays articles where they should be. In addition, unathi hearts now sound like two hearts (as they are separated biologically).

Unathi hearts do not have separate sprites because I cannot sprite to save my life. If anyone wants to contribute some they are welcome to, but I don't think it's a deal breaker.

## Why It's Good For The Game

Bug fix and lore consistency.

## Did you test it?

Yes

![image](https://user-images.githubusercontent.com/25853190/146118469-e5e87a10-6afe-4851-a5f6-71c3f3c51788.png)

## Changelog

:cl:
bugfix: Using a stethoscope is now formatted correctly.
tweak: Unathi hearts now sound like two individual pulses.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
