### PR TITLE
Zombie types

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -106,6 +106,15 @@ var/const/NEGATIVE_INFINITY = -1#INF // win: -1.#INF, lin: -inf
 	var/mob/living/carbon/C = A
 	return C.species?.name == B
 
+/proc/isspecies_inlist(A, L = list())
+	if(!iscarbon(A))
+		return FALSE
+	var/mob/living/carbon/C = A
+	for(var/S in L)
+		if(C.species?.name == S)
+			return TRUE
+	return FALSE
+
 #define sequential_id(key) uniqueness_repository.Generate(/datum/uniqueness_generator/id_sequential, key)
 
 #define random_id(key,min_id,max_id) uniqueness_repository.Generate(/datum/uniqueness_generator/id_random, key, min_id, max_id)

--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -53,3 +53,14 @@
 	r_pocket = /obj/item/handcuffs
 	id_types = list(/obj/item/card/id/security)
 	pda_type = /obj/item/modular_computer/pda/security
+
+/decl/hierarchy/outfit/job/security/officer/armored
+	name = OUTFIT_JOB_NAME("Security Officer - Armored")
+	suit = /obj/item/clothing/suit/armor/vest/old/security
+	head = /obj/item/clothing/head/helmet
+
+/decl/hierarchy/outfit/job/security/officer/armored/riot
+	name = OUTFIT_JOB_NAME("Security Officer - Riot Gear")
+	suit = /obj/item/clothing/suit/armor/riot
+	head = /obj/item/clothing/head/helmet/riot
+	mask = /obj/item/clothing/mask/gas

--- a/code/modules/mob/skills/skillset.dm
+++ b/code/modules/mob/skills/skillset.dm
@@ -88,6 +88,8 @@
 //Skill-related mob helper procs
 
 /mob/proc/get_skill_value(skill_path)
+	if(!skillset)
+		return SKILL_UNTRAINED
 	return skillset.get_value(skill_path)
 
 /mob/proc/reset_skillset()


### PR DESCRIPTION
## About the Pull Request

Adds a bunch of zombie types for events.
Allows zombies to wear armor and helmets for ultimate difficulty tweak.

## Why It's Good For The Game

Funnier and better zombies, I assume.

## Did you test it?

I did.

## Authorship

Me.

## Changelog

:cl:
tweak: Zombies no longer delete the armor and helmet they were wearing prior to infection. Now they only DROP their ID.
tweak: Added a bunch of zombie types for events.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
