### PR TITLE
Bigger preview in character setup!

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -379,7 +379,7 @@
 		dress_mannequin(mannequin)
 		mannequin.dir = SOUTH
 		var/icon/preview_icon = getFlatIcon(mannequin)
-		preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2) // Scaling here to prevent blurring in the browser.
+		preview_icon.Scale(preview_icon.Width() * 4, preview_icon.Height() * 4) // Scaling here to prevent blurring in the browser. //old values were 2 instead of 4
 		SSjobs.job_icons[title] = preview_icon
 	return SSjobs.job_icons[title]
 

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -102,7 +102,7 @@
 	dress_preview_mob(mannequin)
 
 	preview_icon = icon('icons/effects/128x48.dmi', bgstate)
-	preview_icon.Scale(48+32, 16+32)
+	preview_icon.Scale(48+32, 16+32+16) //older values were: (48+32, 16+32), adding a +16 on the Y axis in order to fit in taller species
 
 	mannequin.dir = NORTH
 	var/icon/stamp = getFlatIcon(mannequin, NORTH, always_use_defdir = 1)
@@ -116,4 +116,4 @@
 	stamp = getFlatIcon(mannequin, SOUTH, always_use_defdir = 1)
 	preview_icon.Blend(stamp, ICON_OVERLAY, 49, 1)
 
-	preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2) // Scaling here to prevent blurring in the browser.
+	preview_icon.Scale(preview_icon.Width() * 4, preview_icon.Height() * 4) // Scaling here to prevent blurring in the browser. //old values were 2 instead of 4


### PR DESCRIPTION
## About the Pull Request

<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Tweaks some values in order to make the preview icon larger and overall wide enough to fit in taller species (such as adherents).

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It makes the character preview more visible and more accurate like in the following example:
![example_1](https://user-images.githubusercontent.com/64517916/208703509-d450bf36-3e82-4c0e-adb4-b1a97cdda860.png)
![example_2](https://user-images.githubusercontent.com/64517916/208703530-d8dc908c-8430-48b4-a725-700ff16f2c5c.png)



## Did you test it?

<!--
Please describe if you ran local tests to ensure compilation. If that is not the case, please make it abundantly clear so a maintainer knows they need to run local checks.
Note that this can include own balancing/gameplay tests, but does not need to.
-->

I tested it and it seems to be working fine.

## Authorship

<!--
Please note down any individuals or otherwise inspirations/sources you have for this code if it is ported or adapted.
We recommend using the git blame.
-->

## Changelog

:cl:
tweak
:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
