### PR TITLE
Less slowdowns; Use Initialize() instead of New() when declaring slowdown_per_slot

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -109,8 +109,8 @@
 		bomb = ARMOR_BOMB_PADDED
 	)
 
-/obj/item/clothing/suit/cultrobes/magusred/New()
-	..()
+/obj/item/clothing/suit/cultrobes/magusred/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 1
 
 /obj/item/clothing/head/helmet/space/cult
@@ -145,6 +145,6 @@
 	siemens_coefficient = 0.2
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS
 
-/obj/item/clothing/suit/space/cult/New()
-	..()
+/obj/item/clothing/suit/space/cult/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 1

--- a/code/game/gamemodes/wizard/servant_items/familiar.dm
+++ b/code/game/gamemodes/wizard/servant_items/familiar.dm
@@ -8,12 +8,12 @@
 	desc = "It looks like a cross between Robin Hood's tunic and some patchwork leather armor. Whoever put this together must have been in a hurry."
 	icon_state = "familiartunic"
 	armor = list(
-		melee = ARMOR_MELEE_KNIVES, 
-		laser = ARMOR_LASER_MINOR, 
+		melee = ARMOR_MELEE_KNIVES,
+		laser = ARMOR_LASER_MINOR,
 		energy = ARMOR_ENERGY_SMALL
 	)
 	species_restricted = list(SPECIES_HUMAN)
 
-/obj/item/clothing/under/familiargard/New()
-	..()
-	slowdown_per_slot[slot_w_uniform] = -3
+/obj/item/clothing/under/familiargard/Initialize()
+	. = ..()
+	slowdown_per_slot[slot_w_uniform] = -2

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -203,11 +203,9 @@
 	w_class = ITEM_SIZE_HUGE
 	max_storage_space = DEFAULT_BACKPACK_STORAGE + 10
 
-/obj/item/storage/backpack/dufflebag/New()
-	..()
-	slowdown_per_slot[slot_back] = 3
-	slowdown_per_slot[slot_r_hand] = 1
-	slowdown_per_slot[slot_l_hand] = 1
+/obj/item/storage/backpack/dufflebag/Initialize()
+	. = ..()
+	slowdown_per_slot[slot_back] = 1
 
 /obj/item/storage/backpack/dufflebag/syndie
 	name = "black dufflebag"
@@ -215,9 +213,9 @@
 	icon_state = "duffle_syndie"
 	item_state_slots = list(slot_l_hand_str = "duffle_syndie", slot_r_hand_str = "duffle_syndie")
 
-/obj/item/storage/backpack/dufflebag/syndie/New()
-	..()
-	slowdown_per_slot[slot_back] = 1
+/obj/item/storage/backpack/dufflebag/syndie/Initialize()
+	. = ..()
+	slowdown_per_slot[slot_back] = 0
 
 /obj/item/storage/backpack/dufflebag/syndie/med
 	name = "medical dufflebag"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -507,10 +507,6 @@
 	item_state = "swatbelt"
 	storage_slots = 10
 
-/obj/item/storage/belt/holster/security/tactical/Initialize()
-	.=..()
-	slowdown_per_slot[slot_belt] = 1
-
 /obj/item/storage/belt/waistpack
 	name = "waist pack"
 	desc = "A small bag designed to be worn on the waist. May make your butt look big."
@@ -531,7 +527,7 @@
 	max_storage_space = ITEM_SIZE_NORMAL * 4
 
 /obj/item/storage/belt/waistpack/big/Initialize()
-	.=..()
+	. = ..()
 	slowdown_per_slot[slot_belt] = 1
 
 /obj/item/storage/belt/fire_belt

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -21,11 +21,11 @@
 	icon_state = "swat"
 	force = 3
 	armor = list(
-		melee = ARMOR_MELEE_VERY_HIGH, 
-		bullet = ARMOR_BALLISTIC_RIFLE, 
+		melee = ARMOR_MELEE_VERY_HIGH,
+		bullet = ARMOR_BALLISTIC_RIFLE,
 		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_SMALL, 
-		bomb = ARMOR_BOMB_RESISTANT, 
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_MINOR
 		)
 	item_flags = ITEM_FLAG_NOSLIP
@@ -37,11 +37,11 @@
 	icon_state = "jungle"
 	force = 5
 	armor = list(
-		melee = ARMOR_MELEE_VERY_HIGH, 
-		bullet = ARMOR_BALLISTIC_RIFLE, 
+		melee = ARMOR_MELEE_VERY_HIGH,
+		bullet = ARMOR_BALLISTIC_RIFLE,
 		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_SMALL, 
-		bomb = ARMOR_BOMB_RESISTANT, 
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_MINOR
 		)
 	item_flags = ITEM_FLAG_NOSLIP
