### PR TITLE
Fixes exoplanet events queue

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -191,7 +191,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 /datum/event_container/exo
 	severity = EVENT_LEVEL_EXO
 	available_events = list(
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Exoplanet Awakening",				/datum/event/exo_awakening,			0,	list(ASSIGNMENT_ANY = 45))
+		new /datum/event_meta(EVENT_LEVEL_EXO, "Exoplanet Awakening",				/datum/event/exo_awakening,			0,	list(ASSIGNMENT_ANY = 45))
 	)
 
 

--- a/code/modules/events/exo_awakening/exo_awaken.dm
+++ b/code/modules/events/exo_awakening/exo_awaken.dm
@@ -14,15 +14,16 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 	var/datum/mob_list/chosen_mob_list //the chosen list of mobs we will pick from when spawning, also based on severity
 	var/delay_time // Amount of time between the event starting and mobs beginning spawns
 	var/spawning = FALSE // Set to TRUE once the initial delay passes
+	var/event_severity = EVENT_LEVEL_MODERATE // Used as to not fuck up the event queue
 
 /datum/event/exo_awakening/setup()
 	announceWhen = rand(15, 45)
 	affecting_z = list()
 	if ((GLOB.player_list.len > 12) && prob(50))
-		severity = EVENT_LEVEL_MAJOR
+		event_severity = EVENT_LEVEL_MAJOR
 		chosen_mob_list = pick(typesof(/datum/mob_list/major) - /datum/mob_list/major)
 	else
-		severity = EVENT_LEVEL_MODERATE
+		event_severity = EVENT_LEVEL_MODERATE
 		chosen_mob_list = pick(typesof(/datum/mob_list/moderate) - /datum/mob_list/moderate)
 
 	for (var/area/A in world)
@@ -32,15 +33,15 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 	chosen_mob_list = new chosen_mob_list
 	target_mob_count = chosen_mob_list.limit
 	endWhen = chosen_mob_list.length
-	endWhen += severity*25
+	endWhen += event_severity*25
 
 	apply_spawn_delay()
 
 /datum/event/exo_awakening/proc/apply_spawn_delay()
 	delay_time = chosen_mob_list.delay_time
 	var/delay_mod = delay_time / 6
-	var/delay_max = (EVENT_LEVEL_MAJOR - severity) * delay_mod
-	var/delay_min = -1 * severity * delay_mod
+	var/delay_max = (EVENT_LEVEL_MAJOR - event_severity) * delay_mod
+	var/delay_min = -1 * event_severity * delay_mod
 	delay_mod = max(rand(delay_min, delay_max), 0)
 	delay_time += delay_mod
 	endWhen += delay_time
@@ -114,7 +115,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 //Notify all players on the planet that the event is beginning.
 /datum/event/exo_awakening/proc/notify_players()
 	for (var/mob/M in players_on_site[chosen_area])
-		if (severity > EVENT_LEVEL_MODERATE)
+		if (event_severity > EVENT_LEVEL_MODERATE)
 			to_chat(M, SPAN_DANGER(chosen_mob_list.arrival_message))
 		else
 			to_chat(M, SPAN_WARNING(chosen_mob_list.arrival_message))
@@ -129,7 +130,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 
 /datum/event/exo_awakening/announce()
 	var/announcement = ""
-	if (severity > EVENT_LEVEL_MODERATE)
+	if (event_severity > EVENT_LEVEL_MODERATE)
 		announcement = "Extreme biological activity spike detected on [location_name()]. Recommend away team evacuation."
 	else
 		announcement = "Anomalous biological activity detected on [location_name()]."
@@ -153,7 +154,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 		return
 
 	var/list/area_turfs = get_area_turfs(chosen_area)
-	var/n = rand(severity-1, severity*2)
+	var/n = rand(event_severity-1, event_severity*2)
 	var/I = 0
 	while (I < n)
 		var/turf/T
@@ -214,7 +215,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 		return
 
 	QDEL_NULL(chosen_mob_list)
-	log_debug("Exoplanet Awakening event spawned [spawned_mobs] mobs. It was a level [severity] out of 3 severity.")
+	log_debug("Exoplanet Awakening event spawned [spawned_mobs] mobs. It was a level [event_severity] out of 3 severity.")
 
 	for (var/mob/M in GLOB.player_list)
 		if (M && M.z == chosen_area.z)

