### PR TITLE
Doors can completely destroyed. Fixes some of the door assembly code

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -175,7 +175,6 @@ var/list/airlock_overlays = list()
 	name = "Glass Airlock"
 	icon_state = "preview_glass"
 	hitsound = 'sound/effects/Glasshit.ogg'
-	maxhealth = 300
 	explosion_resistance = 5
 	opacity = 0
 	glass = 1
@@ -279,7 +278,6 @@ var/list/airlock_overlays = list()
 	opacity = 0
 
 /obj/machinery/door/airlock/external/glass
-	maxhealth = 300
 	explosion_resistance = 5
 	opacity = 0
 	glass = 1
@@ -346,6 +344,7 @@ var/list/airlock_overlays = list()
 	name = "Secure Airlock"
 	icon = 'icons/obj/doors/secure/door.dmi'
 	fill_file = 'icons/obj/doors/secure/fill_steel.dmi'
+	maxhealth = 2000
 	explosion_resistance = 20
 	secured_wires = 1
 	assembly_type = /obj/structure/door_assembly/door_assembly_highsecurity
@@ -384,6 +383,7 @@ var/list/airlock_overlays = list()
 	name = "Vault"
 	icon = 'icons/obj/doors/vault/door.dmi'
 	fill_file = 'icons/obj/doors/vault/fill_steel.dmi'
+	maxhealth = 2000
 	explosion_resistance = 20
 	opacity = 1
 	secured_wires = 1
@@ -733,7 +733,7 @@ About the new airlock wires panel:
 
 		if(stat & BROKEN)
 			damage_overlay = sparks_broken_file
-		else if(health < maxhealth * 3/4)
+		else if(health < broken_health * 0.75)
 			damage_overlay = sparks_damaged_file
 
 	if(welded)
@@ -1180,7 +1180,7 @@ About the new airlock wires panel:
 		..()
 	return
 
-/obj/machinery/door/airlock/deconstruct(mob/user, var/moved = FALSE)
+/obj/machinery/door/airlock/deconstruct(mob/user, moved = FALSE)
 	var/obj/structure/door_assembly/da = new assembly_type(src.loc)
 	if (istype(da, /obj/structure/door_assembly/multi_tile))
 		da.set_dir(src.dir)
@@ -1216,8 +1216,8 @@ About the new airlock wires panel:
 		electronics = null
 
 	qdel(src)
-
 	return da
+
 /obj/machinery/door/airlock/phoron/attackby(C as obj, mob/user as mob)
 	if(C)
 		ignite(is_hot(C))
@@ -1342,11 +1342,11 @@ About the new airlock wires panel:
 		return FALSE
 	return ..()
 
-/obj/machinery/door/airlock/New(var/newloc, var/obj/structure/door_assembly/assembly=null)
-	..()
+/obj/machinery/door/airlock/New(newloc, obj/structure/door_assembly/assembly=null)
+	. = ..()
 
 	//if assembly is given, create the new door from the assembly
-	if (assembly && istype(assembly))
+	if(assembly && istype(assembly))
 		assembly_type = assembly.type
 
 		electronics = assembly.electronics

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -24,7 +24,10 @@
 	var/normalspeed = 1
 	var/heat_proof = 0 // For glass airlocks/opacity firedoors
 	var/air_properties_vary_with_direction = 0
-	var/maxhealth = 300
+	var/maxhealth = 400
+	/// At this amount of health the door will be considered broken, but will not be destroyed/deconstructed \
+		By default it is at 20% of max health
+	var/broken_health
 	var/health
 	var/destroy_hits = 10 //How many strong hits it takes to destroy the door
 	var/min_force = 10 //minimum amount of force needed to damage the door with a melee weapon
@@ -85,6 +88,8 @@
 		set_extension(src, /datum/extension/turf_hand, turf_hand_priority)
 
 	health = maxhealth
+	if(!broken_health)
+		broken_health = round(maxhealth * 0.2)
 	update_connections(1)
 	update_icon()
 
@@ -176,8 +181,8 @@
 			do_animate("deny")
 	return
 
