### PR TITLE
Adds "succumb" verb to humans

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -30,7 +30,7 @@
 	BITSET(hud_updateflag, HEALTH_HUD)
 	BITSET(hud_updateflag, STATUS_HUD)
 	BITSET(hud_updateflag, LIFE_HUD)
-	
+
 	//Handle species-specific deaths.
 	species.handle_death(src)
 
@@ -106,3 +106,23 @@
 		E.status |= ORGAN_DISFIGURED
 	update_body(1)
 	return
+
+/mob/living/carbon/human/verb/succumb()
+	set category = "IC"
+	set name = "Succumb"
+	set desc = "Succumb to your pain and die."
+
+	var/obj/item/organ/internal/heart/heart = internal_organs_by_name[BP_HEART]
+	if((heart && heart.is_working()) || (getBrainLoss() < 100 && stat != UNCONSCIOUS))
+		to_chat(src, SPAN_WARNING("You can only succumb to your injuries when dying!"))
+		return
+	if(alert("Are you sure you want to succumb?",, "Yes", "No") != "Yes")
+		return
+	// You got fixed while thinking, keep on living!
+	if((heart && heart.is_working()) || (getBrainLoss() < 100 && stat != UNCONSCIOUS))
+		to_chat(src, SPAN_WARNING("You can only succumb to your injuries when dying!"))
+		return
+	to_chat(src, SPAN_NOTICE("You succumb to your injuries and leave the mortal plane."))
+	var/datum/gender/T = gender_datums[get_gender()]
+	visible_message(SPAN_DANGER("[src] lets out the final gasp, succumbing to [T.his] injuries."))
+	death()


### PR DESCRIPTION
## About the Pull Request

- Adds "succumb" verb to IC tab for human mobs.

## Why It's Good For The Game

- Allows people stuck in near-death state to simply die. Sometimes, with Bay med, it takes too long to actually die, despite there being absolutely no chance of you surviving it even if you lie there for 10 minutes. Additionally, many people would already simply ghost in such scenarios, which is less than ideal in my opinion.

## Did you test it?

No.

## Authorship

Me.

## Changelog

:cl:
tweak: Players can now succumb if their heart stops(no pulse), dying on the spot, allowing them to skip the grueling time of observing the black screen as they die for the next 10 minutes.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