--- a/code/modules/events/exo_awakening/exo_awaken.dm
+++ b/code/modules/events/exo_awakening/exo_awaken.dm
@@ -14,16 +14,16 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 	var/datum/mob_list/chosen_mob_list //the chosen list of mobs we will pick from when spawning, also based on severity
 	var/delay_time // Amount of time between the event starting and mobs beginning spawns
 	var/spawning = FALSE // Set to TRUE once the initial delay passes
-	var/event_severity = EVENT_LEVEL_MODERATE // Used as to not fuck up the event queue
+	var/exo_severity = EVENT_LEVEL_MODERATE // Used as to not fuck up the event queue
 
 /datum/event/exo_awakening/setup()
 	announceWhen = rand(15, 45)
 	affecting_z = list()
 	if ((GLOB.player_list.len > 12) && prob(50))
-		event_severity = EVENT_LEVEL_MAJOR
+		exo_severity = EVENT_LEVEL_MAJOR
 		chosen_mob_list = pick(typesof(/datum/mob_list/major) - /datum/mob_list/major)
 	else
-		event_severity = EVENT_LEVEL_MODERATE
+		exo_severity = EVENT_LEVEL_MODERATE
 		chosen_mob_list = pick(typesof(/datum/mob_list/moderate) - /datum/mob_list/moderate)
 
 	for (var/area/A in world)
@@ -33,15 +33,15 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 	chosen_mob_list = new chosen_mob_list
 	target_mob_count = chosen_mob_list.limit
 	endWhen = chosen_mob_list.length
-	endWhen += event_severity*25
+	endWhen += exo_severity*25
 
 	apply_spawn_delay()
 
 /datum/event/exo_awakening/proc/apply_spawn_delay()
 	delay_time = chosen_mob_list.delay_time
 	var/delay_mod = delay_time / 6
-	var/delay_max = (EVENT_LEVEL_MAJOR - event_severity) * delay_mod
-	var/delay_min = -1 * event_severity * delay_mod
+	var/delay_max = (EVENT_LEVEL_MAJOR - exo_severity) * delay_mod
+	var/delay_min = -1 * exo_severity * delay_mod
 	delay_mod = max(rand(delay_min, delay_max), 0)
 	delay_time += delay_mod
 	endWhen += delay_time
@@ -115,7 +115,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 //Notify all players on the planet that the event is beginning.
 /datum/event/exo_awakening/proc/notify_players()
 	for (var/mob/M in players_on_site[chosen_area])
-		if (event_severity > EVENT_LEVEL_MODERATE)
+		if (exo_severity > EVENT_LEVEL_MODERATE)
 			to_chat(M, SPAN_DANGER(chosen_mob_list.arrival_message))
 		else
 			to_chat(M, SPAN_WARNING(chosen_mob_list.arrival_message))
@@ -130,7 +130,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 
 /datum/event/exo_awakening/announce()
 	var/announcement = ""
-	if (event_severity > EVENT_LEVEL_MODERATE)
+	if (exo_severity > EVENT_LEVEL_MODERATE)
 		announcement = "Extreme biological activity spike detected on [location_name()]. Recommend away team evacuation."
 	else
 		announcement = "Anomalous biological activity detected on [location_name()]."
@@ -154,7 +154,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 		return
 
 	var/list/area_turfs = get_area_turfs(chosen_area)
-	var/n = rand(event_severity-1, event_severity*2)
+	var/n = rand(exo_severity-1, exo_severity*2)
 	var/I = 0
 	while (I < n)
 		var/turf/T
@@ -215,7 +215,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 		return
 
 	QDEL_NULL(chosen_mob_list)
-	log_debug("Exoplanet Awakening event spawned [spawned_mobs] mobs. It was a level [event_severity] out of 3 severity.")
+	log_debug("Exoplanet Awakening event spawned [spawned_mobs] mobs. It was a level [exo_severity] out of 3 severity.")
 
 	for (var/mob/M in GLOB.player_list)
 		if (M && M.z == chosen_area.z)


### PR DESCRIPTION
## About the Pull Request

Basically, the severity variable was updated in the code and as such, once the event ended, it would place it in the medium/major events queue instead of the exoplanet events queue.

## Why It's Good For The Game

A fix.

## Did you test it?

Not really, no. It's an easy tiny fix/update that surely works.

## Authorship

Me.

## Changelog

:cl:
fix: Exoplanet awakening now works properly and can run multiple times.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