-/obj/machinery/door/bullet_act(var/obj/item/projectile/Proj)
-	..()
+/obj/machinery/door/bullet_act(obj/item/projectile/Proj)
+	. = ..()
 
 	var/damage = Proj.get_structure_damage()
 
@@ -195,14 +200,12 @@
 			qdel(src)
 
 	if(damage)
-		//cap projectile damage so that there's still a minimum number of hits required to break the door
-		take_damage(min(damage, 100))
+		take_damage(damage)
 
 
 
 /obj/machinery/door/hitby(AM as mob|obj, var/datum/thrownthing/TT)
-
-	..()
+	. = ..()
 	visible_message("<span class='danger'>[src.name] was hit by [AM].</span>")
 	var/tforce = 0
 	if(ismob(AM))
@@ -280,12 +283,14 @@
 		repairing = null
 		return
 
-	if (check_force(I, user))
+	if(check_force(I, user))
 		return
 
-	if(src.operating > 0 || isrobot(user))	return //borgs can't attack doors open because it conflicts with their AI-like interaction with them.
+	if(src.operating > 0 || isrobot(user))
+		return //borgs can't attack doors open because it conflicts with their AI-like interaction with them.
 
-	if(src.operating) return
+	if(src.operating)
+		return
 
 	if(src.allowed(user) && operable())
 		if(src.density)
@@ -299,7 +304,7 @@
 	update_icon()
 	return
 
-/obj/machinery/door/emag_act(var/remaining_charges)
+/obj/machinery/door/emag_act(remaining_charges)
 	if(density && operable())
 		do_animate("emag")
 		sleep(6)
@@ -325,16 +330,18 @@
 		take_damage(I.force)
 	return TRUE
 
-/obj/machinery/door/proc/take_damage(var/damage)
-	var/initialhealth = src.health
-	src.health = max(0, src.health - damage)
-	if(src.health <= 0 && initialhealth > 0)
-		src.set_broken(TRUE)
-	else if(src.health < src.maxhealth / 4 && initialhealth >= src.maxhealth / 4)
+/obj/machinery/door/proc/take_damage(damage)
+	var/initialhealth = health
+	health = max(0, health - damage)
+	if(health <= 0)
+		return deconstruct()
+	else if(health <= broken_health && initialhealth > 0)
+		set_broken(TRUE)
+	else if(health < broken_health * 0.25 && initialhealth >= broken_health * 0.25)
 		visible_message("\The [src] looks like it's about to break!" )
-	else if(src.health < src.maxhealth / 2 && initialhealth >= src.maxhealth / 2)
+	else if(health < broken_health * 0.5 && initialhealth >= broken_health * 0.5)
 		visible_message("\The [src] looks seriously damaged!" )
-	else if(src.health < src.maxhealth * 3/4 && initialhealth >= src.maxhealth * 3/4)
+	else if(health < broken_health * 0.75 && initialhealth >= broken_health * 0.75)
 		visible_message("\The [src] shows signs of damage!" )
 	update_icon()
 	return
@@ -342,13 +349,13 @@
 
 /obj/machinery/door/examine(mob/user)
 	. = ..()
-	if(src.health <= 0)
+	if(health <= broken_health)
 		to_chat(user, "\The [src] is broken!")
-	else if(src.health < src.maxhealth / 4)
+	else if(health < broken_health / 4)
 		to_chat(user, "\The [src] looks like it's about to break!")
-	else if(src.health < src.maxhealth / 2)
+	else if(health < broken_health / 2)
 		to_chat(user, "\The [src] looks seriously damaged!")
-	else if(src.health < src.maxhealth * 3/4)
+	else if(health < broken_health * 3/4)
 		to_chat(user, "\The [src] shows signs of damage!")
 
 	if (emagged && ishuman(user) && user.skill_check(SKILL_COMPUTER, SKILL_TRAINED))
@@ -536,7 +543,8 @@
 		. *= 2
 	. = round(.)
 
-/obj/machinery/door/proc/deconstruct(mob/user, var/moved = FALSE)
+/obj/machinery/door/proc/deconstruct(mob/user, moved = FALSE)
+	QDEL_NULL(src)
 	return null
 
 /obj/machinery/door/morgue

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -25,8 +25,8 @@
 	var/heat_proof = 0 // For glass airlocks/opacity firedoors
 	var/air_properties_vary_with_direction = 0
 	var/maxhealth = 400
