### PR TITLE
Roundstart, roundend, lobby and credits sounds adjustment

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1243,7 +1243,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	else
 		step(user.pulling, get_dir(user.pulling.loc, A))
 
-/proc/show_blurb(client/C, duration, blurb_text, fade_time = 5, our_loc = "LEFT+1,BOTTOM+2")
+/proc/show_blurb(client/C, duration, blurb_text, fade_time = 5, our_loc = "LEFT+1,BOTTOM+2", typeout = TRUE)
 	set waitfor = 0
 
 	if(!C)
@@ -1263,9 +1263,12 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
 	C.screen += T
 	animate(T, alpha = 255, time = 10)
-	for(var/i = 1 to length(text)+1)
-		T.maptext = "<span style=\"[style]\">[copytext(text,1,i)] </span>"
-		sleep(1)
+	if(typeout)
+		for(var/i = 1 to length(text)+1)
+			T.maptext = "<span style=\"[style]\">[copytext(text,1,i)] </span>"
+			sleep(1)
+	else
+		T.maptext = "<span style=\"[style]\">[text] </span>"
 
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/fade_blurb, C, T, fade_time), duration)
 
@@ -1275,9 +1278,9 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	C.screen -= T
 	qdel(T)
 
-/proc/show_global_blurb(duration, blurb_text, fade_time = 5, our_loc = "LEFT+1,BOTTOM+2") // Shows a blurb to every living player
+/proc/show_global_blurb(duration, blurb_text, fade_time = 5, our_loc = "LEFT+1,BOTTOM+2", typeout = TRUE) // Shows a blurb to every living player
 	for(var/mob/M in GLOB.player_list)
-		show_blurb(M.client, duration, blurb_text, fade_time, our_loc)
+		show_blurb(M.client, duration, blurb_text, fade_time, our_loc, typeout)
 
 /proc/flash_color(mob_or_client, flash_color="#960000", flash_time=20)
 	var/client/C

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1243,7 +1243,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	else
 		step(user.pulling, get_dir(user.pulling.loc, A))
 
-/proc/show_blurb(client/C, duration, blurb_text, fade_time = 5)
+/proc/show_blurb(client/C, duration, blurb_text, fade_time = 5, our_loc = "LEFT+1,BOTTOM+2")
 	set waitfor = 0
 
 	if(!C)
@@ -1259,7 +1259,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	T.layer = FLOAT_LAYER
 	T.plane = HUD_PLANE
 	T.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-	T.screen_loc = "LEFT+1,BOTTOM+2"
+	T.screen_loc = our_loc
 
 	C.screen += T
 	animate(T, alpha = 255, time = 10)
@@ -1275,9 +1275,9 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	C.screen -= T
 	qdel(T)
 
-/proc/show_global_blurb(duration, blurb_text, fade_time = 5) // Shows a blurb to every living player
+/proc/show_global_blurb(duration, blurb_text, fade_time = 5, our_loc = "LEFT+1,BOTTOM+2") // Shows a blurb to every living player
 	for(var/mob/M in GLOB.player_list)
-		show_blurb(M.client, duration, blurb_text, fade_time)
+		show_blurb(M.client, duration, blurb_text, fade_time, our_loc)
 
 /proc/flash_color(mob_or_client, flash_color="#960000", flash_time=20)
 	var/client/C

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1243,13 +1243,13 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	else
 		step(user.pulling, get_dir(user.pulling.loc, A))
 
-/proc/show_blurb(client/C, duration, blurb_text, fade_time = 5, our_loc = "LEFT+1,BOTTOM+2", typeout = TRUE)
+/proc/show_blurb(client/C, duration, blurb_text, fade_time = 5, our_loc = "LEFT+1,BOTTOM+2", our_style = "font-family: 'Fixedsys'; -dm-text-outline: 1 black; font-size: 11px;", typeout = TRUE)
 	set waitfor = 0
 
 	if(!C)
 		return
 
-	var/style = "font-family: 'Fixedsys'; -dm-text-outline: 1 black; font-size: 11px;"
+	var/style = our_style
 	var/text = blurb_text
 	text = uppertext(text)
 
@@ -1278,9 +1278,9 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	C.screen -= T
 	qdel(T)
 
-/proc/show_global_blurb(duration, blurb_text, fade_time = 5, our_loc = "LEFT+1,BOTTOM+2", typeout = TRUE) // Shows a blurb to every living player
+/proc/show_global_blurb(duration, blurb_text, fade_time = 5, our_loc = "LEFT+1,BOTTOM+2", our_style = "font-family: 'Fixedsys'; -dm-text-outline: 1 black; font-size: 11px;", typeout = TRUE) // Shows a blurb to every living player
 	for(var/mob/M in GLOB.player_list)
