### PR TITLE
Reduces organ damage

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -111,11 +111,14 @@
 #define INTERNAL_ORGAN_DAMAGE_THRESHOLD 30
 
 // Damage thresholds for limb(external organ) dismemberment from various damage sources
-// Those are all multipliers of max_damage of limb itself, so for organ with 100 max health - Edge threshold will be 50.
+// Those are all multipliers of max_damage of limb itself, so for organ with 100 max health - Edge threshold will be 20.
 #define DROPLIMB_THRESHOLD_EDGE 0.2
 #define DROPLIMB_THRESHOLD_TEAROFF 0.4
 #define DROPLIMB_THRESHOLD_DESTROY_BRUTE 0.6
 #define DROPLIMB_THRESHOLD_DESTROY_BURN 0.7
+// Multiplier of spillover damage. The spillover is added to brute/burn in droplimb calculations.
+// 0.1 mult with 100 damage above maximum limb's health will equate to +10 damage in the calculation, simple enough.
+#define DROPLIMB_SPILLOVER_MULT 0.05
 
 #define ORGAN_RECOVERY_THRESHOLD (5 MINUTES)
 

--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -34,7 +34,8 @@
 #define DAM_BIO       64 // Toxin damage that should be mitigated by biological (i.e. sterile) armor
 
 #define FIRE_DAMAGE_MODIFIER 0.0215 // Higher values result in more external fire damage to the skin. (default 0.0215)
-#define  AIR_DAMAGE_MODIFIER 2.025  // More means less damage from hot air scalding lungs, less = more damage. (default 2.025)
+#define AIR_DAMAGE_MODIFIER  5.0    // More means less damage from hot air scalding lungs, less = more damage. (default 2.025)
+#define MAX_PRESSURE_LUNGS_DAMAGE 10.0 // The maximum amount of damage each tick in extreme pressure environments
 
 // Organ defines.
 #define ORGAN_CUT_AWAY   (1<<0)  // The organ is in the process of being surgically removed.

--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -35,7 +35,7 @@
 
 #define FIRE_DAMAGE_MODIFIER 0.0215 // Higher values result in more external fire damage to the skin. (default 0.0215)
 #define AIR_DAMAGE_MODIFIER  5.0    // More means less damage from hot air scalding lungs, less = more damage. (default 2.025)
-#define MAX_PRESSURE_LUNGS_DAMAGE 10.0 // The maximum amount of damage each tick in extreme pressure environments
+#define MAX_PRESSURE_LUNGS_DAMAGE 20.0 // The maximum amount of damage upon exposure to extreme pressure environments
 
 // Organ defines.
 #define ORGAN_CUT_AWAY   (1<<0)  // The organ is in the process of being surgically removed.

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -20,13 +20,13 @@
 #define COLD_DAMAGE_LEVEL_3 3 //Amount of damage applied when your body temperature passes the 120K point
 
 //Note that gas heat damage is only applied once every FOUR ticks.
-#define HEAT_GAS_DAMAGE_LEVEL_1 2 //Amount of damage applied when the current breath's temperature just passes the 360.15k safety point
-#define HEAT_GAS_DAMAGE_LEVEL_2 4 //Amount of damage applied when the current breath's temperature passes the 400K point
-#define HEAT_GAS_DAMAGE_LEVEL_3 8 //Amount of damage applied when the current breath's temperature passes the 1000K point
+#define HEAT_GAS_DAMAGE_LEVEL_1 1 //Amount of damage applied when the current breath's temperature just passes the 360.15k safety point
+#define HEAT_GAS_DAMAGE_LEVEL_2 2 //Amount of damage applied when the current breath's temperature passes the 400K point
+#define HEAT_GAS_DAMAGE_LEVEL_3 4 //Amount of damage applied when the current breath's temperature passes the 1000K point
 
 #define COLD_GAS_DAMAGE_LEVEL_1 0.5 //Amount of damage applied when the current breath's temperature just passes the 260.15k safety point
-#define COLD_GAS_DAMAGE_LEVEL_2 1.5 //Amount of damage applied when the current breath's temperature passes the 200K point
-#define COLD_GAS_DAMAGE_LEVEL_3 3 //Amount of damage applied when the current breath's temperature passes the 120K point
+#define COLD_GAS_DAMAGE_LEVEL_2 1 //Amount of damage applied when the current breath's temperature passes the 200K point
+#define COLD_GAS_DAMAGE_LEVEL_3 2 //Amount of damage applied when the current breath's temperature passes the 120K point
 
 #define RADIATION_SPEED_COEFFICIENT 0.025
 

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -371,6 +371,10 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 			droplimb(0, edge_eligible ? DROPLIMB_EDGE : DROPLIMB_BLUNT)
 		return TRUE
 
+	// Broken bones make it easier to dismember via brute damage
+	if(status & ORGAN_BROKEN)
+		brute *= 1.25
+
 	// Sharp/Edgy weapons with enough BRUTE damage
 	if(edge_eligible && brute + (spillover * DROPLIMB_SPILLOVER_MULT) >= max_damage * DROPLIMB_THRESHOLD_EDGE)
 		if(prob(brute))

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -372,25 +372,25 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 		return TRUE
 
 	// Sharp/Edgy weapons with enough BRUTE damage
-	if(edge_eligible && brute >= max_damage * DROPLIMB_THRESHOLD_EDGE)
+	if(edge_eligible && brute + (spillover * DROPLIMB_SPILLOVER_MULT) >= max_damage * DROPLIMB_THRESHOLD_EDGE)
 		if(prob(brute))
 			droplimb(0, DROPLIMB_EDGE)
 			return TRUE
 
 	// Overly high BURN damage
-	else if(burn >= max_damage * DROPLIMB_THRESHOLD_DESTROY_BURN)
+	else if(burn + (spillover * DROPLIMB_SPILLOVER_MULT) >= max_damage * DROPLIMB_THRESHOLD_DESTROY_BURN)
 		if(prob(burn * 0.3))
 			droplimb(0, DROPLIMB_BURN)
 			return TRUE
 
 	// Overly high BRUTE damage
-	else if(brute >= max_damage * DROPLIMB_THRESHOLD_DESTROY_BRUTE)
+	else if(brute + (spillover * DROPLIMB_SPILLOVER_MULT) >= max_damage * DROPLIMB_THRESHOLD_DESTROY_BRUTE)
 		if(prob(brute))
 			droplimb(0, DROPLIMB_BLUNT)
 			return TRUE
 
 	// Not as high brute damage
-	else if(brute >= max_damage * DROPLIMB_THRESHOLD_TEAROFF)
-		if(prob(brute * 0.3))
+	else if(brute + (spillover * DROPLIMB_SPILLOVER_MULT) >= max_damage * DROPLIMB_THRESHOLD_TEAROFF)
+		if(prob(brute * 0.2))
 			droplimb(0, DROPLIMB_EDGE)
 			return TRUE

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -134,6 +134,7 @@
 	exhale_type = species.exhale_type ? species.exhale_type : GAS_CO2
 
 // Exposure to extreme pressures can damage lungs
+// Keep in mind that this only triggers on "successful" breath, so, once per exposure to the environment
 /obj/item/organ/internal/lungs/proc/check_rupturing(breath_pressure)
 	if(isnull(last_int_pressure))
 		last_int_pressure = breath_pressure
@@ -147,7 +148,7 @@
 	if(int_pressure_diff <= max_pressure_diff || ext_pressure_diff <= max_pressure_diff)
 		return
 	// 0 pressure for humans would have ~100 diff, so, maximum damage regardless
-	var/lung_damage = min(max(int_pressure_diff, ext_pressure_diff) * 0.1, MAX_PRESSURE_LUNGS_DAMAGE)
+	var/lung_damage = min(max(int_pressure_diff, ext_pressure_diff) * 0.2, MAX_PRESSURE_LUNGS_DAMAGE)
 	lung_damage *= BP_IS_ROBOTIC(src) ? 0.75 : 1 //Robotic lungs receive less damage
 	take_general_damage(lung_damage)
 

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -133,25 +133,30 @@
 	poison_types = species.poison_types ? species.poison_types : list(GAS_PHORON = TRUE)
 	exhale_type = species.exhale_type ? species.exhale_type : GAS_CO2
 
-/obj/item/organ/internal/lungs/proc/rupture()
-	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
-	if(istype(parent))
-		owner.custom_pain("You feel a stabbing pain in your [parent.name]!", 50, affecting = parent)
-	bruise()
-
-//exposure to extreme pressures can rupture lungs
+// Exposure to extreme pressures can damage lungs
 /obj/item/organ/internal/lungs/proc/check_rupturing(breath_pressure)
 	if(isnull(last_int_pressure))
 		last_int_pressure = breath_pressure
+		return
+	if(is_bruised()) // Already screwed too much
 		return
 	var/datum/gas_mixture/environment = loc.return_air_for_internal_lifeform()
 	var/ext_pressure = environment && environment.return_pressure() // May be null if, say, our owner is in nullspace
 	var/int_pressure_diff = abs(last_int_pressure - breath_pressure)
 	var/ext_pressure_diff = abs(last_ext_pressure - ext_pressure) * owner.get_pressure_weakness(ext_pressure)
-	if(int_pressure_diff > max_pressure_diff && ext_pressure_diff > max_pressure_diff)
-		var/lung_rupture_prob = BP_IS_ROBOTIC(src) ? prob(30) : prob(60) //Robotic lungs are less likely to rupture.
-		if(!is_bruised() && lung_rupture_prob) //only rupture if NOT already ruptured
-			rupture()
+	if(int_pressure_diff <= max_pressure_diff || ext_pressure_diff <= max_pressure_diff)
+		return
+	// 0 pressure for humans would have ~100 diff, so, maximum damage regardless
+	var/lung_damage = min(max(int_pressure_diff, ext_pressure_diff) * 0.1, MAX_PRESSURE_LUNGS_DAMAGE)
+	lung_damage *= BP_IS_ROBOTIC(src) ? 0.75 : 1 //Robotic lungs receive less damage
+	take_general_damage(lung_damage)
+
+// Unused. check_rupturing() now only does damage
+/obj/item/organ/internal/lungs/proc/rupture()
+	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
+	if(istype(parent))
+		owner.custom_pain("You feel a stabbing pain in your [parent.name]!", 50, affecting = parent)
+	bruise()
 
 /obj/item/organ/internal/lungs/proc/handle_breath(datum/gas_mixture/breath, forced)
 	if(!owner)


### PR DESCRIPTION
## About the Pull Request

- Lungs no longer rupture due to high pressure difference, instead they take damage that scales with pressure difference.
- Internal bleeding(sever arteries) and severing tendons now have slightly lower chance and minimum damage thresholds.

## Why It's Good For The Game

- NO MORE INSTANT LUNGS DEATH! WOOHOO!
- Same as above. Only formidably high damage weapons will be able to inflict such serious issues and with a slightly lower chance.

## Did you test it?

Yes.

## Authorship

Me.

## Changelog

:cl:
balance: High pressure difference no longer instantly ruptures your lungs. Instead, you will be taking continuous organ damage that scales with pressure.
balance: Severing artery or tendons now has a minimum damage requirement when done by normal means. The chance is also slightly lower.
/:cl:
