### PR TITLE
Humanoid simple mobs do not threaten enemies, AI tweaks

### DIFF
--- a/code/modules/ai/aI_holder_subtypes/simple_mob_ai.dm
+++ b/code/modules/ai/aI_holder_subtypes/simple_mob_ai.dm
@@ -156,7 +156,6 @@
 /datum/ai_holder/simple_animal/humanoid
 	intelligence_level = AI_SMART //Purportedly
 	retaliate = TRUE //If attacked, attack back
-	threaten = TRUE //Verbal threats
 	firing_lanes = TRUE //Avoid shooting allies
 	conserve_ammo = TRUE //Don't shoot when it can't hit target
 	can_breakthrough = TRUE //Can break through doors

--- a/code/modules/ai/ai_holder_combat.dm
+++ b/code/modules/ai/ai_holder_combat.dm
@@ -12,6 +12,8 @@
 
 	var/prying = FALSE                      // True when the mob is trying to force open a door.
 
+	var/max_attack_range = 7
+
 	var/list/valid_obstacles_by_priority = list(/obj/structure/window,
 												/obj/structure/closet,
 												/obj/machinery/door/window,
@@ -173,7 +175,7 @@
 
 // Can be used to conditionally do a ranged or melee attack.
 /datum/ai_holder/proc/max_range(atom/movable/AM)
-	return holder.ICheckRangedAttack(AM) ? 7 : 1
+	return holder.ICheckRangedAttack(AM) ? max_attack_range : 1
 
 // Goes to the target, to attack them.
 // Called when in STANCE_APPROACH.


### PR DESCRIPTION
## About the Pull Request

- Humanoid AI does not threaten enemies anymore before attacking/leaving them alone.
- Added max attack range variable to AI holders.

## Why It's Good For The Game

- It is kind of broken at the moment; Ideally should be fixed, but that takes a lot of time.
- I wanted to admeme a sniper simple mob. Let me.

## Did you test it?

Not needed.

## Authorship

Me.

## Changelog

:cl:
tweak: Humanoid simple mobs(riot officers in abandoned bunker, for example) do not threaten enemies before attacking anymore. Beware!
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
