### PR TITLE
Nabber & unarmed attack tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -232,7 +232,8 @@
 			else
 				H.visible_message("<span class='danger'>[attack_message]</span>")
 
-			playsound(loc, ((miss_type) ? (miss_type == 1 ? attack.miss_sound : 'sound/weapons/thudswoosh.ogg') : attack.attack_sound), 25, 1, -1)
+			if(miss_type)
+				playsound(loc, (attack.miss_sound ? attack.miss_sound : 'sound/weapons/thudswoosh.ogg'), 25, 1, -1)
 			if (attack.should_attack_log)
 				admin_attack_log(H, src, "[miss_type ? (miss_type == 1 ? "Has missed" : "Was blocked by") : "Has [pick(attack.attack_verb)]"] their victim.", "[miss_type ? (miss_type == 1 ? "Missed" : "Blocked") : "[pick(attack.attack_verb)]"] their attacker", "[miss_type ? (miss_type == 1 ? "has missed" : "was blocked by") : "has [pick(attack.attack_verb)]"]")
 

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -155,6 +155,7 @@ var/global/list/sparring_attack_cache = list()
 	var/organ = affecting.name
 
 	attack_damage = Clamp(attack_damage, 1, 5) // We expect damage input of 1 to 5 for this proc. But we leave this check juuust in case.
+	playsound(user.loc, attack_sound, 25, 1, -1)
 
 	if(target == user)
 		user.visible_message("<span class='danger'>[user] [pick(attack_verb)] \himself in the [organ]!</span>")
@@ -222,6 +223,7 @@ var/global/list/sparring_attack_cache = list()
 	var/organ = affecting.name
 
 	attack_damage = Clamp(attack_damage, 1, 5)
+	playsound(user.loc, attack_sound, 25, 1, -1)
 
 	switch(attack_damage)
 		if(1 to 2)	user.visible_message("<span class='danger'>[user] threw [target] a glancing [pick(attack_noun)] to the [organ]!</span>") //it's not that they're kicking lightly, it's that the kick didn't quite connect
@@ -262,6 +264,7 @@ var/global/list/sparring_attack_cache = list()
 	var/obj/item/clothing/shoes = user.shoes
 
 	attack_damage = Clamp(attack_damage, 1, 5)
+	playsound(user.loc, attack_sound, 25, 1, -1)
 
 	var/shoe_text = shoes ? copytext(shoes.name, 1, -1) : "foot"
 	switch(attack_damage)

--- a/code/modules/mob/living/simple_animal/defense.dm
+++ b/code/modules/mob/living/simple_animal/defense.dm
@@ -45,6 +45,7 @@
 				var/datum/unarmed_attack/attack = M.get_unarmed_attack(src)
 				dealt_damage = attack.damage <= dealt_damage ? dealt_damage : attack.damage
 				harm_verb = pick(attack.attack_verb)
+				playsound(loc, attack.attack_sound, 25, 1, -1)
 				if(attack.sharp || attack.edge)
 					adjustBleedTicks(dealt_damage)
 

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -658,12 +658,12 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 			return
 
 	var/randn = rand(1, 100) - skill_mod + state_mod - stim_mod
-	if(!(check_no_slip(target)) && randn <= 20)
+	if(randn <= 20 && !target.species.check_no_slip(target))
 		var/armor_check = 100 * target.get_blocked_ratio(affecting, BRUTE, damage = 20)
-		target.apply_effect(push_mod, WEAKEN, armor_check)
 		playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 		if(armor_check < 100)
 			target.visible_message("<span class='danger'>[attacker] has pushed [target]!</span>")
+			target.apply_effect(push_mod, WEAKEN, armor_check)
 		else
 			target.visible_message("<span class='warning'>[attacker] attempted to push [target]!</span>")
 		return

--- a/code/modules/species/species_attack.dm
+++ b/code/modules/species/species_attack.dm
@@ -155,7 +155,7 @@
 /datum/unarmed_attack/nabber
 	attack_verb = list("mauled", "slashed", "struck", "pierced")
 	attack_noun = list("forelimb")
-	damage = 8
+	damage = 18
 	shredding = TRUE
 	sharp = TRUE
 	edge = TRUE
@@ -163,6 +163,8 @@
 	eye_attack_text = "a forelimb"
 	eye_attack_text_victim = "a forelimb"
 	attack_name = "forelimb slash"
+	attack_sound = 'sound/weapons/slice.ogg'
+	miss_sound = 'sound/weapons/slashmiss.ogg'
 
 /datum/unarmed_attack/punch/starborn
 	attack_verb = list("scorched", "burned", "fried")


### PR DESCRIPTION
## About the Pull Request

- GAS have much more unarmed damage when not pulling punches.
- Fixed the noslip flag logic to work properly. GAS can't be pushed anymore.
- Unarmed attacks on simple mobs now properly play the sound.
- Unarmed attacks don't play the sound twice.

## Why It's Good For The Game

- You'd expect someone who can kill a human to be able to kill a spider just as well. It still requires GAS to put on the "threat display" first.
- A fix. Previously, it was checking if the attacker has this flag, not the victim.
- Fix.
- Fix.

## Did you test it?

Yes, all tested, all works.

## Authorship

Me.

## Changelog

:cl:
balance: GAS have much more unarmed damage when in "combat stance".
fix: GAS cannot be pushed by disarming attacks anymore, just as intended.
fix: Unarmed attacks on simple mobs now properly play sound.
fix: Unarmed attacks don't play the sound twice anymore.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
