### PR TITLE
Simple mob combat tweaks

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -20,7 +20,7 @@
 /proc/living_observers_present(var/list/zlevels)
 	if(LAZYLEN(zlevels))
 		for(var/mob/M in GLOB.player_list) //if a tree ticks on the empty zlevel does it really tick
-			if(M.stat != DEAD) //(no it doesn't)
+			if(M.stat != DEAD || istype(M, /mob/observer)) //(no it doesn't)
 				var/turf/T = get_turf(M)
 				if(T && (T.z in zlevels))
 					return TRUE

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -48,7 +48,6 @@
 
 
 /mob/proc/death(gibbed,deathmessage="seizes up and falls limp...", show_dead_message = "You have died.")
-
 	if(stat == DEAD)
 		return 0
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -198,7 +198,7 @@ default behaviour is:
 
 /mob/living/proc/updatehealth()
 	if(status_flags & GODMODE)
-		health = 100
+		health = maxHealth
 		set_stat(CONSCIOUS)
 	else
 		health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss() - getHalLoss()

--- a/code/modules/mob/living/simple_animal/combat.dm
+++ b/code/modules/mob/living/simple_animal/combat.dm
@@ -13,6 +13,9 @@
 		. = ATTACK_SUCCESSFUL //Shoving this in here as a 'best guess' since this proc is about to sleep and return and we won't be able to know the real value
 		handle_attack_delay(A, melee_attack_delay) // This will sleep this proc for a bit, which is why waitfor is false.
 
+	if(stat == DEAD) // In case you died during that attack_delay
+		return
+
 	// Cooldown testing is done at click code (for players) and interface code (for AI).
 	setClickCooldown(get_attack_speed(get_natural_weapon()))
 
@@ -70,6 +73,9 @@
 			try_reload()
 			return FALSE
 
+	if(stat == DEAD) // In case you died during that attack_delay
+		return
+
 	visible_message("<span class='danger'><b>\The [src]</b> fires at \the [A]!</span>")
 	shoot(A)
 	if(casingtype)
@@ -101,7 +107,8 @@
 	// P.accuracy += calculate_accuracy()
 	P.dispersion += calculate_dispersion()
 
-	P.launch(target = A)
+	var/selected_zone = pick(BP_ALL_LIMBS) // Random limb targeting.
+	P.launch(A, selected_zone, src)
 	if(needs_reload)
 		reload_count++
 

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -9,6 +9,8 @@
 	maxHealth = 55
 	natural_weapon = /obj/item/natural_weapon/drone_slicer
 	projectiletype = /obj/item/projectile/beam/smalllaser
+	projectile_dispersion = 0.5
+	ranged_attack_delay = 3
 	faction = "hivebot"
 	min_gas = null
 	max_gas = null

--- a/code/modules/mob/living/simple_animal/life.dm
+++ b/code/modules/mob/living/simple_animal/life.dm
@@ -13,15 +13,10 @@
 			set_density(1)
 		return 0
 
-	handle_atmos()
-
-	if(health <= 0)
-		death()
-		return
-
 	if(health > maxHealth)
 		health = maxHealth
 
+	handle_atmos()
 	handle_stunned()
 	handle_weakened()
 	handle_paralysed()
@@ -33,6 +28,9 @@
 
 	if(can_bleed && bleed_ticks > 0)
 		handle_bleeding()
+
+	if(stat == DEAD)
+		return 1
 
 	if(buckled && can_escape)
 		if(istype(buckled, /obj/effect/energy_net))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -70,7 +70,7 @@
 	var/attack_sound = null				// Sound to play when I attack
 	var/attack_armor_pen = 0			// How much armor pen this attack has.
 
-	var/melee_attack_delay = 4			// If set, the mob will do a windup animation and can miss if the target moves out of the way.
+	var/melee_attack_delay = 2			// If set, the mob will do a windup animation and can miss if the target moves out of the way.
 	var/ranged_attack_delay = null
 	var/special_attack_delay = null
 
@@ -190,12 +190,12 @@
 		stat(null, "Health: [round((health / maxHealth) * 100)]%")
 
 /mob/living/simple_animal/death(gibbed, deathmessage = "dies!", show_dead_message)
+	. = ..(gibbed,deathmessage,show_dead_message)
 	icon_state = icon_dead
 	update_icon()
 	density = FALSE
 	adjustBruteLoss(maxHealth) //Make sure dey dead.
 	walk_to(src,0)
-	return ..(gibbed,deathmessage,show_dead_message)
 
 /mob/living/simple_animal/ex_act(severity)
 	if(!blinded)
@@ -229,6 +229,11 @@
 /mob/living/simple_animal/adjustOxyLoss(damage)
 	..()
 	updatehealth()
+
+/mob/living/simple_animal/updatehealth()
+	..()
+	if(stat != DEAD && health <= 0)
+		death()
 
 /mob/living/simple_animal/say(var/message)
 	var/verb = "says"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1075,8 +1075,10 @@
 	else
 		return ..()
 
-/mob/proc/set_stat(var/new_stat)
-	. = stat != new_stat
+/mob/proc/set_stat(new_stat)
+	if(new_stat == stat)
+		return
+	. = stat
 	stat = new_stat
 
 /mob/verb/northfaceperm()


### PR DESCRIPTION
## About the Pull Request

- Simple mobs no longer become immortal while no living players are watching.
- Simple mobs no longer have a delay between reaching 0 health and actually dying.
- Simple mobs now can't attack/shoot while dead.
- Ranged simple mobs now randomly choose limb when shooting at a target.
- Ranged hivebots now have a tiny fire delay and projectile dispersion.

Also a bit of code improvement/cleanup. Self-explanatory.

## Why It's Good For The Game

- Observe exoplanet as a ghost. 10 mobs fighting for eternity, literally wasting time. At least now they die.
- Funny mobs do not attack you before dying now and don't have a stupid delay that makes you waste an attack.
- A fix, basically. Also prevents few runtimes from happening.
- Fixes issue with attack logs and makes fighting ranged mobs a bit easier(?).
- Makes fighting against hivebots less unfair.

## Did you test it?

Yes, it works.

## Changelog

:cl:
tweak: Simple mobs no longer take ~2 seconds between the death message and actual death.
tweak: Simple mobs will now properly die when fighting each other without a living player in sight.
tweak: Ranged hivebots now have a fire delay and an increased projectile dispersion.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
