### PR TITLE
Event tweaks

### DIFF
--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -122,7 +122,7 @@ Would like to add a law like "Law x is _______" where x = a number, and _____ is
 				if(4)
 					M.add_ion_law("HUMANS NEED TO EAT [what2pref] [what2] TO SURVIVE")
 				if(5)
-					M.add_ion_law("THE CAPTAIN, HOP AND HOS ARE [who2]")
+					M.add_ion_law("THE COMMAND ARE [who2]")
 				if(6)
 					M.add_ion_law("THE [uppertext(station_name())] IS BUILT FOR [who2]")
 				if(7)

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -1,16 +1,16 @@
 /datum/event_meta
-	var/name 		= ""
-	var/enabled 	= 1	// Whether or not the event is available for random selection at all
-	var/weight 		= 0 // The base weight of this event. A zero means it may never fire, but see get_weight()
-	var/min_weight	= 0 // The minimum weight that this event will have. Only used if non-zero.
-	var/max_weight	= 0 // The maximum weight that this event will have. Only use if non-zero.
-	var/severity 	= 0 // The current severity of this event
-	var/one_shot	= 0	// If true, then the event will not be re-added to the list of available events
-	var/add_to_queue= 1	// If true, add back to the queue of events upon finishing.
+	var/name = ""
+	var/enabled = 1 // Whether or not the event is available for random selection at all
+	var/weight = 0 // The base weight of this event. A zero means it may never fire, but see get_weight()
+	var/min_weight = 0 // The minimum weight that this event will have. Only used if non-zero.
+	var/max_weight = null // The maximum weight that this event will have. Only use if non-zero.
+	var/severity = 0 // The current severity of this event
+	var/one_shot = 0 // If true, then the event will not be re-added to the list of available events
+	var/add_to_queue = 1 // If true, add back to the queue of events upon finishing.
 	var/list/role_weights = list()
 	var/datum/event/event_type
 
-/datum/event_meta/New(var/event_severity, var/event_name, var/datum/event/type, var/event_weight, var/list/job_weights, var/is_one_shot = 0, var/min_event_weight = 0, var/max_event_weight = 0, var/add_to_queue = 1)
+/datum/event_meta/New(event_severity, event_name, datum/event/type, event_weight, list/job_weights, is_one_shot = 0, min_event_weight = 0, max_event_weight = null, add_to_queue = 1)
 	name = event_name
 	severity = event_severity
 	event_type = type
@@ -33,9 +33,11 @@
 
 	var/total_weight = weight + job_weight
 
-	// Only min/max the weight if the values are non-zero
-	if(min_weight && total_weight < min_weight) total_weight = min_weight
-	if(max_weight && total_weight > max_weight) total_weight = max_weight
+	// Only min/max the weight if the values exist
+	if(min_weight != null && total_weight < min_weight)
+		total_weight = min_weight
+	if(max_weight != null && total_weight > max_weight)
+		total_weight = max_weight
 
 	return total_weight
 
@@ -149,8 +151,10 @@
 
 	event_meta = EM
 	severity = event_meta.severity
