### PR TITLE
Random item stuns weakened & reduced

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -22,6 +22,8 @@
 	var/force = 0
 	var/attack_cooldown = DEFAULT_WEAPON_COOLDOWN
 	var/melee_accuracy_bonus = 0
+	/// Multiplier for use in human_defense.dm : Set to 0 for no random stuns.
+	var/stun_prob = 0.75
 
 	var/heat_protection = 0 //flags which determine which body parts are protected from heat. Use the HEAD, UPPER_TORSO, LOWER_TORSO, etc. flags. See setup.dm
 	var/cold_protection = 0 //flags which determine which body parts are protected from cold. Use the HEAD, UPPER_TORSO, LOWER_TORSO, etc. flags. See setup.dm

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -171,7 +171,7 @@ meteor_act
 	visible_message(SPAN_DANGER("\The [src] has been [I.attack_verb.len? pick(I.attack_verb) : "attacked"] in the [affecting.name][weapon_mention] by \the [user]!"))
 	return standard_weapon_hit_effects(I, user, effective_force, hit_zone)
 
-/mob/living/carbon/human/standard_weapon_hit_effects(obj/item/I, mob/living/user, var/effective_force, var/hit_zone)
+/mob/living/carbon/human/standard_weapon_hit_effects(obj/item/I, mob/living/user, effective_force, hit_zone)
 	var/obj/item/organ/external/affecting = get_organ(hit_zone)
 	if(!affecting)
 		return 0
@@ -192,24 +192,24 @@ meteor_act
 	else if(!..())
 		return 0
 
-	var/unimpeded_force = (1 - blocked) * effective_force
+	var/unimpeded_force = (1 - blocked) * effective_force * I.stun_prob
 	if(effective_force > 10 || effective_force >= 5 && prob(33))
 		forcesay(GLOB.hit_appends)	//forcesay checks stat already
 		radio_interrupt_cooldown = world.time + (RADIO_INTERRUPT_DEFAULT * 0.8) //getting beat on can briefly prevent radio use
-	if((I.damtype == BRUTE || I.damtype == PAIN) && prob(25 + (unimpeded_force * 2)))
+	if((I.damtype == BRUTE || I.damtype == PAIN) && prob(15 + (unimpeded_force * 2)))
 		if(!stat)
 			if(headcheck(hit_zone))
 				//Harder to score a stun but if you do it lasts a bit longer
 				if(prob(unimpeded_force))
-					apply_effect(20, PARALYZE, 100 * blocked)
-					if(lying)
+					if(!lying)
 						visible_message("<span class='danger'>[src] [species.knockout_message]</span>")
+					apply_effect(3, PARALYZE, 100 * blocked)
 			else
 				//Easier to score a stun but lasts less time
 				if(prob(unimpeded_force + 5))
-					apply_effect(3, WEAKEN, 100 * blocked)
-					if(lying)
+					if(!lying)
 						visible_message("<span class='danger'>[src] has been knocked down!</span>")
+					apply_effect(1.5, WEAKEN, 100 * blocked)
 
 		//Apply blood
 		attack_bloody(I, user, effective_force, hit_zone)

--- a/code/modules/mob/living/simple_animal/natural_weapons.dm
+++ b/code/modules/mob/living/simple_animal/natural_weapons.dm
@@ -3,6 +3,7 @@
 	gender = PLURAL
 	attack_verb = list("attacked")
 	force = 0
+	stun_prob = 0 // No random stuns
 	damtype = BRUTE
 	canremove = FALSE
 	obj_flags = OBJ_FLAG_CONDUCTIBLE //for intent of shocking checks, they're right inside the animal


### PR DESCRIPTION
## About the Pull Request

- All items now have "stun_prob" variable. It's a multiplier used in human_defense.dm which, as the name implies, adjusts the probability for random stun to occur. By default, it's at 0.75.
- Natural weapons used by simple mobs have "stun_prob" set to 0, so all their attacks won't be able to stun anyone.
- Stun durations were severely reduced. 20 seconds stun because random decided so is not healthy for gameplay.
- Improved(?) code a bit in some places.

## Why It's Good For The Game

- Allows us to choose whether the weapon can be a stupid stun machine or not.
- Stuns in combat with simple mobs are really, really bad.
- 20 seconds stuns are not healthy for gameplay.
- Just improvements here and there, i.e. removing "var/" in procs and switching some code around.

## Did you test it?

Yes, all works.

## Authorship

Me.

## Changelog

:cl:
tweak: Simple mobs can no longer randomly stun you in melee. Rejoice.
balance: Random weapon stuns are now much shorter: From 20 seconds to 3 seconds and from 3 to 1.5.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
