### PR TITLE
Update auto_cpr.dm

### DIFF
--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -23,7 +23,7 @@
 		if(M.wear_suit)
 			to_chat(user, SPAN_WARNING("Their [M.wear_suit] is in the way, remove it first!"))
 			return 1
-		user.visible_message(SPAN_NOTICE("[user] starts fitting [src] onto the [M]'s chest."))
+		user.visible_message(SPAN_NOTICE("[user] starts fitting [src] onto [M]'s chest."))
 
 		if(!do_after(user, 2 SECONDS, M))
 			return

--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -61,7 +61,7 @@
 		if(!skilled_setup && prob(20))
 			var/obj/item/organ/external/E = H.get_organ(BP_CHEST)
 			E.add_pain(15)
-			to_chat(H, "<span class='danger'>Your [E] is compressed painfully!</span>")	
+			to_chat(H, "<span class='danger'>Your chest is compressed painfully!</span>")	
 			if(prob(5))
 				E.fracture()
 		else


### PR DESCRIPTION
## About the Pull Request

Changes the Auto-Compressor/CPR message to "Your chest is compressed painfully" from "Your **the** chest is compressed painfully"

## Why It's Good For The Game

Fixes the grammatical error when wearing a compressor (literally unplayable)

## Did you test it?

**This needs to be tested.**
i was not able to get the game running locally, so someone will have to confirm this works


## Changelog

:cl:
-Fixes slight grammatical error in the auto-compressor
-Removes the [E] tag from the code in order to prevent grammatical errors (as frankly, the auto-compressor can only be applied to the chest)
/:cl:



