### PR TITLE
Tests use Byond 514.1589 now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ on:
     branches:
       - dev
 env:
-  BYOND_MAJOR: "513"
-  BYOND_MINOR: "1527"
+  BYOND_MAJOR: "514"
+  BYOND_MINOR: "1589"
   SPACEMAN_DMM_VERSION: suite-1.5
 
 jobs:


### PR DESCRIPTION
## About the Pull Request

Github workflows now use 514.1589 BYOND version, same as what we use for the server.