### PR TITLE
Fixes space drift of pulled objects

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -222,8 +222,6 @@ var/list/mob/living/forced_ambiance_list = new
 	if(!istype(A,/mob/living))	return
 
 	var/mob/living/L = A
-	if(!L.ckey)	return
-
 	if(!L.lastarea)
 		L.lastarea = get_area(L.loc)
 	var/area/newarea = get_area(L.loc)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -50,7 +50,7 @@
 	if(has_gravity())
 		return 1
 
-	if(length(pulledby))
+	if(pulledby)
 		return 1
 
 	if(throwing)

--- a/code/modules/mechs/mech_movement.dm
+++ b/code/modules/mechs/mech_movement.dm
@@ -15,20 +15,6 @@
 	if(Process_Spacemove()) //Handle here
 		return TRUE
 
-/mob/living/exosuit/Process_Spacemove()
-	. = ..()
-	if(.)
-		return
-
-	//Regardless of modules, emp prevents control
-	if(emp_damage >= EMP_MOVE_DISRUPT && prob(25))
-		return FALSE
-
-	var/obj/item/mech_equipment/ionjets/J = hardpoints[HARDPOINT_BACK]
-	if(istype(J))
-		if(J.allowSpaceMove())
-			return TRUE
-
 //Inertia drift making us face direction makes exosuit flight a bit difficult, plus newtonian flight model yo
 /mob/living/exosuit/set_dir(ndir)
 	if(inertia_dir && inertia_dir == ndir)
@@ -142,16 +128,24 @@
 	return TRUE
 
 /mob/living/exosuit/Process_Spacemove()
+	//Regardless of modules, emp prevents control
+	if(emp_damage >= EMP_MOVE_DISRUPT && prob(25))
+		return FALSE
+
 	if(has_gravity() || throwing || !isturf(loc) || length(grabbed_by) || check_space_footing() || locate(/obj/structure/lattice) in range(1, get_turf(src)))
 		anchored = TRUE
-		return 1
+		return TRUE
+
+	var/obj/item/mech_equipment/ionjets/J = hardpoints[HARDPOINT_BACK]
+	if(istype(J))
+		if(J.allowSpaceMove())
+			return TRUE
 
 	anchored = FALSE
-	return 0
+	return FALSE
 
 /mob/living/exosuit/check_space_footing()//mechs can't push off things to move around in space, they stick to hull or float away
-	for(var/thing in trange(1,src))
-		var/turf/T = thing
+	for(var/turf/T in trange(1, src))
 		if(T.density || T.is_wall() || T.is_floor())
 			return T
 


### PR DESCRIPTION
## About the Pull Request

Atoms that are being pulled are no longer affected by space drift, as intended.
Fixes mech space movement.

## Why It's Good For The Game

Fix.

## Did you test it?

Nope.

## Authorship

Me.

## Changelog

:cl:
fix: Pulled objects no longer drift in space.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
