### PR TITLE
Aggregate's meatchips die 15 seconds after spawn

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/infestation/aggregate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/infestation/aggregate.dm
@@ -96,3 +96,4 @@
 	if(!throw_target)
 		throw_target = pick(getcircle(get_turf(src), 3))
 	M.throw_at(get_turf(throw_target), 3, 6)
+	addtimer(CALLBACK(M, /mob/living/simple_animal/hostile/infestation/meatchip/proc/TimedDeath), 15 SECONDS)

--- a/code/modules/mob/living/simple_animal/hostile/infestation/meatchip.dm
+++ b/code/modules/mob/living/simple_animal/hostile/infestation/meatchip.dm
@@ -37,3 +37,8 @@
 	default_pixel_y = rand(-6, 6)
 	pixel_x = default_pixel_x
 	pixel_y = default_pixel_y
+
+/mob/living/simple_animal/hostile/infestation/meatchip/proc/TimedDeath()
+	if(QDELETED(src) || stat == DEAD)
+		return
+	death()


### PR DESCRIPTION
## About the Pull Request

Makes aggregate-spawned meatchips die 15 seconds after spawn.

## Why It's Good For The Game

Makes it less tedious to fight the hordes of meatchips.
