### PR TITLE
Adds color background for latejoin job links

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -247,9 +247,9 @@
 	if(is_available(caller))
 		if(is_restricted(caller.prefs))
 			if(show_invalid_jobs)
-				return "<tr><td><a style='background: #9E4444' href='[href_string]'>[title]</a></td><td>[current_positions]</td><td>(Active: [get_active_count()])</td></tr>"
+				return "<tr bgcolor='[selection_color]'><td style='padding-left:2px;padding-right:2px;'><a style='background: #9E4444' href='[href_string]'>[title]</a></td><td style='padding-left:2px;padding-right:2px;''><center>[current_positions]</center></td><td style='padding-left:2px;padding-right:2px;'><center>(Active: [get_active_count()])</center></td></tr>"
 		else
-			return "<tr><td><a href='[href_string]'>[title]</a></td><td>[current_positions]</td><td>(Active: [get_active_count()])</td></tr>"
+			return "<tr bgcolor='[selection_color]'><td style='padding-left:2px;padding-right:2px;'><a href='[href_string]'>[title]</a></td><td style='padding-left:2px;padding-right:2px;'><center>[current_positions]</center></td><td style='padding-left:2px;padding-right:2px;'><center>(Active: [get_active_count()])</center></td></tr>"
 	return ""
 
 // Only players with the job assigned and AFK for less than 10 minutes count as active

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -307,19 +307,34 @@
 	dat += "<tr><td colspan = 3><b>[GLOB.using_map.station_name]:</b></td></tr>"
 
 	// TORCH JOBS
-	var/list/job_summaries
+	var/list/job_summaries = list()
 	var/list/hidden_reasons = list()
 	for(var/datum/job/job in SSjobs.primary_job_datums)
 		var/summary = job.get_join_link(client, "byond://?src=\ref[src];SelectedJob=[job.title]", show_invalid_jobs)
-		if(summary && summary != "")
-			LAZYADD(job_summaries, summary)
+		if(summary)
+			var/summary_key = (job.department ? job.department : "No Department")
+			var/list/existing_summaries = job_summaries[summary_key]
+			if(!existing_summaries)
+				existing_summaries = list()
+				job_summaries[summary_key] = existing_summaries
+			if(job.head_position)
+				existing_summaries.Insert(1, summary)
+			else
+				existing_summaries.Add(summary)
 		else
 			for(var/raisin in job.get_unavailable_reasons(client))
 				hidden_reasons[raisin] = TRUE
 
-	if(LAZYLEN(job_summaries))
-		dat += job_summaries
-	else
+	var/added_job = FALSE
+	if(length(job_summaries))
+		for(var/job_category in job_summaries)
+			if(length(job_summaries[job_category]))
+				// TODO: use bgcolor='[job_dept.display_color]' when less pastel/bright colours are chosen.
+				dat += "<tr><td bgcolor='#333333' colspan = 3><b><font color = '#ffffff'><center>[job_category]</center></font></b></td></tr>"
+				dat += job_summaries[job_category]
+				added_job = TRUE
+
+	if(!added_job)
 		dat += "<tr><td>No available positions.</td></tr>"
 	// END TORCH JOBS
 


### PR DESCRIPTION
## About the Pull Request

Ports #NebulaSS13/Nebula/pull/1500

## Why It's Good For The Game

Neat-looking late-join panel.

![image](https://github.com/vlggms/tegustation-bay12/assets/53223414/4093bce6-6f9c-40fb-8507-1501ac52d8b4)

## Authorship

[quardbreak](https://github.com/quardbreak)

## Changelog

:cl:
tweak: Late-join panel jobs are now categorized and backgrounds colored.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
