### PR TITLE
Byond "\proper" and "\improper" are stripped from occupation prefs

### DIFF
--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -91,17 +91,17 @@
 
 	// Display everything.
 	for(var/job_map in SSjobs.job_lists_by_map_name)
-
+		var/map_name = strip_improper(job_map)
 		var/list/map_data = SSjobs.job_lists_by_map_name[job_map]
-		if(isnull(pref.hiding_maps[job_map]))
-			pref.hiding_maps[job_map] = map_data["default_to_hidden"]
+		if(isnull(pref.hiding_maps[map_name]))
+			pref.hiding_maps[map_name] = map_data["default_to_hidden"]
 
 		. += "<hr><table width = '100%''><tr>"
-		. += "<td width = '50%' align = 'right'><font size = 3><b>[capitalize(job_map)]</b></td>"
-		. += "<td width = '50%' align = 'left''><a href='?src=\ref[src];toggle_map=[job_map]'>[pref.hiding_maps[job_map] ? "Show" : "Hide"]</a></font></td>"
+		. += "<td width = '50%' align = 'right'><font size = 3><b>[capitalize(map_name)]</b></td>"
+		. += "<td width = '50%' align = 'left''><a href='?src=\ref[src];toggle_map=[map_name]'>[pref.hiding_maps[map_name] ? "Show" : "Hide"]</a></font></td>"
 		. += "</tr></table>"
 
-		if(!pref.hiding_maps[job_map])
+		if(!pref.hiding_maps[map_name])
 
 			. += "<hr/>"
 			. += "<table width='100%' cellpadding='1' cellspacing='0'><tr><td width='20%'>" // Table within a table for alignment, also allows you to easily add more columns.


### PR DESCRIPTION
## About the Pull Request

Occupations prefs now stripe the BYOND special characters before using them.

## Why It's Good For The Game

Should fix issues with hiding occupation lists of maps that have "\improper" in their name.

## Did you test it?

No..?

## Authorship

Me.

## Changelog

:cl:
bugfix: You should be able to hide the main map's job list in the occupation preferences now.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
