### PR TITLE
Containment field + PA console tweaks

### DIFF
--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -14,7 +14,7 @@
 	movable_flags = MOVABLE_FLAG_PROXMOVE
 	var/obj/machinery/field_generator/FG1 = null
 	var/obj/machinery/field_generator/FG2 = null
-	var/hasShocked = 0 //Used to add a delay between shocks. In some cases this used to crash servers by spawning hundreds of sparks every second.
+	var/shock_cooldown
 
 /obj/machinery/containment_field/Destroy()
 	if(FG1 && !FG1.clean_up)
@@ -26,38 +26,66 @@
 /obj/machinery/containment_field/physical_attack_hand(mob/user)
 	return shock(user)
 
+/obj/machinery/containment_field/attackby(obj/item/W, mob/user)
+	shock(user)
+	return TRUE
+
 /obj/machinery/containment_field/ex_act(severity)
-	return 0
+	return FALSE
 
-/obj/machinery/containment_field/HasProximity(atom/movable/AM as mob|obj)
-	if(istype(AM,/mob/living/silicon) && prob(40))
+/obj/machinery/containment_field/Move()
+	qdel(src)
+	return FALSE
+
+/obj/machinery/containment_field/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	if(istype(mover, /mob/living) || istype(mover, /obj/machinery) || istype(mover, /obj/structure))
+		return FALSE
+	return TRUE
+
+/obj/machinery/containment_field/Bumped(atom/movable/AM)
+	if(shock_cooldown > world.time)
+		return
+	if(istype(AM, /mob/living))
 		shock(AM)
-		return 1
-	if(istype(AM,/mob/living/carbon) && prob(50))
+		return
+	if(istype(AM, /obj/machinery) || istype(AM, /obj/structure))
+		bump_field(AM)
+	return
+
+/obj/machinery/containment_field/Crossed(atom/movable/AM)
+	. = ..()
+	if(istype(AM, /mob/living))
 		shock(AM)
-		return 1
-	return 0
 
-
+	if(istype(AM, /obj/machinery) || istype(AM, /obj/structure))
+		bump_field(AM)
 
 /obj/machinery/containment_field/shock(mob/living/user as mob)
-	if(hasShocked)
-		return 0
+	if(shock_cooldown > world.time)
+		return FALSE
 	if(!FG1 || !FG2)
 		qdel(src)
-		return 0
+		return FALSE
 	if(isliving(user))
-		hasShocked = 1
+		shock_cooldown = world.time + 10
 		var/shock_damage = min(rand(30,40),rand(30,40))
 		user.electrocute_act(shock_damage, src)
 
 		var/atom/target = get_edge_target_turf(user, get_dir(src, get_step_away(user, src)))
 		user.throw_at(target, 200, 4)
 
-		sleep(20)
-
-		hasShocked = 0
 		return TRUE
+
+/obj/machinery/containment_field/proc/bump_field(atom/movable/AM as obj)
+	if(shock_cooldown > world.time)
+		return FALSE
+	shock_cooldown = world.time + 10
+	playsound(loc, "sparks", 50, 1, -1)
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(5, 1, loc)
+	s.start()
+	var/atom/target = get_edge_target_turf(AM, get_dir(src, get_step_away(AM, src)))
+	AM.throw_at(target, 200, 4)
 
 /obj/machinery/containment_field/proc/set_master(var/master1,var/master2)
 	if(!master1 || !master2)

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -50,7 +50,7 @@
 		update_use_power(POWER_USE_IDLE)
 		active = 0
 		connected_parts = list()
-
+	power_change()
 	return
 
 /obj/machinery/particle_accelerator/control_box/on_update_icon()


### PR DESCRIPTION
## About the Pull Request

- PA console will update its power status each time someone tries to interact with it. This fixes an issue with permanently "powered down" console.
- Containment fields now shock/throw mobs/objects only when they are tring to move into it or touch it. The "cooldown" on this has also been shortened and sleep() has been removed from the proc.

## Why It's Good For The Game

- Fixes a bug/oversight.
- Makes containment fields much less random and forces them to make some sense.

## Did you test it?

![Uploading image.png…]()

## Changelog

:cl:
tweak: Containment fields now shock mobs and structures only when they move into them, instead of randomly doing that when in close proximity.
fix: Particle Accelerator console will now work properly.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
