### PR TITLE
Allows Vox to hold limited positions on Torch

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -94,7 +94,7 @@
 		startswith = list(/obj/item/clothing/mask/breath/scba = 1,
 						/obj/item/tank/emergency/oxygen = 1,
 						/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline = 1,
-						/obj/item/reagent_containers/hypospray/autoinjector/pain,
+						/obj/item/reagent_containers/hypospray/autoinjector/pain = 1,
 						/obj/item/stack/medical/advanced/bruise_pack = 1,
 						/obj/item/device/flashlight/flare/glowstick = 1,
 						/obj/item/reagent_containers/food/snacks/proteinbar = 1,
@@ -106,11 +106,22 @@
 	desc = "A box decorated in warning colors that contains a limited supply of survival tools. The panel and black stripe indicate this one contains nitrogen."
 	icon_state = "survivalvox"
 	startswith = list(/obj/item/clothing/mask/breath = 1,
-					/obj/item/tank/emergency/nitrogen = 1,
+					/obj/item/tank/emergency/nitrogen/double = 2,
 					/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline = 1,
 					/obj/item/stack/medical/bruise_pack = 1,
 					/obj/item/device/flashlight/flare/glowstick = 1,
 					/obj/item/reagent_containers/food/snacks/proteinbar = 1)
+
+/obj/item/storage/box/vox/Initialize()
+	if(has_station_trait(/datum/station_trait/premium_crewbox))
+		startswith = list(/obj/item/clothing/mask/breath = 1,
+						/obj/item/tank/emergency/nitrogen/double = 2,
+						/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline = 1,
+						/obj/item/reagent_containers/hypospray/autoinjector/pain = 1,
+						/obj/item/stack/medical/advanced/bruise_pack = 1,
+						/obj/item/device/flashlight/flare/glowstick = 1,
+						/obj/item/reagent_containers/food/snacks/proteinbar = 1)
+	. = ..()
 
 /obj/item/storage/box/engineer
 	name = "engineer survival kit"
@@ -131,7 +142,7 @@
 						/obj/item/tank/emergency/oxygen/engi = 1,
 						/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline = 1,
 						/obj/item/reagent_containers/hypospray/autoinjector/antirad = 1,
-						/obj/item/reagent_containers/hypospray/autoinjector/pain,
+						/obj/item/reagent_containers/hypospray/autoinjector/pain = 1,
 						/obj/item/stack/medical/advanced/bruise_pack = 1,
 						/obj/item/device/flashlight/flare/glowstick = 1,
 						/obj/item/reagent_containers/food/snacks/proteinbar = 1,

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -123,11 +123,12 @@
 
 /datum/species/vox/equip_survival_gear(var/mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vox(H), slot_wear_mask)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H),slot_shoes)
 
-	if(istype(H.get_equipped_item(slot_back), /obj/item/storage/backpack))
-		H.equip_to_slot_or_del(new /obj/item/tank/nitrogen(H), slot_r_hand)
+	if(istype(H.get_equipped_item(slot_back), /obj/item/storage/backpack)) // This is mostly for station Vox
+		H.equip_to_slot_or_del(new /obj/item/tank/emergency/nitrogen/double(H), slot_belt)
 		H.equip_to_slot_or_del(new /obj/item/storage/box/vox(H.back), slot_in_backpack)
-		H.set_internals(H.r_hand)
+		H.set_internals(H.belt)
 	else
 		H.equip_to_slot_or_del(new /obj/item/tank/nitrogen(H), slot_back)
 		H.equip_to_slot_or_del(new /obj/item/storage/box/vox(H), slot_r_hand)

