### PR TITLE
Changes simple mob burning damage calculation

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -309,7 +309,10 @@
 	if(burn_temperature < 1)
 		return
 
-	adjustBruteLoss(log(10, (burn_temperature + 10)))
+	// At minimum level of fire stacks and default(350) max body temp it will deal ~5 damage per tick
+	// At "absolute maximum" of around 100.000 burn_temperature it will deal ~80 damage per tick
+	var/burn_damage = round(sqrt(burn_temperature) * 0.25)
+	adjustBruteLoss(burn_damage)
 
 /mob/living/simple_animal/update_fire()
 	. = ..()


### PR DESCRIPTION
## About the Pull Request

Changes the burn damage calculation from using logarithm to square root and multiplication.

## Why It's Good For The Game

Would you look at that! The burn damage scaled from ~3 to a whole 5! Burn temperature..? ~700 gives 3 damage, 300000 gives 5. Fancy, isn't it? Now it scales a bit better, making fire not the worst option against simple mobs.

## Did you test it?

Not needed.

## Authorship

Me

## Changelog

:cl:
balance: Fire is more useful against simple mobs, especially infestation.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
