### PR TITLE
Magazine quickload

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -137,12 +137,12 @@
 	update_icon()
 
 /obj/item/ammo_magazine/afterattack(atom/target, mob/living/user, proximity_flag)
-	if(!proximity_flag || (!istype(target, /turf) && !istype(target, ammo_type)))
+	if(!proximity_flag || (!istype(target, /turf) && !istype(target, /obj/item/ammo_casing)))
 		return ..()
 
 	var/turf/T = istype(target, /turf) ? target : get_turf(target)
 	if(istype(target, /turf))
-		if(!locate(ammo_type) in T)
+		if(!locate(/obj/item/ammo_casing) in T)
 			return ..()
 
 	var/curr_ammo = length(stored_ammo)
@@ -154,17 +154,16 @@
 	if(!do_after(user, (max_ammo - curr_ammo) * 2, src))
 		return
 
-	var/ammo_count = 0
 	for(var/obj/item/ammo_casing/C in T)
 		if(stored_ammo.len >= max_ammo)
 			break
 		if(C.caliber != caliber)
 			continue
 		stored_ammo.Add(C)
-		ammo_count += 1
+		C.forceMove(src)
 
-	if(ammo_count)
-		to_chat(user, SPAN_NOTICE("You insert [ammo_count] casings into \the [src]."))
+	if(length(stored_ammo) - curr_ammo)
+		to_chat(user, SPAN_NOTICE("You insert [length(stored_ammo) - curr_ammo] casings into \the [src]."))
 		update_icon()
 	else
 		to_chat(user, SPAN_WARNING("You fail to collect any casings!"))


### PR DESCRIPTION
## About the Pull Request

- Clicking with magazine on a turf or casing will load all casings in the turfs that can be loaded;
- Fully unloading magazine now has do after and plays casing drop sounds.

## Why It's Good For The Game

- Quality Of Life;
- Prevents mistakes, plays silly sounds.

## Did you test it?

Yes.

## Authorship

Me.

## Changelog

:cl:
tweak: You can now collect all casings from a turf with a magazine. Click on a turf or casing to do so.
tweak: Fully unloading magazine takes 1 second to prevent accidents. Additionally, it plays casing drop sounds now.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
