### PR TITLE
Fixes light fixture allowed light tube types

### DIFF
--- a/code/game/objects/alien_props.dm
+++ b/code/game/objects/alien_props.dm
@@ -26,7 +26,7 @@
 	update_state = 0 //Don't pixelshift us on wall
 	cell_type = /obj/item/cell/alien
 	autoname = 0
-	
+
 /obj/machinery/power/apc/alien/on_update_icon()
 	check_updates()
 	if(update_state & APC_UPDATE_ALLGOOD)
@@ -43,7 +43,8 @@
 	icon_state = "bulb_map"
 	base_state = "bulb"
 	color = COLOR_PURPLE
-	light_type = /obj/item/light/alien
+	allowed_light_type = /obj/item/light/alien
+	spawn_light_type = /obj/item/light/alien
 
 /obj/machinery/light/alien/Initialize()
 	color = null  //It's just for mapping

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -161,7 +161,7 @@
 			if (isrobot(U))
 				qdel(bulb)
 
-		var/obj/item/light/L = new target.light_type()
+		var/obj/item/light/L = new target.allowed_light_type()
 		if (emagged)
 			log_and_message_admins("used an emagged light replacer.", U)
 			L.create_reagents(5)

--- a/code/modules/ascent/ascent_machines.dm
+++ b/code/modules/ascent/ascent_machines.dm
@@ -145,8 +145,9 @@ MANTIDIFY(/obj/machinery/door/airlock/external/bolted, "mantid airlock", "door")
 
 /obj/machinery/light/ascent
 	name = "mantid light"
-	light_type = /obj/item/light/tube/ascent
 	desc = "Some kind of strange alien lighting technology."
+	allowed_light_type = /obj/item/light/tube/ascent
+	spawn_light_type = /obj/item/light/tube/ascent
 
 /obj/machinery/computer/ship/helm/ascent
 	icon_state = "ascent"

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -172,7 +172,10 @@
 
 	var/on = 0					// 1 if on, 0 if off
 	var/flickering = 0
-	var/light_type = /obj/item/light/tube		// the type of light item
+	/// Allowed light tube type(and subtypes of it) that can be inserted into the fixture
+	var/allowed_light_type = /obj/item/light/tube
+	/// What type of tube it starts with
+	var/spawn_light_type = /obj/item/light/tube
 	var/construct_type = /obj/machinery/light_construct
 
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
@@ -192,32 +195,44 @@
 
 // Subtypes for mapping
 /obj/machinery/light/medbay
-	light_type = /obj/item/light/tube/medbay
+	spawn_light_type = /obj/item/light/tube/medbay
 
 /obj/machinery/light/yellowish
-	light_type = /obj/item/light/tube/yellowish
+	spawn_light_type = /obj/item/light/tube/yellowish
 
 /obj/machinery/light/dystopian
-	light_type = /obj/item/light/tube/dystopian
+	spawn_light_type = /obj/item/light/tube/dystopian
 
 // the smaller bulb light fixture
 /obj/machinery/light/small
 	icon_state = "bulb_map"
 	base_state = "bulb"
 	desc = "A small lighting fixture."
-	light_type = /obj/item/light/bulb
+	allowed_light_type = /obj/item/light/bulb
+	spawn_light_type = /obj/item/light/bulb
 	construct_type = /obj/machinery/light_construct/small
 
 /obj/machinery/light/small/emergency
-	light_type = /obj/item/light/bulb/red
+	spawn_light_type = /obj/item/light/bulb/red
 
 /obj/machinery/light/small/red
-	light_type = /obj/item/light/bulb/red
+	spawn_light_type = /obj/item/light/bulb/red
+
+// Subtypes for mapping
+/obj/machinery/light/small/medbay
+	spawn_light_type = /obj/item/light/bulb/medbay
+
+/obj/machinery/light/small/yellowish
+	spawn_light_type = /obj/item/light/bulb/yellowish
+
+/obj/machinery/light/small/dystopian
+	spawn_light_type = /obj/item/light/bulb/dystopian
 
 /obj/machinery/light/spot
 	name = "spotlight"
 	desc = "A more robust socket for light tubes that demand more power."
-	light_type = /obj/item/light/tube/large
+	allowed_light_type = /obj/item/light/tube/large
+	spawn_light_type = /obj/item/light/tube/large
 	construct_type = /obj/machinery/light_construct/spot
 
 // create a new lighting fixture
@@ -231,7 +246,7 @@
 		construct.transfer_fingerprints_to(src)
 		set_dir(construct.dir)
 	else
