### PR TITLE
Fix multitile door opacity

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -38,9 +38,12 @@
 
 	var/autoset_access = TRUE // Determines whether the door will automatically set its access from the areas surrounding it. Can be used for mapping.
 
-	//Multi-tile doors
+	// Multi-tile doors
 	dir = SOUTH
+	/// Width of the door in tiles.
 	var/width = 1
+	/// layer view blocking fillers for multi-tile doors.
+	var/list/fillers
 
 	//Used for intercepting clicks on our turf. Set 0 to disable click interception
 	var/turf_hand_priority = 3
@@ -73,13 +76,7 @@
 		layer = open_layer
 
 
-	if(width > 1)
-		if(dir in list(EAST, WEST))
-			bound_width = width * world.icon_size
-			bound_height = world.icon_size
-		else
-			bound_width = world.icon_size
-			bound_height = width * world.icon_size
+	update_bounds()
 
 	if (turf_hand_priority)
 		set_extension(src, /datum/extension/turf_hand, turf_hand_priority)
@@ -430,13 +427,19 @@
 	do_animate("opening")
 	icon_state = "door0"
 	set_opacity(0)
+	if(width > 1)
+		set_fillers_opacity(0)
 	sleep(animation_time*0.3)
 	src.set_density(0)
+	if(width > 1)
+		set_fillers_density(0)
 	update_nearby_tiles()
 	sleep(animation_time*0.7)
 	src.layer = open_layer
 	update_icon()
 	set_opacity(0)
+	if(width > 1)
+		set_fillers_opacity(0)
 	operating = 0
 
 	if(autoclose)
@@ -457,12 +460,16 @@
 	do_animate("closing")
 	sleep(animation_time*0.3)
 	src.set_density(1)
+	if(width > 1)
+		set_fillers_density(1)
 	src.layer = closed_layer
 	update_nearby_tiles()
 	sleep(animation_time*0.7)
 	update_icon()
 	if(visible && !glass)
 		set_opacity(1)	//caaaaarn!
+		if(width > 1)
+			set_fillers_opacity(1)
 	operating = 0
 
 	//I shall not add a check every x ticks if a door has closed over some fire.
@@ -501,15 +508,9 @@
 
 /obj/machinery/door/Move(new_loc, new_dir)
 	update_nearby_tiles()
+	update_bounds()
 
 	. = ..()
-	if(width > 1)
-		if(dir in list(EAST, WEST))
-			bound_width = width * world.icon_size
-			bound_height = world.icon_size
-		else
-			bound_width = world.icon_size
-			bound_height = width * world.icon_size
 
 	if(.)
 		deconstruct(null, TRUE)
@@ -591,6 +592,67 @@
 	if(!requiresID() || allowed(null))
 		toggle()
 	return TRUE
+
+/**
+ * Checks which way the airlock is facing and adjusts the direction accordingly.
+ * For use with multi-tile airlocks.
+ */
+/obj/machinery/door/proc/get_adjusted_dir(dir)
+	if(dir in list(NORTH, SOUTH))
+		return EAST
+	else
+		return NORTH
+
+/**
+ * Sets the bounds of the airlock. For use with multi-tile airlocks.
+ * If the airlock is multi-tile, it will set the bounds to be the size of the airlock.
+ * If the airlock doesn't already have fillers, it will create them.
+ * If the airlock already has fillers, it will move them to the correct location.
+ */
+/obj/machinery/door/proc/update_bounds()
+	if(width <= 1)
+		return
+
+	if(dir in list(NORTH, SOUTH))
+		bound_width = width * world.icon_size
+		bound_height = world.icon_size
+	else
+		bound_width = world.icon_size
+		bound_height = width * world.icon_size
+
+	LAZYINITLIST(fillers)
+
+	var/adjusted_dir = get_adjusted_dir(dir)
+	var/obj/last_filler = src
+	for(var/i = 1, i < width, i++)
+		var/obj/airlock_filler_object/filler
+
+		if(length(fillers) < i)
+			filler = new
+			filler.pair_airlock(src)
+			fillers.Add(filler)
+		else
+			filler = fillers[i]
+
+		filler.loc = get_step(last_filler, adjusted_dir)
+		filler.density = density
+		filler.set_opacity(opacity)
+
+		last_filler = filler
+
+/obj/machinery/door/proc/set_fillers_density(density)
+	if(!length(fillers))
+		return
+
+	for(var/obj/airlock_filler_object/filler as anything in fillers)
+		filler.density = density
+
+/obj/machinery/door/proc/set_fillers_opacity(opacity)
+	if(!length(fillers))
+		return
+
+	for(var/obj/airlock_filler_object/filler as anything in fillers)
+		filler.set_opacity(opacity)
 
 // Public access
 

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -20,23 +20,6 @@
 	opacity = 1
 	assembly_type = /obj/structure/door_assembly/multi_tile
 