-	if(severity < EVENT_LEVEL_MUNDANE) severity = EVENT_LEVEL_MUNDANE
-	if(severity > EVENT_LEVEL_MAJOR) severity = EVENT_LEVEL_MAJOR
+	if(severity < EVENT_LEVEL_MUNDANE)
+		severity = EVENT_LEVEL_MUNDANE
+	if(severity > EVENT_LEVEL_EXO)
+		severity = EVENT_LEVEL_EXO
 
 	startedAt = world.time
 

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -125,73 +125,73 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 /datum/event_container/mundane
 	severity = EVENT_LEVEL_MUNDANE
 	available_events = list(
-		// Severity level, event name, event type, base weight, role weights, one shot, min weight, max weight. Last two only used if set and non-zero
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Nothing",						/datum/event/nothing,				100),
+		// Severity level, event name, event type, base weight, role weights, one shot, min weight, max weight. Last two only used if set and aren't nulls
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "APC Damage",					/datum/event/apc_damage,			20, 	list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Computer Damage",				/datum/event/computer_damage,		20, 	list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Computer Update",				/datum/event/computer_update,		20),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Brand Intelligence",			/datum/event/brand_intelligence,	10, 	list(ASSIGNMENT_JANITOR = 10),	1),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Brand Intelligence",			/datum/event/brand_intelligence,	10, 	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_JANITOR = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Camera Damage",					/datum/event/camera_damage,			20, 	list(ASSIGNMENT_ENGINEER = 10)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Economic News",					/datum/event/economic_event,		300),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Economic News",					/datum/event/economic_event,		100),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Lost Carp",						/datum/event/carp_migration, 		20, 	list(ASSIGNMENT_SECURITY = 10), 1),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Hacker",					/datum/event/money_hacker, 			0, 		list(ASSIGNMENT_ANY = 4), 1, 10, 25),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Lotto",					/datum/event/money_lotto, 			0, 		list(ASSIGNMENT_ANY = 1), 1, 5, 15),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Mundane News", 					/datum/event/mundane_news, 			300),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Mundane News", 					/datum/event/mundane_news, 			200),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Shipping Error",				/datum/event/shipping_error	, 		30, 	list(ASSIGNMENT_ANY = 2), 0),
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MUNDANE, "Space Dust",			/datum/event/dust	, 				30, 	list(ASSIGNMENT_ENGINEER = 10)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Sensor Suit Jamming",			/datum/event/sensor_suit_jamming,	50,		list(ASSIGNMENT_MEDICAL = 20, ASSIGNMENT_AI = 20), 1),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Trivial News",					/datum/event/trivial_news, 			400),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",			/datum/event/infestation, 			100,	list(ASSIGNMENT_JANITOR = 100)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Sensor Suit Jamming",			/datum/event/sensor_suit_jamming,	30,		list(ASSIGNMENT_MEDICAL = 20, ASSIGNMENT_AI = 20), 1),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Trivial News",					/datum/event/trivial_news, 			200),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",			/datum/event/infestation, 			100,	list(ASSIGNMENT_JANITOR = 50)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",						/datum/event/wallrot, 				0,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_GARDENER = 50)),
-		new /datum/event_meta/no_overmap(EVENT_LEVEL_MUNDANE, "Electrical Storm",	/datum/event/electrical_storm, 		20,		list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_JANITOR = 100)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Toilet Clog",					/datum/event/toilet_clog,			50, 	list(ASSIGNMENT_JANITOR = 20)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Drone Malfunction",				/datum/event/rogue_maint_drones/,	10,		list(ASSIGNMENT_ENGINEER = 30)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Disposals Explosion",			/datum/event/disposals_explosion/,	50,		list(ASSIGNMENT_ENGINEER = 40)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Brain Expansion",				/datum/event/brain_expansion/,		20,		list(ASSIGNMENT_SCIENTIST = 20)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Mail Delivery",					/datum/event/mail/,					5,		list(ASSIGNMENT_ANY = 1), 1),
+		new /datum/event_meta/no_overmap(EVENT_LEVEL_MUNDANE, "Electrical Storm",	/datum/event/electrical_storm, 		20,		list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_JANITOR = 50)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Toilet Clog",					/datum/event/toilet_clog,			50, 	list(ASSIGNMENT_JANITOR = 50)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Drone Malfunction",				/datum/event/rogue_maint_drones,	10,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_SECURITY = 50)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Disposals Explosion",			/datum/event/disposals_explosion,	20,		list(ASSIGNMENT_ENGINEER = 40)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Brain Expansion",				/datum/event/brain_expansion,		20,		list(ASSIGNMENT_SCIENTIST = 20)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Mail Delivery",					/datum/event/mail,					0,		list(ASSIGNMENT_ANY = 5), 1),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Whale Migration",				/datum/event/whale_migration,		10)
 	)
 
 /datum/event_container/moderate
 	severity = EVENT_LEVEL_MODERATE
 	available_events = list(
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Nothing",								/datum/event/nothing,					1230),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Nothing",								/datum/event/nothing,					100,		list(ASSIGNMENT_ANY = -5)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Appendicitis", 						/datum/event/spontaneous_appendicitis, 	0,		list(ASSIGNMENT_MEDICAL = 10), 1),
-		new /datum/event_meta/no_overmap(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			100, 	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_SECURITY = 20), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Communication Blackout",				/datum/event/communications_blackout,	100,	list(ASSIGNMENT_AI = 100, ASSIGNMENT_ENGINEER = 20)),
+		new /datum/event_meta/no_overmap(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			50, 	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_SECURITY = 20)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Communication Blackout",				/datum/event/communications_blackout,	50,		list(ASSIGNMENT_AI = 100, ASSIGNMENT_ENGINEER = 20)),
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MODERATE, "Electrical Storm",			/datum/event/electrical_storm, 			10,		list(ASSIGNMENT_ENGINEER = 15, ASSIGNMENT_JANITOR = 10)),
-		new /datum/event_meta/no_overmap(EVENT_LEVEL_MODERATE, "Gravity Failure",			/datum/event/gravity,	 				75,		list(ASSIGNMENT_ENGINEER = 25)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grid Check",							/datum/event/grid_check, 				200,	list(ASSIGNMENT_ENGINEER = 10)),
+		new /datum/event_meta/no_overmap(EVENT_LEVEL_MODERATE, "Gravity Failure",			/datum/event/gravity,	 				50,		list(ASSIGNMENT_ENGINEER = 20)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grid Check",							/datum/event/grid_check, 				40,		list(ASSIGNMENT_ENGINEER = 15, ASSIGNMENT_ANY = 5)),
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MODERATE, "Ion Storm",					/datum/event/ionstorm, 					0,		list(ASSIGNMENT_AI = 50, ASSIGNMENT_CYBORG = 50, ASSIGNMENT_ENGINEER = 15, ASSIGNMENT_SCIENTIST = 5)),
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MODERATE, "Meteor Shower",				/datum/event/meteor_wave,				0,		list(ASSIGNMENT_ENGINEER = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Prison Break",							/datum/event/prison_break,				0,		list(ASSIGNMENT_SECURITY = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Radiation Storm",						/datum/event/radiation_storm, 			0,		list(ASSIGNMENT_MEDICAL = 50), 1),
-		new /datum/event_meta/extended_penalty(EVENT_LEVEL_MODERATE, "Random Antagonist",	/datum/event/random_antag,				2.5,	list(ASSIGNMENT_SECURITY = 1), 1, 0, 5),
+		new /datum/event_meta/extended_penalty(EVENT_LEVEL_MODERATE, "Random Antagonist",	/datum/event/random_antag,				2,	list(ASSIGNMENT_SECURITY = 1), 1, 0, 5),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",							/datum/event/rogue_drone, 				20,		list(ASSIGNMENT_SECURITY = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Sensor Suit Jamming",					/datum/event/sensor_suit_jamming,		10,		list(ASSIGNMENT_MEDICAL = 20, ASSIGNMENT_AI = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Solar Storm",							/datum/event/solar_storm, 				10,		list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_SECURITY = 10), 1),
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust	, 					30, 	list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",					/datum/event/spider_infestation, 		25,		list(ASSIGNMENT_SECURITY = 15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Toilet Flooding",						/datum/event/toilet_clog/flood,			50, 	list(ASSIGNMENT_JANITOR = 20)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Uprising",						/datum/event/rogue_maint_drones/,		25,		list(ASSIGNMENT_ENGINEER = 30)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Uprising",						/datum/event/rogue_maint_drones,		25,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_SECURITY = 20)),
 	)
 
 /datum/event_container/major
 	severity = EVENT_LEVEL_MAJOR
 	available_events = list(
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",							/datum/event/nothing,				1320),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",							/datum/event/blob, 					0,	list(ASSIGNMENT_ENGINEER = 40), 1),
-		new /datum/event_meta/no_overmap(EVENT_LEVEL_MAJOR, "Carp Migration",		/datum/event/carp_migration,		0,	list(ASSIGNMENT_SECURITY =  5), 1),
-		new /datum/event_meta/no_overmap(EVENT_LEVEL_MAJOR, "Meteor Wave",			/datum/event/meteor_wave,			0,	list(ASSIGNMENT_ENGINEER = 10),	1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",						/datum/event/spacevine, 			0,	list(ASSIGNMENT_ENGINEER = 15), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",							/datum/event/nothing,			200,	list(ASSIGNMENT_ANY = -5)), // So higher pop will run events more often
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",							/datum/event/blob, 					0,	list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_MEDICAL = 10, ASSIGNMENT_SECURITY = 20), 1),
+		new /datum/event_meta/no_overmap(EVENT_LEVEL_MAJOR, "Carp Migration",		/datum/event/carp_migration,		0,	list(ASSIGNMENT_SECURITY = 20, ASSIGNMENT_MEDICAL = 10)),
+		new /datum/event_meta/no_overmap(EVENT_LEVEL_MAJOR, "Meteor Wave",			/datum/event/meteor_wave,			0,	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_MEDICAL = 10)),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",						/datum/event/spacevine, 			0,	list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_ANY = 5)),
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MAJOR, "Electrical Storm",		/datum/event/electrical_storm, 		0,	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_JANITOR = 5)),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Drone Revolution",				/datum/event/rogue_maint_drones/,	0,	list(ASSIGNMENT_ENGINEER = 10,ASSIGNMENT_MEDICAL = 10,ASSIGNMENT_SECURITY = 10)),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Drone Revolution",				/datum/event/rogue_maint_drones,	0,	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_MEDICAL = 10, ASSIGNMENT_SECURITY = 20)),
 	)
 
 /datum/event_container/exo
 	severity = EVENT_LEVEL_EXO
 	available_events = list(
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Exoplanet Awakening",				/datum/event/exo_awakening,			0,	list(ASSIGNMENT_ANY = 45))
+		new /datum/event_meta(EVENT_LEVEL_EXO, "Nothing",			/datum/event/nothing,		100,		list(ASSIGNMENT_ANY = -5)),
+		new /datum/event_meta(EVENT_LEVEL_EXO, "Exoplanet Awakening",	/datum/event/exo_awakening,	0,		list(ASSIGNMENT_ANY = 10))
 	)
 
 

