### PR TITLE
Glide size is consistent when orbiting

### DIFF
--- a/code/datums/orbit.dm
+++ b/code/datums/orbit.dm
@@ -6,7 +6,7 @@
 	var/lastprocess
 	var/matrix/init_transform
 
-/datum/orbit/New(atom/movable/_orbiter, var/atom/_orbiting, _lock)
+/datum/orbit/New(atom/movable/_orbiter, atom/_orbiting, _lock)
 	orbiter = _orbiter
 	orbiting = _orbiting
 	init_transform = _orbiter.transform
@@ -59,6 +59,8 @@
 		orbiter.stop_orbit()
 		return
 	orbiter.loc = targetloc
+	if(istype(orbiting, /atom/movable))
+		orbiter.glide_size = AM.glide_size
 	//TODO-LESH-DEL orbiter.update_parallax_contents()
 	orbiter.update_light()
 	lastloc = orbiter.loc


### PR DESCRIPTION
## About the Pull Request

Glide size of an orbiter is set to the glide size of the atom they are orbiting.

## Why It's Good For The Game

This fixes "jumpy" movement when a ghost is orbiting a moving object/mob.

## Did you test it?

No.

## Changelog

:cl:
fix: Ghosts will not longer "jump" while orbiting moving objects.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
