### PR TITLE
Adds verb to spawn supply pack

### DIFF
--- a/code/datums/supplypacks/supplypack.dm
+++ b/code/datums/supplypacks/supplypack.dm
@@ -29,9 +29,9 @@
 	switch(security_level)
 		if(SUPPLY_SECURITY_ELEVATED)
 			if(security_state.all_security_levels.len > 1)
-				security_level = security_state.all_security_levels[2] 
+				security_level = security_state.all_security_levels[2]
 			else
-				security_level = security_state.high_security_level 
+				security_level = security_state.high_security_level
 		if(SUPPLY_SECURITY_HIGH)
 			security_level = security_state.high_security_level
 	if(!istype(security_level))

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1149,6 +1149,29 @@ var/global/floorIsLava = 0
 	A.activation_method = act_met
 	A.effect.effect_type = ef_type
 
+/datum/admins/proc/spawn_supplypack(decl/hierarchy/supply_pack/SP in subtypesof(/decl/hierarchy/supply_pack))
+	set category = "Debug"
+	set desc = "(datum path) Spawn supply pack"
+	set name = "Spawn"
+
+	if(!check_rights(R_SPAWN))
+		return
+
+	var/obj/A = new SP.containertype(get_turf(usr))
+	A.SetName(SP.containername)
+
+	if(SP.access)
+		if(!islist(SP.access))
+			A.req_access = list(SP.access)
+		else if(islist(SP.access))
+			var/list/L = SP.access // access var is a plain var, we need a list
+			A.req_access = L.Copy()
+
+	SP.spawn_contents(A)
+
+	log_and_message_admins("spawned [SP.name] supply pack at ([usr.x],[usr.y],[usr.z])")
+	SSstatistics.add_field_details("admin_verb","SP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /datum/admins/proc/show_traitor_panel(var/mob/M in SSmobs.mob_list)
 	set category = "Admin"
 	set desc = "Edit mobs's memory and role"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -134,6 +134,7 @@ var/list/admin_verbs_spawn = list(
 	/datum/admins/proc/spawn_plant,
 	/datum/admins/proc/spawn_atom,		// allows us to spawn instances,
 	/datum/admins/proc/spawn_artifact,
+	/datum/admins/proc/spawn_supplypack,
 	/client/proc/spawn_chemdisp_cartridge,
 	/datum/admins/proc/mass_debug_closet_icons
 	)


### PR DESCRIPTION
## About the Pull Request

Added an admin verb that spawns a select supply pack at admin's location.

## Why It's Good For The Game

It was missing for some reason, and sometimes you need to spawn a supply pack without ordering one.

## Did you test it?

No.

## Authorship

Me.

## Changelog

:cl:
admin: Added "spawn supply pack" verb.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