--- a/maps/torch/job/misc_jobs.dm
+++ b/maps/torch/job/misc_jobs.dm
@@ -62,7 +62,7 @@ Civilian
 	outfit_type = /decl/hierarchy/outfit/job/torch/merchant
 	allowed_branches = list(
 		/datum/mil_branch/civilian,
-		/datum/mil_branch/alien
+		/datum/mil_branch/alien = /decl/hierarchy/outfit/job/torch/merchant/vox
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/civ,

--- a/maps/torch/job/outfits/misc_outfits.dm
+++ b/maps/torch/job/outfits/misc_outfits.dm
@@ -32,6 +32,11 @@
 	pda_type = /obj/item/modular_computer/pda
 	id_types = list(/obj/item/card/id/torch/merchant)
 
+/decl/hierarchy/outfit/job/torch/merchant/vox
+	name = OUTFIT_JOB_NAME("Merchant - Torch (Vox)")
+	shoes = /obj/item/clothing/shoes/jackboots/unathi
+	uniform = /obj/item/clothing/under/vox/vox_robes
+
 /decl/hierarchy/outfit/job/torch/ert
 	name = OUTFIT_JOB_NAME("ERT - Torch")
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/combat

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -1,11 +1,26 @@
 /datum/map/torch
 	species_to_job_whitelist = list(
-		/datum/species/adherent = list(/datum/job/ai, /datum/job/cyborg, /datum/job/assistant, /datum/job/janitor, /datum/job/chef, /datum/job/bartender, /datum/job/cargo_tech,
-										/datum/job/engineer, /datum/job/roboticist, /datum/job/chemist, /datum/job/scientist_assistant, /datum/job/scientist, /datum/job/nt_pilot,
-										/datum/job/mining, /datum/job/doctor, /datum/job/senior_doctor),
-		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
-									 /datum/job/roboticist, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender),
-		/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg),
+		/datum/species/adherent = list(
+										/datum/job/ai, /datum/job/cyborg, /datum/job/assistant,
+										/datum/job/janitor, /datum/job/chef, /datum/job/bartender,
+										/datum/job/cargo_tech, /datum/job/engineer, /datum/job/roboticist,
+										/datum/job/chemist, /datum/job/scientist_assistant, /datum/job/scientist,
+										/datum/job/nt_pilot, /datum/job/mining, /datum/job/doctor, /datum/job/senior_doctor,
+										),
+		/datum/species/nabber = list(
+										/datum/job/ai, /datum/job/cyborg, /datum/job/janitor,
+										/datum/job/scientist_assistant, /datum/job/chemist,
+										/datum/job/roboticist, /datum/job/cargo_tech,
+										/datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender,
+									),
+		/datum/species/vox = list(
+									/datum/job/ai, /datum/job/cyborg,
+									/datum/job/doctor, /datum/job/junior_doctor, /datum/job/chemist,
+									/datum/job/scientist, /datum/job/scientist_assistant,
+									/datum/job/janitor, /datum/job/chef, /datum/job/bartender,
+									/datum/job/engineer, /datum/job/roboticist,
+									/datum/job/merchant, /datum/job/assistant,
+								),
 		/datum/species/human/mule = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
 	)
 

--- a/maps/torch/loadout/loadout_xeno.dm
+++ b/maps/torch/loadout/loadout_xeno.dm
@@ -22,6 +22,21 @@
 /datum/gear/uniform/harness
 	allowed_branches = null
 
+// Vox
+/datum/gear/uniform/vox_robes
+	display_name = "vox robes"
+	path = /obj/item/clothing/under/vox/vox_robes
+	sort_category = "Xenowear"
+	whitelisted = list(SPECIES_VOX)
+	allowed_branches = list(/datum/mil_branch/civilian, /datum/mil_branch/alien)
+
+/datum/gear/uniform/vox_casual
+	display_name = "vox casual clothes"
+	path = /obj/item/clothing/under/vox/vox_casual
+	sort_category = "Xenowear"
+	whitelisted = list(SPECIES_VOX)
+	allowed_branches = list(/datum/mil_branch/civilian, /datum/mil_branch/alien)
+
 // Patches
 /datum/gear/accessory/cultex_patch
 	display_name = "Cultural Exchange patch"

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -31,7 +31,6 @@
 		/datum/species/vox     = list(
 			/datum/mil_branch/expeditionary_corps,
 			/datum/mil_branch/fleet,
-			/datum/mil_branch/civilian,
 			/datum/mil_branch/solgov,
 			/datum/mil_branch/skrell_fleet
 		)
@@ -44,7 +43,7 @@
 		/datum/species/unathi       = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps, /datum/mil_branch/solgov, /datum/mil_branch/fleet),
 		/datum/species/unathi/yeosa = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps, /datum/mil_branch/solgov, /datum/mil_branch/fleet),
 		/datum/species/adherent     = list(/datum/mil_branch/civilian),
-		/datum/species/vox          = list(/datum/mil_branch/alien)
+		/datum/species/vox          = list(/datum/mil_branch/alien, /datum/mil_branch/civilian)
 	)
 
 	species_to_rank_blacklist = list(
@@ -147,6 +146,9 @@
 		/datum/species/vox = list(
 			/datum/mil_branch/alien = list(
 				/datum/mil_rank/alien
+			),
+			/datum/mil_branch/civilian = list(
+				/datum/mil_rank/civ/contractor
 			)
 		)
 	)


### PR DESCRIPTION
## About the Pull Request

- Vox can now hold several contractor-only positions on Torch.
- Vox survival boxes can now be affected by the "premium boxes" station trait.
- Vox now start with sandals on and emergency tank on the belt, instead of in hand.
- Added 2 Vox clothes loadout options.

## Why It's Good For The Game

- Vox ship is rather rare and this change was discussed with the Vox maintainer. For more info look in Discord.
- Makes sense for it to be affected by the trait that affects every other survival box.
- Vox can't wear normal footwear, just like Unathi. Station Vox would spawn with a tank in-hand and drop it due to being in cryo, so it is fixed.
- Fancy Vox clothes, if someone wants to choose them.

## Did you test it?

Yes, all works.

![vox-start](https://user-images.githubusercontent.com/53223414/148564832-ca488740-cbf3-4625-9f73-0a71bc42bc5b.png)

## Authorship

Me.

## Changelog

:cl:
tweak: Vox species can now work on SEV Torch. Their positions are heavily limited to contractor ranks only. They can also be a merchant now.
tweak: Added 2 Vox clothes options to loadouts.
tweak: Vox spawn with sandals on now.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
