### PR TITLE
Drone tweaks

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2272,6 +2272,7 @@
 #include "code\modules\mob\living\silicon\robot\drone\drone_damage.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_items.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_manufacturer.dm"
+#include "code\modules\mob\living\silicon\robot\drone\drone_remote_control.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_say.dm"
 #include "code\modules\mob\living\silicon\robot\flying\flying.dm"
 #include "code\modules\mob\living\silicon\robot\flying\module_flying.dm"

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -32,12 +32,12 @@ var/list/mob_hat_cache = list()
 	pass_flags = PASS_FLAG_TABLE
 	braintype = "Drone"
 	lawupdate = FALSE
-	density = TRUE
+	density = FALSE
 	req_access = list(access_engine, access_robotics)
 	integrated_light_max_bright = 0.5
 	local_transmit = 1
 	possession_candidate = 1
-	speed = -2
+	speed = -1
 
 	can_pull_size = ITEM_SIZE_NORMAL
 	can_pull_mobs = MOB_PULL_SMALLER
@@ -102,7 +102,7 @@ var/list/mob_hat_cache = list()
 	// None of the tests passed, good bye
 	self_destruct()
 
-/mob/living/silicon/robot/drone/can_be_possessed_by(var/mob/observer/ghost/possessor)
+/mob/living/silicon/robot/drone/can_be_possessed_by(mob/observer/ghost/possessor)
 	if(!istype(possessor) || !possessor.client || !possessor.ckey)
 		return 0
 	if(!config.allow_drone_spawn)
@@ -130,6 +130,21 @@ var/list/mob_hat_cache = list()
 	qdel(possessor)
 	return 1
 
+/mob/living/silicon/robot/drone/show_laws(everyone = FALSE)
+	if(!controlling_ai)
+		return..()
+	to_chat(src, "<b>Obey these laws:</b>")
+	controlling_ai.laws_sanity_check()
+	controlling_ai.laws.show_laws(src)
+
+/mob/living/silicon/robot/drone/robot_checklaws()
+	set category = "Silicon Commands"
+	set name = "State Laws"
+
+	if(!controlling_ai)
+		return ..()
+	controlling_ai.open_subsystem(/datum/nano_module/law_manager)
+
 /mob/living/silicon/robot/drone/construction
 	name = "construction drone"
 	icon_state = "constructiondrone"
@@ -154,14 +169,18 @@ var/list/mob_hat_cache = list()
 	SetName(real_name)
 
 /mob/living/silicon/robot/drone/updatename()
-	real_name = "[initial(name)] ([random_id(type,100,999)])"
+	if(controlling_ai)
+		real_name = "remote [initial(name)] ([controlling_ai.name])"
+	else
+		real_name = "[initial(name)] ([random_id(type,100,999)])"
 	SetName(real_name)
 
 /mob/living/silicon/robot/drone/on_update_icon()
-
 	overlays.Cut()
 	if(stat == 0)
-		if(emagged)
+		if(controlling_ai)
+			overlays += "eyes-[icon_state]-ai"
+		else if(emagged)
 			overlays += "eyes-[icon_state]-emag"
 		else
 			overlays += "eyes-[icon_state]"
@@ -236,7 +255,7 @@ var/list/mob_hat_cache = list()
 
 	..()
 
-/mob/living/silicon/robot/drone/emag_act(var/remaining_charges, var/mob/user)
+/mob/living/silicon/robot/drone/emag_act(remaining_charges, mob/user)
 	if(!client || stat == 2)
 		to_chat(user, "<span class='danger'>There's not much point subverting this heap of junk.</span>")
 		return
@@ -248,9 +267,12 @@ var/list/mob_hat_cache = list()
 
 	to_chat(user, "<span class='danger'>You swipe the sequencer across [src]'s interface and watch its eyes flicker.</span>")
 
-	to_chat(src, "<span class='danger'>You feel a sudden burst of malware loaded into your execute-as-root buffer. Your tiny brain methodically parses, loads and executes the script.</span>")
+	if(controlling_ai)
+		to_chat(src, "<span class='danger'>\The [user] loads some kind of subversive software into the remote drone, corrupting its lawset but luckily sparing yours.</span>")
+	else
+		to_chat(src, "<span class='danger'>You feel a sudden burst of malware loaded into your execute-as-root buffer. Your tiny brain methodically parses, loads and executes the script.</span>")
 
-	log_and_message_admins("emagged drone [key_name_admin(src)].  Laws overridden.", user)
+	log_and_message_admins("[key_name_admin(user)] emagged drone [key_name_admin(src)][controlling_ai ? ", but AI [key_name(controlling_ai)] is in remote control" : ". Laws overridden"].")
 	var/time = time2text(world.realtime,"hh:mm:ss")
 	GLOB.lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) emagged [name]([key])")
 
