### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -8,13 +8,6 @@ The following conduct may result in a warning being logged against your account:
 * Derogatory comments.
 * Trolling.
 * Inappropriate content.
-* Comments on pull requests not addressing technical or code-related issues.
-	* Comments expressing general attitude towards or criticism of the change, giving constructive feedback on non-technical aspects, or discussing balance should be made in appropriate non-repo channels, such as the forum, IRC, or Discord.
-	* The same rule applies to sprite, sound, or map contributions, though there the definition of "technical" will be interpreted rather broadly.
-	* The following are exempt from this rule: 
-		* The PR's author(s).
-		* Developers, or other staff members with the right to approve or veto the pull request.
-	* Emote reactions to pull requests are exempt. Comments on issue reports are exempt so long as they remain on topic.
 * Issuing commits, editing wiki pages, commenting, or opening bug reports in bad faith.
 	* The Head Developer and Developers are obligated to assume good faith until evidence otherwise surfaces.
     * Examples:


### PR DESCRIPTION
## About the Pull Request

Removes the clause in the code of conduct about non-technical issues.

## Changelog

No changelog required
<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