-		show_blurb(M.client, duration, blurb_text, fade_time, our_loc, typeout)
+		show_blurb(M.client, duration, blurb_text, fade_time, our_loc, our_style, typeout)
 
 /proc/flash_color(mob_or_client, flash_color="#960000", flash_time=20)
 	var/client/C

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -105,9 +105,10 @@ SUBSYSTEM_DEF(ticker)
 	spawn(0)//Forking here so we dont have to wait for this to finish
 		mode.post_setup() // Drafts antags who don't override jobs.
 		to_world("<span class='info'><B>Enjoy the game!</B></span>")
-		sound_to(world, sound(GLOB.using_map.welcome_sound))
+		if(LAZYLEN(GLOB.using_map.welcome_sound))
+			sound_to(world, sound(pick(GLOB.using_map.welcome_sound)))
 
-		for (var/mob/new_player/player in GLOB.player_list)
+		for(var/mob/new_player/player in GLOB.player_list)
 			player.new_player_panel()
 
 	if(!length(GLOB.admins))

--- a/code/game/movietitles.dm
+++ b/code/game/movietitles.dm
@@ -11,6 +11,15 @@ client
 /client/proc/RollCredits()
 	set waitfor = FALSE
 
+	// Round-end music is separate from credits themselves
+	if(mob.get_preference_value(/datum/client_preference/play_lobby_music) == GLOB.PREF_YES)
+		sound_to(mob, sound(null, channel = GLOB.lobby_sound_channel))
+		if(GLOB.end_credits_song == null)
+			if(LAZYLEN(GLOB.using_map.credit_sound))
+				sound_to(mob, sound(pick(GLOB.using_map.credit_sound), wait = 0, volume = 40, channel = GLOB.lobby_sound_channel))
+		else if(get_preference_value(/datum/client_preference/play_admin_midis) == GLOB.PREF_YES)
+			sound_to(mob, sound(GLOB.end_credits_song, wait = 0, volume = 40, channel = GLOB.lobby_sound_channel))
+
 	if(get_preference_value(/datum/client_preference/show_credits) != GLOB.PREF_YES)
 		return
 
@@ -23,13 +32,6 @@ client
 		mob.overlay_fullscreen("fishbed",/obj/screen/fullscreen/fishbed)
 		mob.overlay_fullscreen("fadeout",/obj/screen/fullscreen/fadeout)
 
-		if(mob.get_preference_value(/datum/client_preference/play_lobby_music) == GLOB.PREF_YES)
-			sound_to(mob, sound(null, channel = GLOB.lobby_sound_channel))
-			if(GLOB.end_credits_song == null)
-				var/title_song = pick('sound/music/THUNDERDOME.ogg', 'sound/music/europa/Chronox_-_03_-_In_Orbit.ogg', 'sound/music/europa/asfarasitgets.ogg')
-				sound_to(mob, sound(title_song, wait = 0, volume = 40, channel = GLOB.lobby_sound_channel))
-			else if(get_preference_value(/datum/client_preference/play_admin_midis) == GLOB.PREF_YES)				
-				sound_to(mob, sound(GLOB.end_credits_song, wait = 0, volume = 40, channel = GLOB.lobby_sound_channel))
 	sleep(50)
 	var/list/_credits = credits
 	verbs += /client/proc/ClearCredits
@@ -133,7 +135,7 @@ client
 			if(rank.name_short)
 				used_name = "[rank.name_short] [used_name]"
 		var/showckey = 0
-		if(H.ckey && H.client)			
+		if(H.ckey && H.client)
 			if(H.client.get_preference_value(/datum/client_preference/show_ckey_credits) == GLOB.PREF_SHOW)
 				showckey = 1
 		var/decl/cultural_info/actor_culture = SSculture.get_culture(H.get_cultural_value(TAG_CULTURE))
@@ -142,7 +144,7 @@ client
 		if(!showckey)
 			if(prob(90))
 				chunk += "[actor_culture.get_random_name(H.gender)]\t \t \t \t[uppertext(used_name)][job]"
-			else				
+			else
 				var/datum/gender/G = gender_datums[H.gender]
 				chunk += "[used_name]\t \t \t \t[uppertext(G.him)]SELF"
 		else
@@ -192,7 +194,7 @@ client
 					 This motion picture is protected under the copyright laws of the Sol Central Government<br> and other nations throughout the galaxy.<br>\
 					 Colony of First Publication: [pick("Mars", "Luna", "Earth", "Venus", "Phobos", "Ceres", "Tiamat", "Ceti Epsilon", "Eos", "Pluto", "Ouere",\
 					 "Lordania", "Kingston", "Cinu", "Yuklid V", "Lorriman", "Tersten", "Gaia")].<br>"
