### PR TITLE
Space turfs always have no gravity

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -305,26 +305,22 @@ var/list/mob/living/forced_ambiance_list = new
 	return has_gravity
 
 /area/space/has_gravity()
-	return 0
+	return FALSE
 
 /atom/proc/has_gravity()
-	var/area/A = get_area(src)
-	if(A && A.has_gravity())
-		return 1
-	return 0
-
-/mob/has_gravity()
-	if(!lastarea)
-		lastarea = get_area(src)
-	if(!lastarea || !lastarea.has_gravity())
-		return 0
-	return 1
+	var/turf/T = get_turf(src)
+	if(T)
+		return(T.has_gravity())
+	return FALSE
 
 /turf/has_gravity()
 	var/area/A = loc
 	if(A && A.has_gravity())
-		return 1
-	return 0
+		return TRUE
+	return FALSE
+
+/turf/space/has_gravity()
+	return FALSE
 
 /area/proc/get_dimensions()
 	var/list/res = list("x"=1,"y"=1)


### PR DESCRIPTION
## About the Pull Request

All has_gravity() checks now look at their turf, when possible.
Space turfs never have gravity.

## Why It's Good For The Game

When station/ship explodes - you will experience lack of gravity when moving through space tiles, even if area technically has gravity.

## Did you test it?

:)

## Authorship

Me.

## Changelog

:cl:
tweak: Space turfs never have any gravity, regardless of area.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