-/obj/machinery/door/airlock/multi_tile/New()
-	..()
-	SetBounds()
-
-/obj/machinery/door/airlock/multi_tile/Move()
-	. = ..()
-	SetBounds()
-
-/obj/machinery/door/airlock/multi_tile/proc/SetBounds()
-	if(dir in list(NORTH, SOUTH))
-		bound_width = width * world.icon_size
-		bound_height = world.icon_size
-	else
-		bound_width = world.icon_size
-		bound_height = width * world.icon_size
-
-
 /obj/machinery/door/airlock/multi_tile/on_update_icon(state=0, override=0)
 	..()
 	if(connections in list(NORTH, SOUTH, NORTH|SOUTH))
@@ -80,6 +63,55 @@
 		if(success)
 			dirs |= direction
 	connections = dirs
+
+/obj/airlock_filler_object
+	name = "airlock fluff"
+	desc = "You shouldn't be able to see this fluff!"
+	icon = null
+	icon_state = null
+	density = TRUE
+	opacity = TRUE
+	anchored = TRUE
+	invisibility = INVISIBILITY_MAXIMUM
+	atmos_canpass = CANPASS_DENSITY
+	/// The door/airlock this fluff panel is attached to
+	var/obj/machinery/door/filled_airlock
+
+/obj/airlock_filler_object/Bumped(atom/A)
+	if(isnull(filled_airlock))
+		crash_with("Someone bumped into an airlock filler with no parent airlock specified!")
+	return filled_airlock.Bumped(A)
+
+/obj/airlock_filler_object/Destroy()
+	filled_airlock = null
+	return ..()
+
+/// Multi-tile airlocks pair with a filler panel, if one goes so does the other.
+/obj/airlock_filler_object/proc/pair_airlock(obj/machinery/door/parent_airlock)
+	if(isnull(parent_airlock))
+		crash_with("Attempted to pair an airlock filler with no parent airlock specified!")
+
+	filled_airlock = parent_airlock
+	GLOB.destroyed_event.register(filled_airlock, src, .proc/no_airlock)
+
+/obj/airlock_filler_object/proc/no_airlock()
+	GLOB.destroyed_event.unregister(filled_airlock, src)
+	qdel_self()
+
+/// Multi-tile airlocks (using a filler panel) have special handling for movables with PASS_FLAG_GLASS
+/obj/airlock_filler_object/CanPass(atom/movable/mover, turf/target)
+	. = ..()
+	if(.)
+		return
+
+	if(istype(mover) && mover.checkpass(PASS_FLAG_GLASS))
+		return !opacity
+
+/obj/airlock_filler_object/singularity_act()
+	return
+
+/obj/airlock_filler_object/singularity_pull(S, current_size)
+	return
 
 /obj/machinery/door/airlock/multi_tile/command
 	door_color = COLOR_COMMAND_BLUE
@@ -133,7 +165,8 @@
 /obj/machinery/door/airlock/multi_tile/glass
 	name = "Glass Airlock"
 	hitsound = 'sound/effects/Glasshit.ogg'
-	glass = 1
+	glass = TRUE
+	opacity = 0
 
 /obj/machinery/door/airlock/multi_tile/glass/command
 	door_color = COLOR_COMMAND_BLUE


### PR DESCRIPTION
## About the Pull Request

Ports #Baystation12/Baystation12/pull/34156

## Why It's Good For The Game

Fixes issue where non-opaque(without glass) multi-tile doors had only one tile blocking the sight.

## Authorship

[SuhEugene](https://github.com/SuhEugene)

## Changelog

:cl: SuhEugene
bugfix: Fixed multitile doors opacity.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
