### PR TITLE
Runechat whispering fix

### DIFF
--- a/code/modules/mob/floating_message.dm
+++ b/code/modules/mob/floating_message.dm
@@ -15,7 +15,7 @@ var/global/list/floating_chat_colors = list()
 /atom/movable
 	var/list/stored_chat_text
 
-/atom/movable/proc/animate_chat(message, datum/language/language, small, list/show_to, duration = CHAT_MESSAGE_LIFESPAN)
+/atom/movable/proc/animate_chat(message, datum/language/language, small, list/show_to, whisper = FALSE, unique_messages = null, duration = CHAT_MESSAGE_LIFESPAN)
 	set waitfor = FALSE
 
 	/// Get rid of any URL schemes that might cause BYOND to automatically wrap something in an anchor tag
@@ -48,6 +48,14 @@ var/global/list/floating_chat_colors = list()
 	// create 2 messages, one that appears if you know the language, and one that appears when you don't know the language
 	var/image/understood = generate_floating_text(src, capitalize(message), style, fontsize, duration, show_to)
 	var/image/gibberish = language ? generate_floating_text(src, language.scramble(message), style, fontsize, duration, show_to) : understood
+
+	// hack for unique messages, i.e. misunderstood whispers
+	for(var/client/client in unique_messages)
+		var/image/unique = generate_floating_text(src, capitalize(unique_messages[client]), style, fontsize, duration, show_to)
+
+		show_to -= client //remove the client from the normal list if we're giving them a unique response to this
+		if(!client.mob.is_deaf() && client.get_preference_value(/datum/client_preference/floating_messages) == GLOB.PREF_SHOW)
+			client.images += unique
 
 	for(var/client/C in show_to)
 		if(!C.mob.is_deaf() && C.get_preference_value(/datum/client_preference/floating_messages) == GLOB.PREF_SHOW)

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -90,6 +90,8 @@
 			var/turf/source = speaker? get_turf(speaker) : get_turf(src)
 			src.playsound_local(source, speech_sound, sound_vol, 1)
 
+		return message
+
 /mob/proc/on_hear_say(var/message)
 	to_chat(src, message)
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -306,6 +306,8 @@ proc/get_radio_key_from_channel(var/channel)
 			if(O) //It's possible that it could be deleted in the meantime.
 				O.hear_talk(src, message, verb, speaking)
 
+	var/heard_message
+	var/list/unique = list()
 	if(whispering)
 		var/eavesdroping_range = 5
 		var/list/eavesdroping = list()
@@ -315,15 +317,16 @@ proc/get_radio_key_from_channel(var/channel)
 		eavesdroping_obj -= listening_obj
 		for(var/mob/M in eavesdroping)
 			if(M)
-				M.hear_say(stars(message), verb, speaking, alt_name, italics, src, speech_sound, sound_vol)
+				heard_message = M.hear_say(stars(message), verb, speaking, alt_name, italics, src, speech_sound, sound_vol)
 				if(M.client)
 					speech_bubble_recipients |= M.client
+					unique[M.client] = heard_message
 
 		for(var/obj/O in eavesdroping)
 			spawn(0)
 				if(O) //It's possible that it could be deleted in the meantime.
 					O.hear_talk(src, stars(message), verb, speaking)
-	INVOKE_ASYNC(src, /atom/movable/proc/animate_chat, message, speaking, italics, speech_bubble_recipients)
+	INVOKE_ASYNC(src, /atom/movable/proc/animate_chat, message, speaking, italics, speech_bubble_recipients, whispering, unique)
 
 	if(whispering)
 		log_whisper("[name]/[key] : [message]")


### PR DESCRIPTION
## About the Pull Request

Ports #Foundation-19/Foundation-19/pull/301

- Whispers will be no longer broadcasted to runechat in its full form, instead they will be "starred".

## Why It's Good For The Game

- Whispering isn't visible to everyone with runechat enabled.

## Did you test it?

Has been tested on downstream, seems like it works.

## Authorship

Vivalas

## Changelog

:cl: Vivalas
fix: Whisper messages in runechat will no longer be fully visible, instead, their contents will be slightly hidden by star symbols.
/:cl: