### PR TITLE
Edit regeneration aura messages to be more natural

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -97,13 +97,13 @@
 		to_chat(src, SPAN_WARNING("You don't possess an innate healing ability."))
 		return
 	if(!aura.can_toggle())
-		to_chat(src, SPAN_WARNING("You can't toggle the healing at this time!"))
+		to_chat(src, SPAN_WARNING("Your body can't alter its healing processes at this time!"))
 		return
 	aura.toggle()
 	if (aura.innate_heal)
-		to_chat(src, "<span class='alium'>You are now using nutrients to regenerate.</span>")
+		to_chat(src, SPAN_CLASS("alium", "You shift your body's healing processes to use nutrients to regenerate."))
 	else
-		to_chat(src, "<span class='alium'>You are no longer using nutrients to regenerate.</span>")
+		to_chat(src, SPAN_CLASS("alium", "You shift your body's healing processes to no longer use nutrients to regenerate."))
 
 /mob/living/carbon/human/proc/change_colour()
 	set category = "Abilities"


### PR DESCRIPTION
## About the Pull Request

Regeneration auras now sound more natural instead of "You can't toggle the healing at this time!" and such.

## Why It's Good For The Game

Helps maintain immersion of the game.

## Did you test it?

Yes

## Changelog

:cl:
tweak: Toggling (or trying to toggle) regenerative auras provides more immersive messages.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