@@ -58,11 +58,11 @@
 	icon_state = "jungle"
 	force = 3
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT, 
-		bullet = ARMOR_BALLISTIC_MINOR, 
-		laser = ARMOR_LASER_MINOR, 
-		energy = ARMOR_ENERGY_MINOR, 
-		bomb = ARMOR_BOMB_PADDED, 
+		melee = ARMOR_MELEE_RESISTANT,
+		bullet = ARMOR_BALLISTIC_MINOR,
+		laser = ARMOR_LASER_MINOR,
+		energy = ARMOR_ENERGY_MINOR,
+		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_MINOR
 		)
 	siemens_coefficient = 0.7
@@ -73,11 +73,11 @@
 	icon_state = "desert"
 	force = 3
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT, 
-		bullet = ARMOR_BALLISTIC_MINOR, 
-		laser = ARMOR_LASER_MINOR, 
-		energy = ARMOR_ENERGY_MINOR, 
-		bomb = ARMOR_BOMB_PADDED, 
+		melee = ARMOR_MELEE_RESISTANT,
+		bullet = ARMOR_BALLISTIC_MINOR,
+		laser = ARMOR_LASER_MINOR,
+		energy = ARMOR_ENERGY_MINOR,
+		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_MINOR
 		)
 	siemens_coefficient = 0.7
@@ -87,9 +87,9 @@
 	desc = "A pair of steel-toed synthleather boots with a mirror shine."
 	icon_state = "duty"
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT, 
-		energy = ARMOR_ENERGY_MINOR, 
-		bomb = ARMOR_BOMB_PADDED, 
+		melee = ARMOR_MELEE_RESISTANT,
+		energy = ARMOR_ENERGY_MINOR,
+		bomb = ARMOR_BOMB_PADDED,
 		rad = ARMOR_RAD_MINOR
 		)
 	siemens_coefficient = 0.7
@@ -106,10 +106,10 @@
 	icon_state = "desert"
 	force = 3
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT, 
-		bullet = ARMOR_BALLISTIC_PISTOL, 
-		laser = ARMOR_LASER_HANDGUNS, 
-		energy = ARMOR_ENERGY_SMALL, 
+		melee = ARMOR_MELEE_RESISTANT,
+		bullet = ARMOR_BALLISTIC_PISTOL,
+		laser = ARMOR_LASER_HANDGUNS,
+		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_RESISTANT)
 	siemens_coefficient = 0.7
 
@@ -151,8 +151,8 @@
 	species_restricted = null
 	can_add_hidden_item = FALSE
 
-/obj/item/clothing/shoes/clown_shoes/New()
-	..()
+/obj/item/clothing/shoes/clown_shoes/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_shoes]  = 1
 
 /obj/item/clothing/shoes/clown_shoes/handle_movement(var/turf/walking, var/running)
@@ -217,8 +217,8 @@
 	can_add_hidden_item = FALSE
 	can_add_cuffs = FALSE
 
-/obj/item/clothing/shoes/swimmingfins/New()
-	..()
+/obj/item/clothing/shoes/swimmingfins/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_shoes] = 1
 
 /obj/item/clothing/shoes/athletic

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -19,8 +19,8 @@
 	species_restricted = list(SPECIES_VOX, SPECIES_VOX_ARMALIS)
 	flags_inv = HIDEJUMPSUIT
 
-/obj/item/clothing/suit/space/vox/New()
-	..()
+/obj/item/clothing/suit/space/vox/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 1
 
 /obj/item/clothing/head/helmet/space/vox

--- a/code/modules/clothing/spacesuits/captain.dm
+++ b/code/modules/clothing/spacesuits/captain.dm
@@ -10,12 +10,12 @@
 	flags_inv = HIDEFACE|BLOCKHAIR
 	permeability_coefficient = 0.01
 	armor = list(
-		melee = ARMOR_MELEE_MAJOR, 
-		bullet = ARMOR_BALLISTIC_RESISTANT, 
+		melee = ARMOR_MELEE_MAJOR,
+		bullet = ARMOR_BALLISTIC_RESISTANT,
 		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_SMALL, 
-		bomb = ARMOR_BOMB_RESISTANT, 
-		bio = ARMOR_BIO_SHIELDED, 
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_RESISTANT,
+		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL
 		)
 
@@ -36,12 +36,12 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
 	allowed = list(/obj/item/tank/emergency, /obj/item/device/flashlight,/obj/item/gun/energy, /obj/item/gun/projectile, /obj/item/ammo_magazine, /obj/item/ammo_casing, /obj/item/melee/baton,/obj/item/handcuffs)
 	armor = list(
-		melee = ARMOR_MELEE_MAJOR, 
-		bullet = ARMOR_BALLISTIC_RESISTANT, 
+		melee = ARMOR_MELEE_MAJOR,
+		bullet = ARMOR_BALLISTIC_RESISTANT,
 		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_SMALL, 
-		bomb = ARMOR_BOMB_RESISTANT, 
-		bio = ARMOR_BIO_SHIELDED, 
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_RESISTANT,
+		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL
 		)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
@@ -49,6 +49,6 @@
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.7
 
-/obj/item/clothing/suit/armor/captain/New()
-	..()
+/obj/item/clothing/suit/armor/captain/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 1.5

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -36,8 +36,8 @@
 	icon_state = "santa"
 	allowed = list(/obj/item) //for stuffing exta special presents
 
-/obj/item/clothing/suit/space/santa/New()
-	..()
+/obj/item/clothing/suit/space/santa/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 0
 
 //Orange emergency space suit
@@ -53,9 +53,9 @@
 	icon_state = "space_emergency"
 	desc = "A thin, ungainly softsuit colored in blaze orange for rescuers to easily locate. Looks pretty fragile."
 
-/obj/item/clothing/suit/space/emergency/New()
-	..()
-	slowdown_per_slot[slot_wear_suit] = 4
+/obj/item/clothing/suit/space/emergency/Initialize()
+	. = ..()
+	slowdown_per_slot[slot_wear_suit] = 3
 
 /obj/item/clothing/head/helmet/space/fishbowl
 	name = "spacesuit helmet"

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -134,6 +134,6 @@
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_DIONA)
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
 
-/obj/item/clothing/suit/space/New()
-	..()
+/obj/item/clothing/suit/space/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 1

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -36,12 +36,6 @@
 		)
 	siemens_coefficient = 0.3
 
-/obj/item/clothing/suit/space/syndicate/New()
-	..()
-	slowdown_per_slot[slot_wear_suit] = 1
-
-
-
 //Black syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black
 	name = "black space helmet"
@@ -55,6 +49,3 @@
 		slot_l_hand_str = "syndicate-black",
 		slot_r_hand_str = "syndicate-black",
 	)
-
-
-

--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -59,9 +59,9 @@
 		SPECIES_VOX = 'icons/obj/clothing/species/vox/obj_suit_vox.dmi'
 		)
 
-/obj/item/clothing/suit/space/void/merc/New()
-	..()
-	slowdown_per_slot[slot_wear_suit] = 1
+/obj/item/clothing/suit/space/void/merc/Initialize()
+	. = ..()
+	slowdown_per_slot[slot_wear_suit] = 0.5
 
 /obj/item/clothing/suit/space/void/merc/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/merc

--- a/code/modules/clothing/spacesuits/void/misc.dm
+++ b/code/modules/clothing/spacesuits/void/misc.dm
@@ -17,8 +17,8 @@
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
 	siemens_coefficient = 0.6
 
-/obj/item/clothing/suit/space/void/swat/New()
-	..()
+/obj/item/clothing/suit/space/void/swat/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 1
 
 //Skrell space gear. Sleek like a wetsuit.

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -41,8 +41,8 @@
 		)
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd,/obj/item/rpd)
 
-/obj/item/clothing/suit/space/void/engineering/New()
-	..()
+/obj/item/clothing/suit/space/void/engineering/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 1
 
 /obj/item/clothing/suit/space/void/engineering/prepared
@@ -252,8 +252,8 @@
 		rad = ARMOR_RAD_SHIELDED
 		)
 
-/obj/item/clothing/suit/space/void/engineering/alt/New()
-	..()
+/obj/item/clothing/suit/space/void/engineering/alt/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 2
 
 /obj/item/clothing/suit/space/void/engineering/alt/prepared
@@ -303,8 +303,8 @@
 		rad = ARMOR_RAD_RESISTANT
 		)
 
-/obj/item/clothing/suit/space/void/medical/alt/New()
-	..()
+/obj/item/clothing/suit/space/void/medical/alt/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 0
 
 /obj/item/clothing/suit/space/void/medical/alt/prepared

--- a/code/modules/clothing/spacesuits/void/wizard.dm
+++ b/code/modules/clothing/spacesuits/void/wizard.dm
@@ -43,9 +43,9 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS
 
-/obj/item/clothing/suit/space/void/wizard/New()
-	..()
-	slowdown_per_slot[slot_wear_suit] = 1
+/obj/item/clothing/suit/space/void/wizard/Initialize()
+	. = ..()
+	slowdown_per_slot[slot_wear_suit] = 0.5
 
 /obj/item/clothing/gloves/wizard
 	name = "mystical gloves"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -84,9 +84,9 @@
 	blood_overlay_type = "armor"
 	armor = null
 
-/obj/item/clothing/suit/armor/reactive/New()
-	..()
-	slowdown_per_slot[slot_wear_suit] = 1
+/obj/item/clothing/suit/armor/reactive/Initialize()
+	. = ..()
+	slowdown_per_slot[slot_wear_suit] = 0.5
 
 /obj/item/clothing/suit/armor/reactive/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 	if(prob(50))
@@ -424,8 +424,8 @@
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	siemens_coefficient = 0
 
-/obj/item/clothing/suit/armor/heavy/New()
-	..()
+/obj/item/clothing/suit/armor/heavy/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 3
 
 /obj/item/clothing/suit/armor/tdome

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -9,7 +9,7 @@
 	desc = "A hood that protects the head and face from biological comtaminants."
 	permeability_coefficient = 0
 	armor = list(
-		bio = ARMOR_BIO_SHIELDED, 
+		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 		)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
@@ -31,16 +31,16 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/tank/emergency,/obj/item/pen,/obj/item/device/flashlight/pen,/obj/item/device/scanner/health,/obj/item/device/ano_scanner,/obj/item/clothing/head/bio_hood,/obj/item/clothing/mask/gas)
 	armor = list(
-		bio = ARMOR_BIO_SHIELDED, 
+		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 		)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	siemens_coefficient = 0.9
 
-/obj/item/clothing/suit/bio_suit/New()
-	..()
-	slowdown_per_slot[slot_wear_suit] = 1.0
+/obj/item/clothing/suit/bio_suit/Initialize()
+	. = ..()
+	slowdown_per_slot[slot_wear_suit] = 1
 
 //Standard biosuit, orange stripe
 /obj/item/clothing/head/bio_hood/general

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -54,7 +54,7 @@
 	w_class = ITEM_SIZE_HUGE//bulky item
 
 /obj/item/clothing/suit/fire/heavy/Initialize()
-	..()
+	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 0.5
 
 /*
@@ -95,8 +95,8 @@
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0
 
-/obj/item/clothing/suit/bomb_suit/New()
-	..()
+/obj/item/clothing/suit/bomb_suit/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 2
 
 /obj/item/clothing/head/bomb_hood/security
@@ -142,6 +142,6 @@
 		)
 	flags_inv = HIDEJUMPSUIT|HIDETAIL|HIDEGLOVES|HIDESHOES
 
-/obj/item/clothing/suit/radiation/New()
-	..()
-	slowdown_per_slot[slot_shoes] = 1.5
+/obj/item/clothing/suit/radiation/Initialize()
+	. = ..()
+	slowdown_per_slot[slot_shoes] = 1

--- a/maps/torch/items/clothing/solgov-suit.dm
+++ b/maps/torch/items/clothing/solgov-suit.dm
@@ -456,8 +456,8 @@
 		)
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/briefcase/inflatable)
 
-/obj/item/clothing/suit/space/void/command/New()
-	..()
+/obj/item/clothing/suit/space/void/command/Initialize()
+	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 0
 
 /obj/item/clothing/suit/space/void/command/prepared


### PR DESCRIPTION
## About the Pull Request

Most(if not all) New() procs that were used to declare slowdown_per_slot were replaced by Initialize().
Dufflebag has much less slowdown when worn and 0 slowdown when in hand. Syndi dufflebag has no slowdown at all.
Mercenary void suit had its slowdown reduced from 1 to 0.5, combat belt had its slowdown reduced to 0.

## Why It's Good For The Game

Yada-yada, code improvements, init had no return values and overall we'd want to use New() less, especially when it isn't needed.
Dufflebag shouldn't slow you down to a crawl imo, especially when you aren't wearing it. Also makes syndi dufflebags a good item to have on you, if you can find one and don't get instantly arrested for being a traitor, that is.
Makes sense(to me) that a combat void suit that fits in backpacks allows for faster movement. The same goes for the combat belt.

## Did you test it?

No, everything is basically the same as it was save for a few changed values.

## Authorship

Got the idea from this PR: Baystation12/Baystation12/pull/31587
Changed a few values but otherwise, it's structurally the same.

## Changelog

:cl:
tweak: Dufflebags now have much less slowdown when worn.
tweak: Mercenary void suits now have slightly less slowdown when worn.
tweak: Combat belts(those can be found in ERT base) now have 0 slowdown.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
