### PR TITLE
Incendiary bullets have a fire stack limit

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -131,7 +131,8 @@
 
 /obj/item/projectile/bullet/pistol/flame/attack_mob(mob/living/target_mob, distance, miss_modifier)
 	. = ..()
-	target_mob.adjust_fire_stacks(1)
+	if(target_mob.fire_stacks < 5)
+		target_mob.adjust_fire_stacks(1)
 	target_mob.IgniteMob()
 
 /obj/item/projectile/bullet/pistol/holdout
@@ -214,7 +215,8 @@
 
 /obj/item/projectile/bullet/shotgun/flame/attack_mob(mob/living/target_mob, distance, miss_modifier)
 	. = ..()
-	target_mob.adjust_fire_stacks(1)
+	if(target_mob.fire_stacks < 5)
+		target_mob.adjust_fire_stacks(3)
 	target_mob.IgniteMob()
 
 /obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets
@@ -252,7 +254,8 @@
 
 /obj/item/projectile/bullet/rifle/flame/attack_mob(mob/living/target_mob, distance, miss_modifier)
 	. = ..()
-	target_mob.adjust_fire_stacks(1)
+	if(target_mob.fire_stacks < 5)
+		target_mob.adjust_fire_stacks(1)
 	target_mob.IgniteMob()
 
 /obj/item/projectile/bullet/rifle/military
@@ -267,7 +270,8 @@
 
 /obj/item/projectile/bullet/rifle/military/flame/attack_mob(mob/living/target_mob, distance, miss_modifier)
 	. = ..()
-	target_mob.adjust_fire_stacks(1)
+	if(target_mob.fire_stacks < 5)
+		target_mob.adjust_fire_stacks(1)
 	target_mob.IgniteMob()
 
 /obj/item/projectile/bullet/rifle/t12
@@ -289,7 +293,8 @@
 
 /obj/item/projectile/bullet/rifle/ak47/flame/attack_mob(mob/living/target_mob, distance, miss_modifier)
 	. = ..()
-	target_mob.adjust_fire_stacks(1)
+	if(target_mob.fire_stacks < 5)
+		target_mob.adjust_fire_stacks(1)
 	target_mob.IgniteMob()
 
 /obj/item/projectile/bullet/rifle/m16


### PR DESCRIPTION
## About the Pull Request

Incendiary bullets will not apply fire stacks beyond 5.

## Why It's Good For The Game

30 fire stacks were a mistake.

## Did you test it?

NO

## Authorship

???

## Changelog

:cl:
balance: Incendiary bullets will no longer apply firestacks beyond reasonable limit.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
