### PR TITLE
Explosion damage tweak

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -477,25 +477,29 @@ meteor_act
 		if (1.0)
 			b_loss = 400
 			f_loss = 100
+			if(get_sound_volume_multiplier() >= 0.2)
+				ear_damage += 60
+				ear_deaf += 120
+			Paralyse(10)
 			var/atom/target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
 			throw_at(target, 200, 4)
-		if (2.0)
+		if(2.0)
 			b_loss = 60
 			f_loss = 60
 
-			if (get_sound_volume_multiplier() >= 0.2)
+			if(get_sound_volume_multiplier() >= 0.2)
 				ear_damage += 30
-				ear_deaf += 120
-			if (prob(50))
+				ear_deaf += 60
+			if(prob(50))
 				Paralyse(6)
 
 		if(3.0)
 			b_loss = 30
-			if (get_sound_volume_multiplier() >= 0.2)
+			if(get_sound_volume_multiplier() >= 0.2)
 				ear_damage += 15
-				ear_deaf += 60
-			if (prob(20))
-				Paralyse(2)
+				ear_deaf += 30
+			if(prob(20))
+				Weaken(2)
 
 	// focus most of the blast on one organ
 	apply_damage(0.7 * b_loss, BRUTE, null, DAM_EXPLODE, used_weapon = "Explosive blast")


### PR DESCRIPTION
## About the Pull Request

- Devastation explosion deafens and paralyzes people;
- Weakest explosion severity can only weaken, instead of paralyzing.

## Why It's Good For The Game

- Sometimes 400 brute isn't enough on its own and it was rather weird with strongest explosion being "weaker" than lower levels;
- Random weak explosions stunning you is rather weird as it is.

## Did you test it?

Noooo.

## Authorship

Me.

## Changelog

:cl:
balance: Low-severity explosions no longer paralyze people.
balance: Devastation severity explosions now paralyze and deafen people.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
