### PR TITLE
Fixes planet edges and explosive projectiles

### DIFF
--- a/code/modules/overmap/exoplanets/turfs.dm
+++ b/code/modules/overmap/exoplanets/turfs.dm
@@ -292,3 +292,7 @@
 			if(L.pulling)
 				var/atom/movable/AM = L.pulling
 				AM.forceMove(T)
+
+// Singulo won't delete literal planet edges
+/turf/simulated/planet_edge/singularity_act()
+	return

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -463,7 +463,10 @@
 	tracer_type = /obj/effect/projectile/tracer/emitter
 	impact_type = /obj/effect/projectile/impact/emitter
 
-/obj/item/projectile/beam/gigabeam/on_hit(atom/target, blocked = 0)
-	..()
+/obj/item/projectile/beam/gigabeam/on_impact(atom/target)
+	if(QDELETED(src))
+		return
 	var/turf/T = get_turf(target)
-	explosion(T, 1, 3, 5)
+	if(T)
+		explosion(T, 1, 3, 5)
+	return ..()

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -330,11 +330,13 @@
 	var/exp_heavy_impact = 2
 	var/exp_light_impact = 4
 
-/obj/item/projectile/bullet/rocket/on_hit(atom/target, blocked = 0)
+/obj/item/projectile/bullet/rocket/on_impact(atom/target, blocked = 0)
+	if(QDELETED(src))
+		return
 	var/turf/T = get_turf(target)
 	if(T)
 		explosion(T, exp_devastation, exp_heavy_impact, exp_light_impact)
-	..()
+	return ..()
 
 /obj/item/projectile/bullet/rocket/heavy
 	exp_devastation = 2


### PR DESCRIPTION
## About the Pull Request

- Explosive projectiles recursion fixed.
- Singularity cannot delete planet edges.

## Why It's Good For The Game

- Fix.
- As rare as it could be, we shouldn't make it possible for singularity to eat literal world edges.

## Did you test it?

Of course not.

## Changelog

:cl:
fix: Explosive projectiles(rockets, gigabeam) no longer crash the server with infinite explosions.
fix: Singularity cannot destroy planet edges anymore.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