@@ -262,6 +284,9 @@ var/list/mob_hat_cache = list()
 	QDEL_NULL(laws)
 	laws = new /datum/ai_laws/syndicate_override
 	set_zeroth_law("Only [user.real_name] and people \he designates as being such are operatives.")
+	if(!controlling_ai)
+		to_chat(src, "<b>Obey these laws:</b>")
+		show_laws()
 
 //DRONE LIFE/DEATH
 //For some goddamn reason robots have this hardcoded. Redefining it for our fragile friends here.
@@ -296,6 +321,10 @@ var/list/mob_hat_cache = list()
 
 //CONSOLE PROCS
 /mob/living/silicon/robot/drone/proc/law_resync()
+	if(controlling_ai)
+		to_chat(src, "<span class='warning'>Someone issues a remote law reset order for this unit, but you disregard it.</span>")
+		return
+
 	if(stat != 2)
 		if(emagged)
 			to_chat(src, "<span class='danger'>You feel something attempting to modify your programming, but your hacked subroutines are unaffected.</span>")
@@ -305,6 +334,9 @@ var/list/mob_hat_cache = list()
 			show_laws()
 
 /mob/living/silicon/robot/drone/proc/shut_down()
+	if(controlling_ai)
+		to_chat(src, "<span class='warning'>Someone issues a remote kill order for this unit, but you disregard it.</span>")
+		return
 
 	if(stat != 2)
 		if(emagged)

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -1,6 +1,6 @@
 /proc/count_drones()
 	var/drones = 0
-	for(var/mob/living/silicon/robot/drone/D in world)
+	for(var/mob/living/silicon/robot/drone/D in GLOB.living_mob_list_)
 		if(D.key && D.client)
 			drones++
 	return drones
@@ -8,6 +8,8 @@
 /obj/machinery/drone_fabricator
 	name = "drone fabricator"
 	desc = "A large automated factory for producing maintenance drones."
+	icon = 'icons/obj/machines/drone_fab.dmi'
+	icon_state = "drone_fab_idle"
 	appearance_flags = 0
 
 	density = TRUE
@@ -21,16 +23,10 @@
 	var/time_last_drone = 500
 	var/drone_type = /mob/living/silicon/robot/drone
 
-	icon = 'icons/obj/machines/drone_fab.dmi'
-	icon_state = "drone_fab_idle"
-
 /obj/machinery/drone_fabricator/derelict
 	name = "construction drone fabricator"
 	fabricator_tag = "Derelict"
 	drone_type = /mob/living/silicon/robot/drone/construction
-
-/obj/machinery/drone_fabricator/New()
-	..()
 
 /obj/machinery/drone_fabricator/power_change()
 	. = ..()
@@ -59,10 +55,9 @@
 /obj/machinery/drone_fabricator/examine(mob/user)
 	. = ..()
 	if(produce_drones && drone_progress >= 100 && isghost(user) && config.allow_drone_spawn && count_drones() < config.max_maint_drones)
-		to_chat(user, "<BR><B>A drone is prepared. Select 'Join As Drone' from the Ghost tab to spawn as a maintenance drone.</B>")
+		to_chat(user, "<BR><B>A drone is prepared. Select 'Join As Drone' from the Ghost tab or click on it to spawn as a maintenance drone.</B>")
 
-/obj/machinery/drone_fabricator/proc/create_drone(var/client/player)
-
+/obj/machinery/drone_fabricator/proc/create_drone(client/player)
 	if(stat & NOPOWER)
 		return
 
@@ -72,18 +67,30 @@
 	if(player && !isghost(player.mob))
 		return
 
-	visible_message("\The [src] churns and grinds as it lurches into motion, disgorging a shiny new drone after a few moments.")
+	var/mob/living/silicon/robot/drone/D = drone_type
+	visible_message("\The [src] churns and grinds as it lurches into motion, disgorging a shiny new [initial(D.name)] after a few moments.")
 	flick("h_lathe_leave",src)
 	drone_progress = 0
 	time_last_drone = world.time
 
-	var/mob/living/silicon/robot/drone/new_drone = new drone_type(get_turf(src))
+	var/mob/living/silicon/robot/drone/new_drone = new D(get_turf(src))
 	if(player)
