### PR TITLE
Fixes multi-tile doors

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -87,12 +87,12 @@
 /obj/machinery/door/Initialize()
 	set_extension(src, /datum/extension/penetration, /datum/extension/penetration/proc_call, .proc/CheckPenetration)
 	. = ..()
-	if(autoset_access)
 #ifdef UNIT_TEST
+	if(autoset_access)
 		if(length(req_access))
 			crash_with("A door with mapped access restrictions was set to autoinitialize access.")
 #endif
-		return INITIALIZE_HINT_LATELOAD
+	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/door/LateInitialize()
 	..()


### PR DESCRIPTION
## About the Pull Request

Makes multi-tile doors always late-initialize to make sure bounds are set correctly.

## Why It's Good For The Game

Didn't notice this bug due to weird way late initialization was used to be triggered (only with autoset access doors). This fixes it.

## Did you test it?

Yes.

## Authorship

Me.
