### PR TITLE
Suit breaches consider armor, have higher threshold

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -46,8 +46,6 @@
 	item_flags =         ITEM_FLAG_THICKMATERIAL | ITEM_FLAG_AIRTIGHT
 	//will reach 10 breach damage after 25 laser carbine blasts, 3 revolver hits, or ~1 PTR hit. Completely immune to smg or sts hits.
 	breach_threshold = 38
-	resilience = 0.2
-	can_breach = 1
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_suit_unathi.dmi',
 		)

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -64,9 +64,7 @@
 		)
 
 	//Breach thresholds, should ideally be inherited by most (if not all) voidsuits.
-	//With 0.2 resiliance, will reach 10 breach damage after 3 laser carbine blasts or 8 smg hits.
 	breach_threshold = 15
-	can_breach = 1
 
 	//Inbuilt devices.
 	var/obj/item/clothing/shoes/magboots/boots = null // Deployable boots, if any.

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -420,8 +420,6 @@ This function restores all organs.
 	if(!istype(organ))
 		return 0 // This is reasonable and means the organ is missing.
 
-	handle_suit_punctures(damagetype, damage, def_zone)
-
 	var/list/after_armor = modify_damage_by_armor(def_zone, damage, damagetype, damage_flags, src, armor_pen, silent)
 	damage = after_armor[1]
 	damagetype = after_armor[2]
@@ -429,6 +427,7 @@ This function restores all organs.
 	if(!damage)
 		return 0
 
+	handle_suit_punctures(damagetype, damage, def_zone)
 	if(damage > 15 && prob(damage*4) && organ.can_feel_pain())
 		make_reagent(round(damage/10), /datum/reagent/medicine/adrenaline)
 	var/datum/wound/created_wound

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -401,19 +401,20 @@ meteor_act
 		w_uniform.add_blood(source)
 		update_inv_w_uniform(0)
 
-/mob/living/carbon/human/proc/handle_suit_punctures(var/damtype, var/damage, var/def_zone)
-
+// TODO: This is stupid, all of it. Let's remove or rework it later.
+/mob/living/carbon/human/proc/handle_suit_punctures(damtype, damage, def_zone)
 	// Tox and oxy don't matter to suits.
-	if(damtype != BURN && damtype != BRUTE) return
+	if(damtype != BURN && damtype != BRUTE)
+		return
 
 	// The rig might soak this hit, if we're wearing one.
-	if(back && istype(back,/obj/item/rig))
+	if(back && istype(back, /obj/item/rig))
 		var/obj/item/rig/rig = back
 		rig.take_hit(damage)
 
-	// We may also be taking a suit breach.
-	if(!wear_suit) return
-	if(!istype(wear_suit,/obj/item/clothing/suit/space)) return
+	if(!istype(wear_suit,/obj/item/clothing/suit/space))
+		return
+
 	var/obj/item/clothing/suit/space/SS = wear_suit
 	SS.create_breaches(damtype, damage)
 


### PR DESCRIPTION
## About the Pull Request

- Space suit breaches now consider the damage after armor calculation instead of flat.
- Default breach damage threshold increased slightly.
- Cleaned up some comments/code.

## Why It's Good For The Game

- Let's say you get hit with a bullet(30 damage) in your nice void suit(50% bullet armor). Instead of getting all 30 damage transfered to the calculation proc and ending up with it being over threshold, ripping your suit apart, it takes as much damage as you did - 15, not enough(or barely enough) to damage the suit. A carp biting you with pitiful 10 damage will never damage your nice armored suit either. tl;dr - less breaches when wearing armored suits, so long as you aren't hit with something really dangerous.
- 3 damage threshold..? Really..? I get that it was for soft suits, but 3 damage is like the damage of a pen or random wrench. Chill out.
- Clean.

## Did you test it?

Yes.

## Authorship

Me.

## Changelog

:cl:
balance: Space suit breaches now consider the armor. Getting hit with a powerful sniper round of 50 damage will still pierce the suit, but not some random carp that bit you for 8 damage.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