-		announce_ghost_joinleave(player, 0, "They have taken control over a maintenance drone.")
-		if(player.mob && player.mob.mind) player.mob.mind.reset()
+		announce_ghost_joinleave(player, 0, "They have taken control over a [initial(D.name)].")
+		if(player.mob && player.mob.mind)
+			player.mob.mind.reset()
 		new_drone.transfer_personality(player)
 
 	return new_drone
+
+/obj/machinery/drone_fabricator/Click(location, control, params)
+	if(!isghost(usr))
+		return ..()
+
+	var/list/modifiers = params2list(params)
+	if(modifiers["shift"])
+		return ..()
+
+	try_drone_spawn(usr, src)
 
 /mob/observer/ghost/verb/join_as_drone()
 	set category = "Ghost"
@@ -91,30 +98,28 @@
 	set desc = "If there is a powered, enabled fabricator in the game world with a prepared chassis, join as a maintenance drone."
 	try_drone_spawn(src)
 
-/proc/try_drone_spawn(var/mob/user, var/obj/machinery/drone_fabricator/fabricator)
-
+/proc/try_drone_spawn(mob/user, obj/machinery/drone_fabricator/fabricator)
 	if(GAME_STATE < RUNLEVEL_GAME)
-		to_chat(user, "<span class='danger'>The game hasn't started yet!</span>")
+		to_chat(user, SPAN_DANGER("The game hasn't started yet!"))
 		return
 
 	if(!(config.allow_drone_spawn))
-		to_chat(user, "<span class='danger'>That verb is not currently permitted.</span>")
+		to_chat(user, SPAN_DANGER("That verb is not currently permitted."))
 		return
 
 	if(jobban_isbanned(user,"Robot"))
-		to_chat(user, "<span class='danger'>You are banned from playing synthetics and cannot spawn as a drone.</span>")
+		to_chat(user, SPAN_DANGER("You are banned from playing synthetics and cannot spawn as a drone."))
 		return
 
 	if(config.use_age_restriction_for_jobs && isnum(user.client.player_age))
 		if(user.client.player_age <= 3)
-			to_chat(user, "<span class='danger'> Your account is not old enough to play as a maintenance drone.</span>")
+			to_chat(user, SPAN_DANGER("Your account is not old enough to play as a maintenance drone."))
 			return
 
 	if(!user.MayRespawn(1, DRONE_SPAWN_DELAY))
 		return
 
 	if(!fabricator)
-
 		var/list/all_fabricators = list()
 		for(var/obj/machinery/drone_fabricator/DF in SSmachines.machinery)
 			if((DF.stat & NOPOWER) || !DF.produce_drones || DF.drone_progress < 100)
@@ -122,7 +127,7 @@
 			all_fabricators[DF.fabricator_tag] = DF
 
 		if(!all_fabricators.len)
-			to_chat(user, "<span class='danger'>There are no available drone spawn points, sorry.</span>")
+			to_chat(user, SPAN_DANGER("There are no available drone spawn points, sorry."))
 			return
 
 		var/choice = input(user,"Which fabricator do you wish to use?") as null|anything in all_fabricators
@@ -130,10 +135,14 @@
 			return
 		fabricator = all_fabricators[choice]
 
+	var/mob/living/silicon/robot/drone/D = fabricator.drone_type
+	if(alert(usr, "Do you wish to respawn as a [initial(D.name)]?",, "Yes", "No") != "Yes")
+		return
+
 	if(user && fabricator && !((fabricator.stat & NOPOWER) || !fabricator.produce_drones || fabricator.drone_progress < 100))
-		log_and_message_admins("has joined the round as a maintenance drone.")
 		var/mob/drone = fabricator.create_drone(user.client)
 		if(drone)
 			drone.status_flags |= NO_ANTAG
-		return 1
+			log_and_message_admins("has joined the round as a [initial(drone.name)].")
+		return TRUE
 	return

