### PR TITLE
Fix chat loading on reconnect

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -101,6 +101,10 @@
 	if(machine)
 		machine.on_user_login(src)
 
+	if(SScharacter_setup.initialized && SSchat.initialized && !isnull(client.chatOutput))
+		if(client.get_preference_value(/datum/client_preference/goonchat) == GLOB.PREF_YES)
+			client.chatOutput.start()
+
 /mob/living/carbon/Login()
 	. = ..()
 	if(internals && internal)


### PR DESCRIPTION
## About the Pull Request

Ports Baystation12/Baystation12/pull/33938
Whenever mob logins - the chat will load for them properly.

## Why It's Good For The Game

Fix. For some reason, only new player login was loading the chat.

## Did you test it?

Yes.

## Authorship

[SuhEugene](https://github.com/SuhEugene)

## Changelog

:cl: SuhEugene
bugfix: Fixed goonchat loading for players re-entering game outside the lobby.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