-	/// At this amount of health the door will be considered broken, but will not be destroyed/deconstructed \
-		By default it is at 20% of max health
+	/// At this amount of health the door will be considered broken, but will not be destroyed/deconstructed
+	/// By default it is at 20% of max health
 	var/broken_health
 	var/health
 	var/destroy_hits = 10 //How many strong hits it takes to destroy the door

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -5,6 +5,11 @@
 	anchored = FALSE
 	density = TRUE
 	w_class = ITEM_SIZE_NO_CONTAINER
+
+	health_max = 50
+	health_min_damage = 8
+	damage_hitsound = 'sound/weapons/smash.ogg'
+
 	var/state = 0
 	var/base_icon_state = ""
 	var/base_name = "Airlock"
@@ -24,6 +29,11 @@
 /obj/structure/door_assembly/Initialize()
 	. = ..()
 	update_state()
+
+/obj/structure/door_assembly/handle_death_change(new_death_state)
+	if(new_death_state)
+		visible_message(SPAN_DANGER("[src] falls apart!"))
+		qdel(src)
 
 /obj/structure/door_assembly/door_assembly_hatch
 	icon = 'icons/obj/doors/hatch/door.dmi'

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -21,8 +21,9 @@
 	var/stripe_color = "none"
 	var/symbol_color = "none"
 
-	New()
-		update_state()
+/obj/structure/door_assembly/Initialize()
+	. = ..()
+	update_state()
 
 /obj/structure/door_assembly/door_assembly_hatch
 	icon = 'icons/obj/doors/hatch/door.dmi'
@@ -59,27 +60,28 @@
 	airlock_type = /obj/machinery/door/airlock/multi_tile
 	glass_type = /obj/machinery/door/airlock/multi_tile/glass
 
-	New()
-		if(dir in list(EAST, WEST))
-			bound_width = width * world.icon_size
-			bound_height = world.icon_size
-		else
-			bound_width = world.icon_size
-			bound_height = width * world.icon_size
-		update_state()
+/obj/structure/door_assembly/multi_tile/Initialize()
+	. = ..()
+	if(dir in list(EAST, WEST))
+		bound_width = width * world.icon_size
+		bound_height = world.icon_size
+	else
+		bound_width = world.icon_size
+		bound_height = width * world.icon_size
+	update_state()
 
-	Move()
-		. = ..()
-		if(dir in list(EAST, WEST))
-			bound_width = width * world.icon_size
-			bound_height = world.icon_size
-		else
-			bound_width = world.icon_size
-			bound_height = width * world.icon_size
+/obj/structure/door_assembly/multi_tile/Move()
+	. = ..()
+	if(dir in list(EAST, WEST))
+		bound_width = width * world.icon_size
+		bound_height = world.icon_size
+	else
+		bound_width = world.icon_size
+		bound_height = width * world.icon_size
 
 
 
-/obj/structure/door_assembly/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/door_assembly/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/pen))
 		var/t = sanitizeSafe(input(user, "Enter the name for the door.", src.name, src.created_name), MAX_NAME_LEN)
 		if(!t)	return
@@ -183,7 +185,7 @@
 
 	else if(istype(W, /obj/item/stack/material) && !glass)
 		var/obj/item/stack/material/S = W
-		var/material_name = S.get_material_name()		
+		var/material_name = S.get_material_name()
 		if (S)
 			if (S.get_amount() >= 1)
 				if(material_name == MATERIAL_GLASS && S.reinf_material)


### PR DESCRIPTION
## About the Pull Request

- Airlocks are now fully destructible. They, however, have slightly more overall health (300 -> 400), with vault and high-security having received a serius buff (2000 health).
- Fixes some code bullshit in door assembly files.

## Why It's Good For The Game

- Ever spent eternity shooting at the door with nothing happening? Yeah, doors are no longer made out of indestructibilium.
- Code.

## Did you test it?

Eh.

## Authorship

Me.

## Changelog

:cl:
tweak: Doors can now be destroyed with pure brute force. Some airlock types are now much resilient, however.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
