### PR TITLE
Psionics fix

### DIFF
--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -200,7 +200,8 @@
 			current.set_psi_rank(href_list["set_psi_faculty"], text2num(href_list["set_psi_faculty_rank"]))
 			log_and_message_admins("set [key_name(current)]'s [href_list["set_psi_faculty"]] faculty to [text2num(href_list["set_psi_faculty_rank"])].")
 			var/datum/admins/admin = GLOB.admins[usr.key]
-			if(istype(admin)) admin.show_player_panel(current)
+			if(istype(admin))
+				admin.show_player_panel(current)
 			return TRUE
 
 	if(href_list["add_antagonist"])

--- a/code/modules/psionics/complexus/complexus.dm
+++ b/code/modules/psionics/complexus/complexus.dm
@@ -3,7 +3,6 @@
 	var/announced = FALSE             // Whether or not we have been announced to our holder yet.
 	var/suppressed = TRUE             // Whether or not we are suppressing our psi powers.
 	var/use_psi_armour = TRUE         // Whether or not we should automatically deflect/block incoming damage.
-	var/rebuild_power_cache = TRUE    // Whether or not we need to rebuild our cache of psi powers.
 
 	var/rating = 0                    // Overall psi rating.
 	var/cost_modifier = 1             // Multiplier for power use stamina costs.
@@ -44,7 +43,7 @@
 		_aura_image = create_aura_image(owner)
 	return _aura_image
 
-/proc/create_aura_image(var/newloc)
+/proc/create_aura_image(newloc)
 	var/image/aura_image = image(loc = newloc, icon = 'icons/effects/psi_aura_small.dmi', icon_state = "aura")
 	aura_image.blend_mode = BLEND_MULTIPLY
 	aura_image.appearance_flags = NO_CLIENT_COLOR | RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM
@@ -61,14 +60,14 @@
 	SSpsi.all_aura_images[aura_image] = TRUE
 	return aura_image
 
-/proc/destroy_aura_image(var/image/aura_image)
+/proc/destroy_aura_image(image/aura_image)
 	for(var/thing in SSpsi.processing)
 		var/datum/psi_complexus/psychic = thing
 		if(psychic.owner.client)
 			psychic.owner.client.images -= aura_image
 	SSpsi.all_aura_images -= aura_image
 
-/datum/psi_complexus/New(var/mob/_owner)
+/datum/psi_complexus/New(mob/_owner)
 	owner = _owner
 	START_PROCESSING(SSpsi, src)
 	set_extension(src, /datum/extension/armor/psionic)

--- a/code/modules/psionics/complexus/complexus_helpers.dm
+++ b/code/modules/psionics/complexus/complexus_helpers.dm
@@ -1,4 +1,4 @@
-/datum/psi_complexus/proc/cancel(var/play_sound = TRUE)
+/datum/psi_complexus/proc/cancel(play_sound = TRUE)
 	if(play_sound)
 		sound_to(owner, sound('sound/effects/psi/power_fail.ogg'))
 	if(LAZYLEN(manifested_items))
@@ -7,7 +7,7 @@
 			qdel(thing)
 		manifested_items = null
 
-/datum/psi_complexus/proc/stunned(var/amount)
+/datum/psi_complexus/proc/stunned(amount)
 	var/old_stun = stun
 	stun = max(stun, amount)
 	if(amount && !old_stun)
@@ -15,16 +15,16 @@
 		ui.update_icon()
 	cancel()
 
-/datum/psi_complexus/proc/get_armour(var/armourtype)
+/datum/psi_complexus/proc/get_armour(armourtype)
 	if(use_psi_armour && can_use_passive())
 		return round(Clamp(Clamp(4 * rating, 0, 20) * get_rank(SSpsi.armour_faculty_by_type[armourtype]), 0, 100) * (stamina/max_stamina))
 	else
 		return 0
 
-/datum/psi_complexus/proc/get_rank(var/faculty)
+/datum/psi_complexus/proc/get_rank(faculty)
 	return LAZYACCESS(ranks, faculty)
 
