### PR TITLE
Gamemode & Ticker tweaks

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(ticker)
 	var/round_progressing = 1       //Whether the lobby clock is ticking down.
 
 	var/list/bad_modes = list()     //Holds modes we tried to start and failed to.
-	var/revotes_allowed = 0         //How many times a game mode revote might be attempted before giving up.
+	var/revotes_allowed = 5         //How many times a game mode revote might be attempted before giving up.
 
 	var/list/round_start_events
 
@@ -33,6 +33,8 @@ SUBSYSTEM_DEF(ticker)
 
 	///Set to TRUE when an admin forcibly ends round.
 	var/forced_end = FALSE
+
+	var/skip_requirement_checks = FALSE
 
 	var/news_report
 
@@ -269,7 +271,11 @@ Helpers
 	SSjobs.divide_occupations(mode_datum) // Gives out jobs to everyone who was not selected to antag.
 
 	var/list/lobby_players = SSticker.lobby_players()
-	if(mode_datum.check_startable(lobby_players))
+	var/result = FALSE
+	if(!skip_requirement_checks)
+		result = mode_datum.check_startable(lobby_players)
+
+	if(result)
 		mode_datum.fail_setup()
 		SSjobs.reset_occupations()
 		bad_modes += mode_datum.config_tag

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1583,3 +1583,15 @@ var/global/floorIsLava = 0
 		qdel(P)
 		faxreply = null
 	return
+
+/datum/admins/proc/ToggleModeRequirementChecks()
+	set category = "Server"
+	set desc = "Toggle the gamemode requirement checks on/off. Toggling off will allow any gamemode to start regardless of readied players."
+	set name = "Toggle Gamemode Requirement Checks"
+
+	if (GAME_STATE > RUNLEVEL_LOBBY)
+		to_chat(usr, SPAN_WARNING("You cannot change the gamemode requirement checks after the game has started!"))
+		return
+
+	SSticker.skip_requirement_checks = !SSticker.skip_requirement_checks
+	log_and_message_admins("toggled the gamemode requirement checks [SSticker.skip_requirement_checks ? "OFF" : "ON"]")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -97,7 +97,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/remove_trader,
 	/datum/admins/proc/sendFax,
 	/client/proc/check_fax_history,
-	/client/proc/cmd_admin_notarget
+	/client/proc/cmd_admin_notarget,
+	/datum/admins/proc/ToggleModeRequirementChecks,
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,


### PR DESCRIPTION
## About the Pull Request

- Admins can skip game mode requirements check;
- By default, the round will not restart automatically for up to 5 times if gamemode failed to start.

## Why It's Good For The Game

- Admins can force-start gamemode regardless of pop or other requirements;
- Prevents the game from restarting because random player didn't ready up.
