### PR TITLE
Fixes rogue drones event

### DIFF
--- a/code/modules/events/rogue_drones.dm
+++ b/code/modules/events/rogue_drones.dm
@@ -3,21 +3,21 @@
 	var/list/drones_list = list()
 
 /datum/event/rogue_drone/start()
-	//spawn them at the same place as carp
-	var/list/possible_spawns = list()
-	for(var/obj/effect/landmark/C in landmarks_list)
-		if(C.name == "carpspawn")
-			possible_spawns.Add(C)
-
-	//25% chance for this to be a false alarm
-	var/num = 0
-	if (length(possible_spawns) && prob(75))
-		num = rand(2, 6)
-	for(var/i=0, i<num, i++)
-		var/mob/living/simple_animal/hostile/retaliate/malf_drone/D = new(get_turf(pick(possible_spawns)))
-		drones_list.Add(D)
-		if(prob(25))
-			D.disabled = rand(15, 60)
+	var/n = rand(2, 6)
+	var/I = 0
+	while(I < n)
+		var/speed = rand(1,3)
+		var/dir = pick(GLOB.cardinal)
+		var/Z = pick(affecting_z)
+		var/turf/T = get_random_edge_turf(dir,TRANSITIONEDGE + 2, Z)
+		if(istype(T,/turf/space))
+			var/mob/living/simple_animal/hostile/retaliate/malf_drone/M
+			M = new /mob/living/simple_animal/hostile/retaliate/malf_drone(T)
+			drones_list.Add(M)
+			if(prob(25))
+				M.disabled = rand(15, 60)
+			M.throw_at(get_random_edge_turf(GLOB.reverse_dir[dir],TRANSITIONEDGE + 2, Z), 5, speed)
+		I++
 
 /datum/event/rogue_drone/announce()
 	command_announcement.Announce("Attention: unidentified patrol drones detected within proximity to the [location_name()]", "[location_name()] Sensor Array", zlevels = affecting_z)


### PR DESCRIPTION
## About the Pull Request

Ports #Baystation12/Baystation12/pull/32270

This, supposedly, makes rogue drones actually spawn.

## Why It's Good For The Game

Fix.

## Did you test it?

No.

## Authorship

[MuckerMayhem](https://github.com/MuckerMayhem)

## Changelog

:cl:Mucker
bugfix: Fixed the rogue drone event so that it actually spawns drones.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