-/datum/psi_complexus/proc/set_rank(var/faculty, var/rank, var/defer_update, var/temporary)
+/datum/psi_complexus/proc/set_rank(faculty, rank, defer_update = FALSE, temporary = FALSE)
 	if(get_rank(faculty) != rank)
 		LAZYSET(ranks, faculty, rank)
 		if(!temporary)
@@ -32,17 +32,17 @@
 		if(!defer_update)
 			update()
 
-/datum/psi_complexus/proc/set_cooldown(var/value)
+/datum/psi_complexus/proc/set_cooldown(value)
 	next_power_use = world.time + value
 	ui.update_icon()
 
 /datum/psi_complexus/proc/can_use_passive()
 	return (owner.stat == CONSCIOUS && !suppressed && !stun)
 
-/datum/psi_complexus/proc/can_use(var/incapacitation_flags)
+/datum/psi_complexus/proc/can_use(incapacitation_flags)
 	return (owner.stat == CONSCIOUS && (!incapacitation_flags || !owner.incapacitated(incapacitation_flags)) && !suppressed && !stun && world.time >= next_power_use)
 
-/datum/psi_complexus/proc/spend_power(var/value = 0, var/check_incapacitated)
+/datum/psi_complexus/proc/spend_power(value = 0, check_incapacitated)
 	. = FALSE
 	if(isnull(check_incapacitated))
 		check_incapacitated = (INCAPACITATION_STUNNED|INCAPACITATION_KNOCKOUT)
@@ -58,7 +58,7 @@
 			. = FALSE
 		ui.update_icon()
 
-/datum/psi_complexus/proc/spend_power_armor(var/value = 0)
+/datum/psi_complexus/proc/spend_power_armor(value = 0)
 	armor_cost += value
 
 /datum/psi_complexus/proc/hide_auras()
@@ -71,7 +71,7 @@
 		for(var/image/I in SSpsi.all_aura_images)
 			owner.client.images |= I
 
-/datum/psi_complexus/proc/backblast(var/value)
+/datum/psi_complexus/proc/backblast(value)
 
 	// Can't backblast if you're controlling your power.
 	if(!owner || suppressed)

--- a/code/modules/psionics/complexus/complexus_power_cache.dm
+++ b/code/modules/psionics/complexus/complexus_power_cache.dm
@@ -1,49 +1,45 @@
 /datum/psi_complexus/proc/rebuild_power_cache()
-	if(rebuild_power_cache)
+	melee_powers =         list()
+	grab_powers =          list()
+	ranged_powers =        list()
+	manifestation_powers = list()
+	powers_by_faculty =    list()
 
-		melee_powers =         list()
-		grab_powers =          list()
-		ranged_powers =        list()
-		manifestation_powers = list()
-		powers_by_faculty =    list()
+	for(var/faculty in ranks)
+		var/relevant_rank = get_rank(faculty)
+		var/decl/psionic_faculty/faculty_decl = SSpsi.get_faculty(faculty)
+		for(var/thing in faculty_decl.powers)
+			var/decl/psionic_power/power = thing
+			if(relevant_rank >= power.min_rank)
+				if(!powers_by_faculty[power.faculty])
+					powers_by_faculty[power.faculty] = list()
+				powers_by_faculty[power.faculty] += power
+				if(power.use_ranged)
+					if(!ranged_powers[faculty])
+						ranged_powers[faculty] = list()
+					ranged_powers[faculty] += power
+				if(power.use_melee)
+					if(!melee_powers[faculty])
+						melee_powers[faculty] = list()
+					melee_powers[faculty] += power
+				if(power.use_manifest)
+					manifestation_powers += power
+				if(power.use_grab)
+					if(!grab_powers[faculty])
+						grab_powers[faculty] = list()
+					grab_powers[faculty] += power
 