--- a/code/modules/events/exo_awakening/exo_awaken.dm
+++ b/code/modules/events/exo_awakening/exo_awaken.dm
@@ -14,16 +14,17 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 	var/datum/mob_list/chosen_mob_list //the chosen list of mobs we will pick from when spawning, also based on severity
 	var/delay_time // Amount of time between the event starting and mobs beginning spawns
 	var/spawning = FALSE // Set to TRUE once the initial delay passes
+	var/exo_severity = EVENT_LEVEL_MODERATE
 
 /datum/event/exo_awakening/setup()
 	announceWhen = rand(15, 45)
 	affecting_z = list()
 	if ((GLOB.player_list.len > 12) && prob(50))
-		severity = EVENT_LEVEL_MAJOR
-		chosen_mob_list = pick(typesof(/datum/mob_list/major) - /datum/mob_list/major)
+		exo_severity = EVENT_LEVEL_MAJOR
+		chosen_mob_list = pick(subtypesof(/datum/mob_list/major))
 	else
-		severity = EVENT_LEVEL_MODERATE
-		chosen_mob_list = pick(typesof(/datum/mob_list/moderate) - /datum/mob_list/moderate)
+		exo_severity = EVENT_LEVEL_MODERATE
+		chosen_mob_list = pick(subtypesof(/datum/mob_list/moderate))
 
 	for (var/area/A in world)
 		if (A.planetary_surface)
@@ -32,15 +33,15 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 	chosen_mob_list = new chosen_mob_list
 	target_mob_count = chosen_mob_list.limit
 	endWhen = chosen_mob_list.length
-	endWhen += severity*25
+	endWhen += exo_severity*25
 
 	apply_spawn_delay()
 
 /datum/event/exo_awakening/proc/apply_spawn_delay()
 	delay_time = chosen_mob_list.delay_time
 	var/delay_mod = delay_time / 6
-	var/delay_max = (EVENT_LEVEL_MAJOR - severity) * delay_mod
-	var/delay_min = -1 * severity * delay_mod
+	var/delay_max = (EVENT_LEVEL_MAJOR - exo_severity) * delay_mod
+	var/delay_min = -1 * exo_severity * delay_mod
 	delay_mod = max(rand(delay_min, delay_max), 0)
 	delay_time += delay_mod
 	endWhen += delay_time
@@ -114,7 +115,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 //Notify all players on the planet that the event is beginning.
 /datum/event/exo_awakening/proc/notify_players()
 	for (var/mob/M in players_on_site[chosen_area])
-		if (severity > EVENT_LEVEL_MODERATE)
+		if (exo_severity > EVENT_LEVEL_MODERATE)
 			to_chat(M, SPAN_DANGER(chosen_mob_list.arrival_message))
 		else
 			to_chat(M, SPAN_WARNING(chosen_mob_list.arrival_message))
