### PR TITLE
Cooperative AI tweaks

### DIFF
--- a/code/modules/ai/ai_holder_communication.dm
+++ b/code/modules/ai/ai_holder_communication.dm
@@ -33,8 +33,9 @@
 		last_threaten_time = world.time
 
 		// All our friends nearby will also count as if they threatened the target
-		for(var/mob/living/L in GetFriendsInCallRange())
-			L.ai_holder.last_threaten_time = world.time
+		if(cooperative)
+			for(var/mob/living/L in GetFriendsInCallRange())
+				L.ai_holder.last_threaten_time = world.time
 
 		if (holder.say_list)
 			holder.ISay(pick(holder.say_list.say_threaten))
@@ -50,8 +51,9 @@
 			if (should_escalate)
 				threatening = FALSE
 				set_stance(STANCE_APPROACH)
-				for(var/mob/living/L in GetFriendsInCallRange())
-					L.ai_holder.set_stance(STANCE_APPROACH)
+				if(cooperative)
+					for(var/mob/living/L in GetFriendsInCallRange())
+						L.ai_holder.last_conflict_time = world.time
 				if (holder.say_list)
 					holder.ISay(pick(holder.say_list.say_escalate))
 					PlayMobSound(holder.say_list.speak_sounds)

--- a/code/modules/ai/ai_holder_cooperation.dm
+++ b/code/modules/ai/ai_holder_cooperation.dm
@@ -6,6 +6,9 @@
 	/// How far away calls for help will go for.
 	var/call_distance = 10
 
+	/// Percentage of max health below which we will call for help
+	var/help_request_min_health = 0.6
+
 	/// time when this mob is allowed to call for help
 	var/next_sent_help_request  = 0
 
@@ -50,7 +53,7 @@
 		faction_friends |= holder
 
 /datum/ai_holder/proc/ShouldRequestHelp()
-	if(holder.health >= holder.maxHealth * 0.6)
+	if(holder.health >= holder.maxHealth * help_request_min_health)
 		return FALSE
 	if(!length(faction_friends))
 		return FALSE

--- a/code/modules/ai/ai_holder_targeting.dm
+++ b/code/modules/ai/ai_holder_targeting.dm
@@ -261,6 +261,10 @@
 /datum/ai_holder/proc/on_attacked(atom/movable/AM)
 	last_conflict_time = world.time
 	add_attacker(AM)
+	// Attacking one is like attacking the entire faction
+	if(cooperative)
+		for(var/mob/living/L in GetFriendsInCallRange())
+			L.ai_holder.add_attacker(AM)
 
 /// Checks to see if an atom attacked us lately
 /datum/ai_holder/proc/check_attacker(atom/movable/A)


### PR DESCRIPTION
## About the Pull Request

When attacked, cooperative AI holders will signal all friendly mobs in range to add the attacker to their own lists.

## Why It's Good For The Game

Makes AI holders that threaten people instantly react to someone attacking their friends.

## Authorship

Me.