-		lightbulb = new light_type(src)
+		lightbulb = new spawn_light_type(src)
 		if(prob(lightbulb.broken_chance))
 			broken(1)
 
@@ -368,7 +383,7 @@
 			to_chat(user, "The [fitting] has been smashed.")
 
 /obj/machinery/light/proc/get_fitting_name()
-	var/obj/item/light/L = light_type
+	var/obj/item/light/L = allowed_light_type
 	return initial(L.name)
 
 // attack with item - insert light (if right type), otherwise try to break the light
@@ -394,7 +409,7 @@
 		if(lightbulb)
 			to_chat(user, SPAN_WARNING("There is a [get_fitting_name()] already inserted."))
 			return
-		if(!istype(W, light_type))
+		if(!istype(W, allowed_light_type))
 			to_chat(user, SPAN_WARNING("This type of light requires a [get_fitting_name()]."))
 			return
 		if(!user.unEquip(W, src))
@@ -571,7 +586,7 @@
 		broken()
 
 /obj/machinery/light/small/readylight
-	light_type = /obj/item/light/bulb/red/readylight
+	spawn_light_type = /obj/item/light/bulb/red/readylight
 	var/state = 0
 
 /obj/machinery/light/small/readylight/proc/set_state(var/new_state)
@@ -587,7 +602,8 @@
 	icon = 'icons/obj/lighting_nav.dmi'
 	icon_state = "nav10"
 	base_state = "nav1"
-	light_type = /obj/item/light/tube/large
+	allowed_light_type = /obj/item/light/tube/large
+	spawn_light_type = /obj/item/light/tube/large
 	on = TRUE
 
 /obj/machinery/light/navigation/delay2
@@ -672,16 +688,19 @@
 // Blue-ish color for use in medical areas
 /obj/item/light/tube/medbay
 	desc = "A replacement light tube. This one is meant to be used in sterile/medical areas."
+	color = "#e0fefe"
 	b_colour = "#e0fefe"
 
 // Yellow-ish color
 /obj/item/light/tube/yellowish
 	desc = "A replacement light tube. This one has a yellow tint to it."
+	color = "#fffee0"
 	b_colour = "#fffee0"
 
 // DYSTOPIAN GREEN-BLUE COLOR OF CORPORATE OFFICES!
 /obj/item/light/tube/dystopian
 	desc = "A replacement light tube. This one is meant to be used in a corporate office where you will spend your life doing meaningless, soul-consuming paperwork."
+	color = "#addbbe"
 	b_colour = "#addbbe"
 
 /obj/item/light/tube/party/Initialize() //Randomly colored light tubes. Mostly for testing, but maybe someone will find a use for them.
@@ -739,6 +758,22 @@
 	base_state = "fbulb"
 	item_state = "egg4"
 	matter = list(MATERIAL_GLASS = 100)
+
+// Subtypes for mapping
+/obj/item/light/bulb/medbay
+	desc = "A replacement light bulb. This one is meant to be used in sterile/medical areas."
+	color = "#e0fefe"
+	b_colour = "#e0fefe"
+
+/obj/item/light/bulb/yellowish
+	desc = "A replacement light bulb. This one has a yellow tint to it."
+	color = "#fffee0"
+	b_colour = "#fffee0"
+
+/obj/item/light/bulb/dystopian
+	desc = "A replacement light bulb. This one is meant to be used in a corporate office where you will spend your life doing meaningless, soul-consuming paperwork."
+	color = "#addbbe"
+	b_colour = "#addbbe"
 
 // update the icon state and description of the light
 /obj/item/light/on_update_icon()

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -249,8 +249,9 @@
 
 /obj/machinery/light/skrell
 	name = "skrellian light"
-	light_type = /obj/item/light/tube/skrell
 	desc = "Some kind of strange alien lighting technology."
+	allowed_light_type = /obj/item/light/tube/skrell
+	spawn_light_type = /obj/item/light/tube/skrell
 
 
 /obj/item/light/tube/skrell


### PR DESCRIPTION
## About the Pull Request

- Added variable to distinct what tubes/bulbs can be inserted into machine and what it spawns with.
- Added mapping subtypes for small lights, similar to those that existed for tubes.

## Why It's Good For The Game

- This mainly affects subtypes, as previously it would require a very specific type of tube/bulb, despite being absolutely the same as normal fixture type.
- Just a nice mapping thing.

## Did you test it?

Yes.

## Authorship

Me.

## Changelog

:cl:
fix: Normal light tubes can be inserted into subtype fixtures(i.e. medbay, yellow and dystopian).
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
