### PR TITLE
Admins can bypass respawn locks

### DIFF
--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -578,17 +578,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Respawn"
 	set category = "OOC"
 
-	if (!(config.abandon_allowed))
-		to_chat(usr, SPAN_WARNING("Respawn is disabled."))
-		return
-	if (!SSticker.mode)
-		to_chat(usr, SPAN_WARNING("<b>You may not attempt to respawn yet.</b>"))
-		return
-	if (SSticker.mode.deny_respawn)
-		to_chat(usr, SPAN_WARNING("Respawn is disabled for this roundtype."))
-		return
-	else if(!MayRespawn(1, config.respawn_delay))
-		return
+	if(!check_rights(R_INVESTIGATE, FALSE, client))
+		if(!(config.abandon_allowed))
+			to_chat(usr, SPAN_WARNING("Respawn is disabled."))
+			return
+		if(!SSticker.mode)
+			to_chat(usr, SPAN_WARNING("<b>You may not attempt to respawn yet.</b>"))
+			return
+		if(SSticker.mode.deny_respawn)
+			to_chat(usr, SPAN_WARNING("Respawn is disabled for this roundtype."))
+			return
+		else if(!MayRespawn(1, config.respawn_delay))
+			return
 
 	to_chat(usr, SPAN_NOTICE("You can respawn now, enjoy your new life!"))
 	to_chat(usr, SPAN_NOTICE("<b>Make sure to play a different character, and please roleplay correctly!</b>"))


### PR DESCRIPTION
## About the Pull Request

Simply adds a check for R_INVESTIGATE(same perms that allow to bypass respawn cooldown) for all of the respawn checks.

## Why It's Good For The Game

Admins don't need to hear all of this, right?

## Did you test it?

Not needed.

## Authorship

Me.

## Changelog

:cl:
admin: Admins can bypass all respawn checks.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
