### PR TITLE
Crew Manifest Department Colors

### DIFF
--- a/code/__defines/colors.dm
+++ b/code/__defines/colors.dm
@@ -131,6 +131,20 @@
 
 #define COLOR_BLOOD_HUMAN      "#a10808"
 
+// Color defines used by the crew manifest
+#define MANIFEST_COLOR_COMMAND  "#204090"
+#define MANIFEST_COLOR_SUPPORT  "#3085b6"
+#define MANIFEST_COLOR_SCIENCE  "#993399"
+#define MANIFEST_COLOR_SECURITY "#930000"
+#define MANIFEST_COLOR_MEDICAL  "#009190"
+#define MANIFEST_COLOR_ENGINEER "#a66300"
+#define MANIFEST_COLOR_SUPPLY   "#7f6539"
+#define MANIFEST_COLOR_EXPLORER "#ff3300"
+#define MANIFEST_COLOR_SERVICE  "#709b00"
+#define MANIFEST_COLOR_CIVILIAN "#408010"
+#define MANIFEST_COLOR_MISC     "#353a42"
+#define MANIFEST_COLOR_SILICON  "#4c535b"
+
 //Color defines used by the assembly detailer.
 #define COLOR_ASSEMBLY_BLACK   "#545454"
 #define COLOR_ASSEMBLY_BGRAY   "#9497ab"

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -422,15 +422,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		host.ckey = src.ckey
 		host.status_flags |= NO_ANTAG
 		to_chat(host, "<span class='info'>You are now a mouse. Try to avoid interaction with players, and do not give hints away that you are more than a simple rodent.</span>")
+
 /mob/observer/ghost/verb/view_manfiest()
 	set name = "Show Crew Manifest"
 	set category = "Ghost"
 
 	var/dat
 	dat += "<h4>Crew Manifest</h4>"
-	dat += html_crew_manifest()
+	dat += html_crew_manifest(OOC = TRUE)
 
-	show_browser(src, dat, "window=manifest;size=370x420;can_close=1")
+	var/datum/browser/popup = new(src, "Crew Manifest", "Crew Manifest", 370, 420, src)
+	popup.set_content(dat)
+	popup.open()
 
 //This is called when a ghost is drag clicked to something.
 /mob/observer/ghost/MouseDrop(atom/over)

--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -1,18 +1,18 @@
 // Generates a simple HTML crew manifest for use in various places
 /proc/html_crew_manifest(var/monochrome, var/OOC)
 	var/list/dept_data = list(
-		list("names" = list(), "header" = "Heads of Staff", "flag" = COM),
-		list("names" = list(), "header" = "Command Support", "flag" = SPT),
-		list("names" = list(), "header" = "Research", "flag" = SCI),
-		list("names" = list(), "header" = "Security", "flag" = SEC),
-		list("names" = list(), "header" = "Medical", "flag" = MED),
-		list("names" = list(), "header" = "Engineering", "flag" = ENG),
-		list("names" = list(), "header" = "Supply", "flag" = SUP),
-		list("names" = list(), "header" = "Exploration", "flag" = EXP),
-		list("names" = list(), "header" = "Service", "flag" = SRV),
-		list("names" = list(), "header" = "Civilian", "flag" = CIV),
-		list("names" = list(), "header" = "Miscellaneous", "flag" = MSC),
-		list("names" = list(), "header" = "Silicon")
+		list("names" = list(), "header" = "Heads of Staff", "flag" = COM, "color" = MANIFEST_COLOR_COMMAND),
+		list("names" = list(), "header" = "Command Support", "flag" = SPT, "color" = MANIFEST_COLOR_SUPPORT),
+		list("names" = list(), "header" = "Research", "flag" = SCI, "color" = MANIFEST_COLOR_SCIENCE),
+		list("names" = list(), "header" = "Security", "flag" = SEC, "color" = MANIFEST_COLOR_SECURITY),
+		list("names" = list(), "header" = "Medical", "flag" = MED, "color" = MANIFEST_COLOR_MEDICAL),
+		list("names" = list(), "header" = "Engineering", "flag" = ENG, "color" = MANIFEST_COLOR_ENGINEER),
+		list("names" = list(), "header" = "Supply", "flag" = SUP, "color" = MANIFEST_COLOR_SUPPLY),
+		list("names" = list(), "header" = "Exploration", "flag" = EXP, "color" = MANIFEST_COLOR_EXPLORER),
+		list("names" = list(), "header" = "Service", "flag" = SRV, "color" = MANIFEST_COLOR_SERVICE),
+		list("names" = list(), "header" = "Civilian", "flag" = CIV, "color" = MANIFEST_COLOR_CIVILIAN),
+		list("names" = list(), "header" = "Miscellaneous", "flag" = MSC, "color" = MANIFEST_COLOR_MISC),
+		list("names" = list(), "header" = "Silicon", "color" = MANIFEST_COLOR_SILICON),
 	)
 	var/list/misc //Special departments for easier access
 	var/list/bot
@@ -27,11 +27,11 @@
 	var/dat = {"
 	<head><style>
 		.manifest {border-collapse:collapse;width:100%;}
-		.manifest td, th {border:1px solid [monochrome?"black":"[OOC?"black; background-color:#272727; color:white":"#DEF; background-color:white; color:black"]"]; padding:.25em}
-		.manifest th {height: 2em; [monochrome?"border-top-width: 3px":"background-color: [OOC?"#40628a":"#48C"]; color:white"]}
-		.manifest tr.head th { [monochrome?"border-top-width: 1px":"background-color: [OOC?"#013D3B;":"#488;"]"] }
+		.manifest td, th {border:1px solid [monochrome?"black":"black; background-color:#272727; color:white"]; padding:.25em}
+		.manifest th {height: 2em; [monochrome?"border-top-width: 3px":"background-color: #40628a; color:white"]}
+		.manifest tr.head th { background-color: #013D3B; }
 		.manifest td:first-child {text-align:right}
-		.manifest tr.alt td {[monochrome?"border-top-width: 2px":"background-color: [OOC?"#373737; color:white":"#DEF"]"]}
+		.manifest tr.alt td {[monochrome?"border-top-width: 2px":"background-color: #373737; color:white"]}
 	</style></head>
 	<table class="manifest" width='350px'>
 	<tr class='head'><th>Name</th><th>Position</th><th>Activity</th></tr>
@@ -85,7 +85,7 @@
 	for(var/list/department in dept_data)
 		var/list/names = department["names"]
 		if(names.len > 0)
-			dat += "<tr><th colspan=3>[department["header"]]</th></tr>"
+			dat += "<tr><th colspan=3 style=background-color:[department["color"]]>[department["header"]]</th></tr>"
 			for(var/name in names)
 				dat += "<tr class='candystripe'><td>[mil_ranks[name]][name]</td><td>[names[name]]</td><td>[isactive[name]]</td></tr>"
 


### PR DESCRIPTION
## About the Pull Request

Ports #Baystation12/Baystation12/pull/33093

- Departments have their respective color in the manifest.
- The manifest for ghosts is now the same as the manifest from the lobby(uses browser popup).

## Why It's Good For The Game

Looks better.

## Did you test it?

No.

## Authorship

[Hubblenaut](https://github.com/Hubblenaut)

## Changelog

:cl: Hubblenaut
tweak: Introduces department colors for the manifest.
/:cl:
