### PR TITLE
Windows fire_act() fix

### DIFF
--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -159,11 +159,11 @@
  * - `skip_death_state_change` will skip calling `handle_death_change()` when applicable. Used for when the originally calling proc needs handle it in a unique way.
  * - `severity` should be a passthrough of `severity` from `ex_act()` and `emp_act()` for `DAMAGE_EXPLODE` and `DAMAGE_EMP` types respectively.
  */
-/atom/proc/damage_health(damage, damage_type = null, skip_death_state_change = FALSE, severity)
+/atom/proc/damage_health(damage, damage_type = null, skip_death_state_change = FALSE, severity, forced = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
 	if(!health_max)
 		return
-	if (!can_damage_health(damage, damage_type))
+	if (!forced && !can_damage_health(damage, damage_type))
 		return FALSE
 
 	// Apply resistance/weakness modifiers

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -573,7 +573,7 @@
 	if(reinf_material)
 		melting_point += 0.25*reinf_material.melting_point
 	if(exposed_temperature > melting_point)
-		damage_health(damage_per_fire_tick, DAMAGE_FIRE)
+		damage_health(damage_per_fire_tick, DAMAGE_FIRE, forced = TRUE)
 	// Don't call parent proc
 
 /obj/structure/window/basic

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -574,7 +574,7 @@
 		melting_point += 0.25*reinf_material.melting_point
 	if(exposed_temperature > melting_point)
 		damage_health(damage_per_fire_tick, DAMAGE_FIRE)
-	..()
+	// Don't call parent proc
 
 /obj/structure/window/basic
 	icon_state = "window"


### PR DESCRIPTION
## About the Pull Request

A tiny issue caused by #260

## Why It's Good For The Game

Windows melt down properly now

## Did you test it?

No, it works, trust me, I'm a professional.

## Authorship

Me.

## Changelog

:cl:
fix: Windows now get damaged by fires only if material melting point is met.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