-	disclaimer += pick("Use for parody prohibited. PROHIBITED.", 
+	disclaimer += pick("Use for parody prohibited. PROHIBITED.",
 					   "All stunts were performed by underpaid interns. Do NOT try at home.",
 					   "[GLOB.using_map.company_name] does not endorse behaviour depicted. Attempt at your own risk.",
 					   "Any unauthorized exhibition, distribution, or copying of this film or any part thereof (including soundtrack)<br>\

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -464,7 +464,7 @@ GLOBAL_VAR_INIT(world_topic_last, world.timeofday)
 
 	var/datum/chatOutput/co
 	for(var/client/C in GLOB.clients)
-		show_blurb(C, 900, "Round is restarting...", 30, "CENTER,CENTER", FALSE)
+		show_blurb(C, 900, "Round is restarting...", 30, "CENTER,CENTER", "font-family: 'Fixedsys'; -dm-text-outline: 1 black; font-size: 14px; text-align:center;", FALSE)
 		co = C.chatOutput
 		if(co)
 			co.ehjax_send(data = "roundrestart")

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -464,7 +464,7 @@ GLOBAL_VAR_INIT(world_topic_last, world.timeofday)
 
 	var/datum/chatOutput/co
 	for(var/client/C in GLOB.clients)
-		show_blurb(C, 900, "Round is restarting...", fade_time = 30, our_loc = "CENTER,CENTER")
+		show_blurb(C, 900, "Round is restarting...", 30, "CENTER,CENTER", FALSE)
 		co = C.chatOutput
 		if(co)
 			co.ehjax_send(data = "roundrestart")

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -455,16 +455,16 @@ GLOBAL_VAR_INIT(world_topic_last, world.timeofday)
 #undef SET_THROTTLE
 
 /world/Reboot(var/reason)
-	/*spawn(0)
-		sound_to(world, sound(pick('sound/AI/newroundsexy.ogg','sound/misc/apcdestroyed.ogg','sound/misc/bangindonk.ogg')))// random end sounds!! - LastyBatsy
+	if(LAZYLEN(GLOB.using_map.reboot_sound))
+		sound_to(world, sound(pick(GLOB.using_map.reboot_sound)))
 
-		*/
 	TgsReboot()
 
 	Master.Shutdown()
 
 	var/datum/chatOutput/co
 	for(var/client/C in GLOB.clients)
+		show_blurb(C, 900, "Round is restarting...", fade_time = 30, our_loc = "CENTER,CENTER")
 		co = C.chatOutput
 		if(co)
 			co.ehjax_send(data = "roundrestart")

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -91,9 +91,17 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 
 	var/list/lobby_screens = list('icons/default_lobby.png')    // The list of lobby screen images to pick() from.
 	var/current_lobby_screen
-	var/decl/audio/track/lobby_track                     // The track that will play in the lobby screen.
-	var/list/lobby_tracks = list()                  // The list of lobby tracks to pick() from. If left unset will randomly select among all available decl/audio/track subtypes.
-	var/welcome_sound = 'sound/AI/welcome.ogg'		// Sound played on roundstart
+	/// The track that will play in the lobby screen.
+	var/decl/audio/track/lobby_track
+	/// The list of lobby tracks to pick() from. If left unset will randomly select among all available /music_track subtypes.
+	var/list/lobby_tracks = list()
+
+	/// Sounds played on roundstart
+	var/list/welcome_sound = list('sound/AI/welcome.ogg')
+	/// Sounds played with end titles (credits)
+	var/list/credit_sound = list('sound/music/THUNDERDOME.ogg', 'sound/music/europa/Chronox_-_03_-_In_Orbit.ogg', 'sound/music/europa/asfarasitgets.ogg')
+	/// Sounds played on server reboot
+	var/list/reboot_sound = list('sound/AI/newroundsexy.ogg','sound/misc/apcdestroyed.ogg','sound/misc/bangindonk.ogg')
 
 	var/default_law_type = /datum/ai_laws/nanotrasen  // The default lawset use by synth units, if not overriden by their laws var.
 	var/security_state = /decl/security_state/default // The default security state system to use.

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -39,7 +39,7 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 414 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 413 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 4 ".Replace( matches" '\.Replace(_char)?\(' -P
 exactly 5 ".Find( matches" '\.Find(_char)?\(' -P


### PR DESCRIPTION
## About the Pull Request

- Roundstart, roundend and credits sounds are tied to map datum.
- Credits music is separate from credits themselves and will play if credits alone are disabled.
- Roundend(reboot) sounds reimplemented.
- On roundend - a text blurb will appear.

## Why It's Good For The Game

- Allows us to change those things on case-by-case basis, instead of hardcoded values.
- For example: I don't want to be fixed in place, watching at pointless credits roll, but I like the music.
- Roundend sounds! Don't have much to say about them other than signifying the round-end.
- Another thing indicating that round is restarting, eh?

## Did you test it?

Yes.

## Authorship

Me.

## Changelog

:cl:
tweak: Round-end credits music is separate from the credits themselves. This is tied to lobby music preference.
tweak: Round restart sounds reimplemented. Additionally, there'll be a text blurb when round restarts.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