-		for(var/faculty in ranks)
-			var/relevant_rank = get_rank(faculty)
-			var/decl/psionic_faculty/faculty_decl = SSpsi.get_faculty(faculty)
-			for(var/thing in faculty_decl.powers)
-				var/decl/psionic_power/power = thing
-				if(relevant_rank >= power.min_rank)
-					if(!powers_by_faculty[power.faculty]) powers_by_faculty[power.faculty] = list()
-					powers_by_faculty[power.faculty] += power
-					if(power.use_ranged)
-						if(!ranged_powers[faculty]) ranged_powers[faculty] = list()
-						ranged_powers[faculty] += power
-					if(power.use_melee)
-						if(!melee_powers[faculty]) melee_powers[faculty] = list()
-						melee_powers[faculty] += power
-					if(power.use_manifest)
-						manifestation_powers += power
-					if(power.use_grab)
-						if(!grab_powers[faculty]) grab_powers[faculty] = list()
-						grab_powers[faculty] += power
-		rebuild_power_cache = FALSE
-
-/datum/psi_complexus/proc/get_powers_by_faculty(var/faculty)
-	rebuild_power_cache()
+/datum/psi_complexus/proc/get_powers_by_faculty(faculty)
 	return powers_by_faculty[faculty]
 
-/datum/psi_complexus/proc/get_melee_powers(var/faculty)
-	rebuild_power_cache()
+/datum/psi_complexus/proc/get_melee_powers(faculty)
 	return melee_powers[faculty]
 
-/datum/psi_complexus/proc/get_ranged_powers(var/faculty)
-	rebuild_power_cache()
+/datum/psi_complexus/proc/get_ranged_powers(faculty)
 	return ranged_powers[faculty]
 
-/datum/psi_complexus/proc/get_grab_powers(var/faculty)
-	rebuild_power_cache()
+/datum/psi_complexus/proc/get_grab_powers(faculty)
 	return grab_powers[faculty]
 
 /datum/psi_complexus/proc/get_manifestations()
-	rebuild_power_cache()
 	return manifestation_powers

--- a/code/modules/psionics/complexus/complexus_process.dm
+++ b/code/modules/psionics/complexus/complexus_process.dm
@@ -1,4 +1,4 @@
-/datum/psi_complexus/proc/update(var/force)
+/datum/psi_complexus/proc/update(force)
 
 	set waitfor = FALSE
 
@@ -26,7 +26,6 @@
 				qdel(src)
 			return
 		else
-			rebuild_power_cache = TRUE
 			sound_to(owner, 'sound/effects/psi/power_unlock.ogg')
 			rating = ceil(combined_rank/rank_count)
 			cost_modifier = 1
@@ -61,6 +60,8 @@
 					aura_color = "#cccc33"
 			aura_image.pixel_x = -64 - owner.default_pixel_x
 			aura_image.pixel_y = -64 - owner.default_pixel_y
+
+	rebuild_power_cache()
 
 	if(!announced && owner && owner.client && !QDELETED(src))
 		announced = TRUE

--- a/code/modules/psionics/complexus/complexus_topic.dm
+++ b/code/modules/psionics/complexus/complexus_topic.dm
@@ -1,7 +1,7 @@
-/datum/psi_complexus/CanUseTopic(var/mob/user, var/datum/topic_state/state = GLOB.default_state)
+/datum/psi_complexus/CanUseTopic(mob/user, datum/topic_state/state = GLOB.default_state)
 	return (user.client && check_rights(R_ADMIN, FALSE, user.client))
 
-/datum/psi_complexus/Topic(var/href, var/list/href_list)
+/datum/psi_complexus/Topic(href, list/href_list)
 	. = ..()
 	if(!. && check_rights(R_ADMIN))
 		if(href_list && href_list["remove_psionics"])

--- a/code/modules/psionics/equipment/cerebro_enhancers.dm
+++ b/code/modules/psionics/equipment/cerebro_enhancers.dm
@@ -5,6 +5,9 @@
 	action_button_name = "Install Boosters"
 	icon_state = "cerebro"
 