@@ -129,7 +130,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 
 /datum/event/exo_awakening/announce()
 	var/announcement = ""
-	if (severity > EVENT_LEVEL_MODERATE)
+	if (exo_severity > EVENT_LEVEL_MODERATE)
 		announcement = "Extreme biological activity spike detected on [location_name()]. Recommend away team evacuation."
 	else
 		announcement = "Anomalous biological activity detected on [location_name()]."
@@ -153,7 +154,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 		return
 
 	var/list/area_turfs = get_area_turfs(chosen_area)
-	var/n = rand(severity-1, severity*2)
+	var/n = rand(exo_severity-1, exo_severity*2)
 	var/I = 0
 	while (I < n)
 		var/turf/T
@@ -214,7 +215,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 		return
 
 	QDEL_NULL(chosen_mob_list)
-	log_debug("Exoplanet Awakening event spawned [spawned_mobs] mobs. It was a level [severity] out of 3 severity.")
+	log_debug("Exoplanet Awakening event spawned [spawned_mobs] mobs. It was a level [exo_severity] out of 3 severity.")
 
 	for (var/mob/M in GLOB.player_list)
 		if (M && M.z == chosen_area.z)

--- a/code/modules/events/mail.dm
+++ b/code/modules/events/mail.dm
@@ -33,7 +33,7 @@
 
 /datum/event/mail/setup()
 	for(var/datum/computer_file/report/crew_record/CR in GLOB.all_crew_records)
-		if(prob(25))
+		if(prob(50))
 			to_receive.Add(CR.get_name())
 
 	// Nobody got any mail :(

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -838,6 +838,13 @@
 	if(..())
 		return 1
 
+	// Rebooting doesn't require it to be unlocked
+	if( href_list["reboot"] )
+		failure_timer = 0
+		update_icon()
+		update()
+		return 0
+
 	if(!istype(usr, /mob/living/silicon) && (locked && !emagged))
 		// Shouldn't happen, this is here to prevent href exploits
 		to_chat(usr, "You must unlock the panel to use this!")
@@ -845,11 +852,6 @@
 
 	if (href_list["lock"])
 		coverlocked = !coverlocked
-
-	else if( href_list["reboot"] )
-		failure_timer = 0
-		update_icon()
-		update()
 
 	else if (href_list["breaker"])
 		toggle_breaker()


### PR DESCRIPTION
## About the Pull Request

- Adjusts chances for all events. "Nothing" has SIGNIFICANTLY less weight.
- Rebooting APCs doesn't require it to be unlocked.
- Some code improvements, I'd say.
- Fixes exo events this time for sure.

## Why It's Good For The Game

- All the time we would play, "Nothing" had absurd weight of 1000+, meaning no events would happen at all. Well, off with it.
- Grid check event is already annoying, so I think we should just let people reboot APCs faster and without waiting for AI/Cyborg/Engineer.
- Code.
- Fix.

## Did you test it?

Yes.

## Authorship

Me.

## Changelog

:cl:
tweak: Events have slightly different chances to run. "Nothing" has significantly lower chance.
tweak: You can reboot APCs without unlocking them first.
fix: Exoplanet events now work properly after trying to run for once.
/:cl: