### PR TITLE
Overmap pixel movement

### DIFF
--- a/code/__defines/overmap.dm
+++ b/code/__defines/overmap.dm
@@ -12,3 +12,14 @@
 #define OVERMAP_WEAKNESS_MINING 4
 #define OVERMAP_WEAKNESS_EXPLOSIVE 8
 #define OVERMAP_WEAKNESS_DROPPOD 16
+
+#define SHIP_MOVE_RESOLUTION 0.00001
+#define MOVING(speed) abs(speed) >= min_speed
+#define SANITIZE_SPEED(speed) SIGN(speed) * Clamp(abs(speed), 0, max_speed)
+#define CHANGE_SPEED_BY(speed_var, v_diff) \
+	v_diff = SANITIZE_SPEED(v_diff);\
+	if(!MOVING(speed_var + v_diff)) \
+		{speed_var = 0};\
+	else \
+		{speed_var = SANITIZE_SPEED((speed_var + v_diff)/(1 + speed_var*v_diff/(max_speed ** 2)))}
+// Uses Lorentzian dynamics to avoid going too fast.

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -463,3 +463,6 @@ Class Procs:
 	var/obj/item/stock_parts/power/battery/battery = get_component_of_type(/obj/item/stock_parts/power/battery)
 	if(battery)
 		return battery.get_cell()
+
+/obj/machinery/proc/on_user_login(mob/M)
+	return

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -98,6 +98,9 @@
 	update_action_buttons()
 	update_mouse_pointer()
 
+	if(machine)
+		machine.on_user_login(src)
+
 /mob/living/carbon/Login()
 	. = ..()
 	if(internals && internal)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -351,6 +351,8 @@
 
 /mob/proc/reset_view(atom/A)
 	if (client)
+		client.pixel_x = initial(client.pixel_x)
+		client.pixel_y = initial(client.pixel_y)
 		A = A ? A : eyeobj
 		if (istype(A, /atom/movable))
 			client.perspective = EYE_PERSPECTIVE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -351,8 +351,12 @@
 
 /mob/proc/reset_view(atom/A)
 	if (client)
-		client.pixel_x = initial(client.pixel_x)
-		client.pixel_y = initial(client.pixel_y)
+		if(istype(A))
+			client.pixel_x = A.pixel_x
+			client.pixel_y = A.pixel_y
+		else
+			client.pixel_x = initial(client.pixel_x)
+			client.pixel_y = initial(client.pixel_y)
 		A = A ? A : eyeobj
 		if (istype(A, /atom/movable))
 			client.perspective = EYE_PERSPECTIVE

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -14,7 +14,13 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 		return
 	if(sector.check_ownership(src))
 		linked = sector
+		LAZYSET(linked.consoles, src, TRUE)
 		return 1
+
+/obj/machinery/computer/ship/Destroy()
+	if(linked)
+		LAZYREMOVE(linked.consoles, src)
+	. = ..()
 
 /obj/machinery/computer/ship/proc/sync_linked()
 	var/obj/effect/overmap/visitable/ship/sector = map_sectors["[z]"]
@@ -51,6 +57,8 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 	return TOPIC_NOACTION
 
 // Management of mob view displacement. look to shift view to the ship on the overmap; unlook to shift back.
+/obj/machinery/computer/ship/on_user_login(var/mob/M)
+	unlook(M)
 
 /obj/machinery/computer/ship/proc/look(var/mob/user)
 	if(linked)

--- a/code/modules/overmap/ships/landable.dm
+++ b/code/modules/overmap/ships/landable.dm
@@ -128,7 +128,7 @@
 	var/datum/shuttle/autodock/auto = given_shuttle
 	if(into == auto.landmark_transition)
 		status = SHIP_STATUS_TRANSIT
-		on_takeoff(from, into)
+		on_transit(from, into)
 		return
 	if(into == landmark)
 		status = SHIP_STATUS_OVERMAP
@@ -136,6 +136,9 @@
 		return
 	status = SHIP_STATUS_LANDED
 	on_landing(from, into)
+
+/obj/effect/overmap/visitable/ship/landable/proc/on_transit(obj/effect/shuttle_landmark/from, obj/effect/shuttle_landmark/into)
+	halt()
 
 /obj/effect/overmap/visitable/ship/landable/proc/on_landing(obj/effect/shuttle_landmark/from, obj/effect/shuttle_landmark/into)
 	var/obj/effect/overmap/visitable/target = map_sectors["[into.z]"]

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -1,31 +1,24 @@
-#define SHIP_MOVE_RESOLUTION 0.00001
-#define MOVING(speed) abs(speed) >= min_speed
-#define SANITIZE_SPEED(speed) SIGN(speed) * Clamp(abs(speed), 0, max_speed)
-#define CHANGE_SPEED_BY(speed_var, v_diff) \
-	v_diff = SANITIZE_SPEED(v_diff);\
-	if(!MOVING(speed_var + v_diff)) \
-		{speed_var = 0};\
-	else \
-		{speed_var = SANITIZE_SPEED((speed_var + v_diff)/(1 + speed_var*v_diff/(max_speed ** 2)))}
-// Uses Lorentzian dynamics to avoid going too fast.
+var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 
 /obj/effect/overmap/visitable/ship
 	name = "generic ship"
 	desc = "Space faring vessel."
 	icon_state = "ship"
+
 	var/moving_state = "ship_moving"
 
-	var/vessel_mass = 10000             //tonnes, arbitrary number, affects acceleration provided by engines
-	var/vessel_size = SHIP_SIZE_LARGE	//arbitrary number, affects how likely are we to evade meteors
-	var/max_speed = 1/(1 SECOND)        //"speed of light" for the ship, in turfs/tick.
+	var/list/consoles
+	var/vessel_mass = 10000             // tonnes, arbitrary number, affects acceleration provided by engines
+	var/vessel_size = SHIP_SIZE_LARGE	// arbitrary number, affects how likely are we to evade meteors
+	var/max_speed = 1/(1 SECOND)        // "speed of light" for the ship, in turfs/tick.
 	var/min_speed = 1/(2 MINUTES)       // Below this, we round speed to 0 to avoid math errors.
-	var/max_autopilot = 1 / (20 SECONDS) // The maximum speed any attached helm can try to autopilot at.
+	var/max_autopilot = 1 / (10 SECONDS) // The maximum speed any attached helm can try to autopilot at.
 
-	var/list/speed = list(0,0)          //speed in x,y direction
-	var/last_burn = 0                   //worldtime when ship last acceleated
-	var/burn_delay = 1 SECOND           //how often ship can do burns
-	var/list/last_movement = list(0,0)  //worldtime when ship last moved in x,y direction
-	var/fore_dir = NORTH                //what dir ship flies towards for purpose of moving stars effect procs
+	var/list/speed = list(0,0)          // speed in x,y direction
+	var/list/position = list(0,0)       // position within a tile.
+	var/last_burn = 0                   // worldtime when ship last acceleated
+	var/burn_delay = 1 SECOND           // how often ship can do burns
+	var/fore_dir = NORTH                // what dir ship flies towards for purpose of moving stars effect procs
 
 	var/list/engines = list()
 	var/engines_state = 0 //global on/off toggle for all engines
@@ -36,6 +29,7 @@
 
 /obj/effect/overmap/visitable/ship/Initialize()
 	. = ..()
+	glide_size = world.icon_size
 	min_speed = round(min_speed, SHIP_MOVE_RESOLUTION)
 	max_speed = round(max_speed, SHIP_MOVE_RESOLUTION)
 	SSshuttle.ships += src
@@ -44,6 +38,11 @@
 /obj/effect/overmap/visitable/ship/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	SSshuttle.ships -= src
+	if(LAZYLEN(consoles))
+		for(var/obj/machinery/computer/ship/machine in consoles)
+			if(machine.linked == src)
+				machine.linked = null
+		consoles = null
 	. = ..()
 
 /obj/effect/overmap/visitable/ship/relaymove(mob/user, direction, accel_limit)
@@ -154,22 +153,41 @@
 /obj/effect/overmap/visitable/ship/Process()
 	if(!halted && !is_still())
 		var/list/deltas = list(0,0)
-		for(var/i=1, i<=2, i++)
-			if(MOVING(speed[i]) && world.time > last_movement[i] + 1/abs(speed[i]))
-				deltas[i] = SIGN(speed[i])
-				last_movement[i] = world.time
+		for(var/i = 1 to 2)
+			if(MOVING(speed[i]))
+				position[i] += speed[i] * OVERMAP_SPEED_CONSTANT
+				if(position[i] < 0)
+					deltas[i] = ceil(position[i])
+				else if(position[i] > 0)
+					deltas[i] = Floor(position[i])
+				if(deltas[i] != 0)
+					position[i] -= deltas[i]
+					position[i] += (deltas[i] > 0) ? -1 : 1
+
+		update_icon()
 		var/turf/newloc = locate(x + deltas[1], y + deltas[2], z)
-		if(newloc)
+		if(newloc && loc != newloc)
 			Move(newloc)
 			handle_wraparound()
-		update_icon()
 
 /obj/effect/overmap/visitable/ship/on_update_icon()
+	pixel_x = position[1] * (world.icon_size/2)
+	pixel_y = position[2] * (world.icon_size/2)
+
 	if(!is_still())
 		icon_state = moving_state
 		dir = get_heading()
 	else
 		icon_state = initial(icon_state)
+
+	for(var/obj/machinery/computer/ship/machine in consoles)
+		if(machine.z in map_z)
+			for(var/weakref/W in machine.viewers)
+				var/mob/M = W.resolve()
+				if(istype(M) && M.client)
+					M.client.pixel_x = pixel_x
+					M.client.pixel_y = pixel_y
+
 	..()
 
 /obj/effect/overmap/visitable/ship/proc/burn()
@@ -191,10 +209,10 @@
 //deciseconds to next step
 /obj/effect/overmap/visitable/ship/proc/ETA()
 	. = INFINITY
-	for(var/i=1, i<=2, i++)
+	for(var/i = 1 to 2)
 		if(MOVING(speed[i]))
-			. = min(last_movement[i] - world.time + 1/abs(speed[i]), .)
-	. = max(.,0)
+			. = min(., ((speed[i] > 0 ? 1 : -1) - position[i]) / speed[i])
+	. = max(ceil(.), 0)
 
 /obj/effect/overmap/visitable/ship/proc/handle_wraparound()
 	var/nx = x


### PR DESCRIPTION
## About the Pull Request

Ports the following PR:
- #NebulaSS13/Nebula/pull/255

Additional changes:
- Maximum autopilot speed increased to 10;
- Shuttles will automatically halt when in transit.

## Why It's Good For The Game

- The strict tile-based movement was a bit jarring, if I had to pick a word. This makes maneuvering in space a bit more precise.
- Autopilot is no longer completely inferior to normal people, unless you need to go through meteor fields.
- Ships won't keep on moving when going to some place. Prevents them from entering meteor fields while arriving to a planet or such.

## Did you test it?

Of course (not).

## Authorship

[MistakeNot4892](https://github.com/MistakeNot4892) for pixel movement;

## Changelog

:cl: MistakeNot4892
rscadd: Overmap objects now move by pixels, instead of strictly by tiles.
tweak: Autopilot can move with the speed of up to 10.
fix: When in transit - overmap ships will halt all movement.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