+	flags_inv = 0
+	body_parts_covered = 0
+
 	item_state_slots = list(
 		slot_l_hand_str = "helmet",
 		slot_r_hand_str = "helmet"
@@ -17,23 +20,11 @@
 	var/max_boosted_faculties = 3
 	var/boosted_psipower = 120
 
-/obj/item/clothing/head/helmet/space/psi_amp/lesser
-	name = "psionic amplifier"
-	desc = "A crown-of-thorns cerebro-energetic enhancer that interfaces directly with the brain, isolating and strengthening psionic signals. It kind of looks like a tiara having sex with an industrial robot."
-	icon_state = "amp"
-	flags_inv = 0
-	body_parts_covered = 0
-
-	max_boosted_faculties = 2
-	boosted_rank = PSI_RANK_MASTER
-	unboosted_rank = PSI_RANK_OPERANT
-	boosted_psipower = 50
-
 /obj/item/clothing/head/helmet/space/psi_amp/Initialize()
 	. = ..()
 	verbs += /obj/item/clothing/head/helmet/space/psi_amp/proc/integrate
 
-/obj/item/clothing/head/helmet/space/psi_amp/attack_self(var/mob/user)
+/obj/item/clothing/head/helmet/space/psi_amp/attack_self(mob/user)
 	if(operating)
 		return
 
@@ -162,3 +153,13 @@
 	H.update_action_buttons()
 
 	set_light(0.5, 0.1, 3, 2, l_color = "#880000")
+
+/obj/item/clothing/head/helmet/space/psi_amp/lesser
+	name = "psionic amplifier"
+	desc = "A crown-of-thorns cerebro-energetic enhancer that interfaces directly with the brain, isolating and strengthening psionic signals. It kind of looks like a tiara having sex with an industrial robot."
+	icon_state = "amp"
+
+	max_boosted_faculties = 2
+	boosted_rank = PSI_RANK_MASTER
+	unboosted_rank = PSI_RANK_OPERANT
+	boosted_psipower = 50

--- a/code/modules/psionics/events/_psi.dm
+++ b/code/modules/psionics/events/_psi.dm
@@ -20,5 +20,5 @@
 	for(var/thing in SSpsi.processing)
 		apply_psi_effect(thing)
 
-/datum/event/psi/proc/apply_psi_effect(var/datum/psi_complexus/psi)
+/datum/event/psi/proc/apply_psi_effect(datum/psi_complexus/psi)
 	return

--- a/code/modules/psionics/events/mini_spasm.dm
+++ b/code/modules/psionics/events/mini_spasm.dm
@@ -30,7 +30,7 @@
 		var/obj/item/device/radio/source = victims[victim]
 		do_spasm(victim, source)
 
-/datum/event/minispasm/proc/do_spasm(var/mob/living/victim, var/obj/item/device/radio/source)
+/datum/event/minispasm/proc/do_spasm(mob/living/victim, obj/item/device/radio/source)
 	set waitfor = 0
 
 	if(iscarbon(victim) && !victim.isSynthetic())

--- a/code/modules/psionics/events/psi_balm.dm
+++ b/code/modules/psionics/events/psi_balm.dm
@@ -5,7 +5,7 @@
 		"A sense of peace and comfort falls over you like a warm blanket."
 		)
 
-/datum/event/psi/balm/apply_psi_effect(var/datum/psi_complexus/psi)
+/datum/event/psi/balm/apply_psi_effect(datum/psi_complexus/psi)
 	var/soothed
 	if(psi.stun > 1)
 		psi.stun--

--- a/code/modules/psionics/events/psi_wail.dm
+++ b/code/modules/psionics/events/psi_wail.dm
@@ -5,7 +5,7 @@
 		"Your head aches as a psychic wail intrudes on your psyche."
 		)
 
-/datum/event/psi/wail/apply_psi_effect(var/datum/psi_complexus/psi)
+/datum/event/psi/wail/apply_psi_effect(datum/psi_complexus/psi)
 	var/annoyed
 	if(prob(1))
 		psi.stunned(1)


### PR DESCRIPTION
## About the Pull Request

Fixes an issue where sometimes upon changing psi faculty ranks the powers wouldn't update.
Additionally, cleans up the code a little bit.

## Why It's Good For The Game

Fix + cleaner code.

## Did you test it?

Yes, seems to be working as expected.

## Authorship

Me.

## Changelog

:cl:
fix: Psionic powers will properly update whenever faculty levels are changed.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