--- a/code/modules/mob/living/silicon/robot/drone/drone_remote_control.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_remote_control.dm
@@ -1,0 +1,114 @@
+/mob/living/silicon/ai
+	var/mob/living/silicon/robot/drone/controlling_drone
+
+/mob/living/silicon/robot/drone
+	var/mob/living/silicon/ai/controlling_ai
+	var/obj/item/device/radio/drone_silicon_radio
+
+/mob/living/silicon/robot/drone/attack_ai(var/mob/living/silicon/ai/user)
+
+	if(!istype(user) || controlling_ai || !config.allow_drone_spawn)
+		return
+
+	if(stat != 2 || client || key)
+		to_chat(user, "<span class='warning'>You cannot take control of an autonomous, active drone.</span>")
+		return
+
+	if(health < -35 || emagged)
+		to_chat(user, "<span class='notice'><b>WARNING:</b> connection timed out.</span>")
+		return
+
+	assume_control(user)
+
+/mob/living/silicon/robot/drone/proc/assume_control(var/mob/living/silicon/ai/user)
+	user.controlling_drone = src
+	controlling_ai = user
+	verbs += /mob/living/silicon/robot/drone/proc/release_ai_control_verb
+	local_transmit = FALSE
+	languages = controlling_ai.languages.Copy()
+
+	//give controlled drone access to AI radio
+	drone_silicon_radio = silicon_radio
+	silicon_radio = new /obj/item/device/radio/headset/heads/ai_integrated(src)
+	//silicon_radio.recalculateChannels()
+
+	add_language(LANGUAGE_DRONE_GLOBAL, 1)
+	add_language(LANGUAGE_ROBOT_GLOBAL, 1)
+	default_language = controlling_ai.default_language
+
+	stat = CONSCIOUS
+	if(user.mind)
+		user.mind.transfer_to(src)
+	else
+		key = user.key
+	updatename()
+	to_chat(src, "<span class='notice'><b>You have shunted your primary control loop into \a [initial(name)].</b> Use the <b>Release Control</b> verb to return to your core.</span>")
+
+/obj/machinery/drone_fabricator/attack_ai(var/mob/living/silicon/ai/user)
+
+	if(!istype(user) || user.controlling_drone || !config.allow_drone_spawn)
+		return
+
+	if(stat & NOPOWER)
+		to_chat(user, "<span class='warning'>\The [src] is unpowered.</span>")
+		return
+
+	if(!produce_drones)
+		to_chat(user, "<span class='warning'>\The [src] is disabled.</span>")
+		return
+
+	if(drone_progress < 100)
+		to_chat(user, "<span class='warning'>\The [src] is not ready to produce a new drone.</span>")
+		return
+
+	if(count_drones() >= config.max_maint_drones)
+		to_chat(user, "<span class='warning'>The drone control subsystems are tasked to capacity; they cannot support any more drones.</span>")
+		return
+
+	var/mob/living/silicon/robot/drone/new_drone = create_drone()
+	new_drone.assume_control(user)
+
+
+/mob/living/silicon/robot/drone/death(gibbed)
+	if(controlling_ai)
+		release_ai_control("<b>WARNING: remote system failure.</b> Connection timed out.")
+	drone_silicon_radio = null
+	. = ..(gibbed)
+
+/mob/living/silicon/ai/death(gibbed)
+	if(controlling_drone)
+		controlling_drone.release_ai_control("<b>WARNING: Primary control loop failure.</b> Session terminated.")
+	. = ..(gibbed)
+
+/mob/living/silicon/ai/Life()
+	. = ..()
+	if(controlling_drone && stat != CONSCIOUS)
+		controlling_drone.release_ai_control("<b>WARNING: Primary control loop failure.</b> Session terminated.")
+
+/mob/living/silicon/robot/drone/proc/release_ai_control_verb()
+	set name = "Release Control"
+	set desc = "Release control of a remote drone."
+	set category = "Silicon Commands"
+
+	release_ai_control("Remote session terminated.")
+
+/mob/living/silicon/robot/drone/proc/release_ai_control(var/message = "Connection terminated.")
+
+	if(controlling_ai)
+		if(mind)
+			mind.transfer_to(controlling_ai)
+		else
+			controlling_ai.key = key
+		to_chat(controlling_ai, "<span class='notice'>[message]</span>")
+		controlling_ai.controlling_drone = null
+		controlling_ai = null
+	//releases controlled drone access to AI radio
+	QDEL_NULL(silicon_radio)
+	silicon_radio = drone_silicon_radio
+	drone_silicon_radio = null
+	default_language = all_languages[LANGUAGE_DRONE_GLOBAL]
+
+	verbs -= /mob/living/silicon/robot/drone/proc/release_ai_control_verb
+	full_law_reset()
+	updatename()
+	death()


### PR DESCRIPTION
## About the Pull Request

- Drones can be once again remote-controlled by AI.
- Drones are slightly slower and aren't dense.
- Drone fabricator can be activated by clicking on it as a ghost, instead of only by using verb.

## Why It's Good For The Game

- Allows AI to do more stuff, simple as that.
- Drones used to be too fast and could block people(especially annoying). This isn't the case anymore.
- Just QOL.

## Did you test it?

Yes.

## Authorship

I believe the "remote control" code was already there before, just deleted at some point.

## Changelog

:cl:
tweak: AI can remote-control drones.
tweak: You can now click on drone fabricator as ghost to respawn as a drone.
balance: Drones are no longer dense and are slightly slower.
/:cl:
