### PR TITLE
Singularity tweaks

### DIFF
--- a/code/modules/power/singularity/act.dm
+++ b/code/modules/power/singularity/act.dm
@@ -18,16 +18,12 @@
 	apply_damage(current_size * 3, IRRADIATE, damage_flags = DAM_DISPERSED)
 
 /mob/living/carbon/human/singularity_pull(S, current_size)
-	if(current_size >= STAGE_THREE)
-		var/list/handlist = list(l_hand, r_hand)
-		for(var/obj/item/hand in handlist)
-			if(prob(current_size*5) && hand.w_class >= ((11-current_size)/2) && unEquip(hand))
-				step_towards(hand, S)
-				to_chat(src, "<span class = 'warning'>\The [S] pulls \the [hand] from your grip!</span>")
-		if(!lying && (!shoes || !(shoes.item_flags & ITEM_FLAG_NOSLIP)) && (!species || !(species.check_no_slip(src))) && prob(current_size*5))
-			to_chat(src, "<span class='danger'>A strong gravitational force slams you to the ground!</span>")
-			Weaken(current_size)
-	..()
+	if(current_size < STAGE_THREE)
+		return ..()
+	if(!lying && (!shoes || !(shoes.item_flags & ITEM_FLAG_NOSLIP)) && (!species || !(species.check_no_slip(src))) && prob(current_size*5))
+		to_chat(src, "<span class='danger'>A strong gravitational force slams you to the ground!</span>")
+		Weaken(current_size)
+	return ..()
 
 /obj/singularity_act()
 	if(simulated)
@@ -97,6 +93,8 @@
 				continue
 			if(O.invisibility == 101)
 				O.singularity_act(src, current_size)
+	if(ispath(get_base_turf_by_area(src), src.type))
+		return // Do not increase power if we're eating something that will regenerate back into itself(exoplanet turfs)
 	ChangeTurf(get_base_turf_by_area(src))
 	return 2
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -59,7 +59,7 @@
 		return
 	switch(severity)
 		if(1.0)
-			if(prob(25))
+			if(prob(35 / current_size))
 				investigate_log("has been destroyed by an explosion.", I_SINGULO)
 				qdel(src)
 				return
@@ -112,7 +112,7 @@
 	else
 		dissipate_track++
 
-/obj/singularity/proc/expand(var/force_size = 0, var/growing = 1)
+/obj/singularity/proc/expand(force_size = 0, growing = 1)
 	if(current_size == STAGE_SUPER)//if this is happening, this is an error
 		message_admins("expand() was called on a super singulo. This should not happen. Contact a coder immediately!")
 		return
@@ -293,11 +293,11 @@
 
 	return
 
-/obj/singularity/proc/consume(const/atom/A)
-	src.energy += A.singularity_act(src, current_size)
+/obj/singularity/proc/consume(atom/A)
+	energy += A.singularity_act(src, current_size)
 	return
 
-/obj/singularity/proc/move(var/force_move = 0)
+/obj/singularity/proc/move(force_move = 0)
 	if(!move_self)
 		return 0
 


### PR DESCRIPTION
## About the Pull Request

- Singularity will not gain energy from consuming turfs that will return to themselves(mostly affects exoplanets).
- Singularity will not pull items from your hands anymore.

## Why It's Good For The Game

- Building singularity on a planet is a nice project, but less so when it's literally impossible to contain.
- Annoying mechanic with no counterplay.

## Did you test it?

Yes.

## Authorship

Me.

## Changelog

:cl:
tweak: Singularities will no longer increase energy from consuming turfs that regress into themselves (exoplanets).
tweak: Singularities no longer can pull items from your hands.
/:cl:
