### PR TITLE
Singularity tweaks

### DIFF
--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -31,6 +31,10 @@
 			toxmob(A)
 		if((istype(A,/obj/machinery/the_singularitygen))||(istype(A,/obj/singularity/)))
 			A:energy += energy
+			// Regardless of energy level - singularity will not lose power after being hit
+			var/obj/singularity/S = A
+			if(istype(S))
+				S.dissipate_track = -10
 		else if(istype(A,/obj/machinery/power/fusion_core))
 			var/obj/machinery/power/fusion_core/collided_core = A
 			if(particle_type && particle_type != "neutron")

--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -94,8 +94,8 @@
 
 /obj/effect/accelerated_particle/weak
 	movement_range = 8
-	energy = 5
+	energy = 0
 
 /obj/effect/accelerated_particle/strong
 	movement_range = 15
-	energy = 15
+	energy = 20

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -428,16 +428,29 @@
 	if(world.time < next_contained_check_time)
 		return last_contained_check
 
-	for(var/turf/T in range(6))
-		if(!ContainmentCheck(T))
-			last_contained_check = FALSE
-			// Might as well forget about checking entirely
-			next_contained_check_time = INFINITY
-			return FALSE
+	// Checks if we're contained from all cardinal directions
+	var/check_sum = 0
+	for(var/direction in GLOB.cardinal)
+		var/turf/T = get_turf(src)
+		for(var/i = 1 to 6)
+			T = get_step(T, direction)
+			if(!istype(T))
+				last_contained_check = FALSE
+				next_contained_check_time = world.time + 30 SECONDS
+				return FALSE
 
-	last_contained_check = TRUE
+			if(ContainmentCheck(T))
+				check_sum++
+				break
+
+	if(check_sum >= 4)
+		last_contained_check = TRUE
+		next_contained_check_time = world.time + 10 SECONDS
+		return TRUE
+
+	last_contained_check = FALSE
 	next_contained_check_time = world.time + 30 SECONDS
-	return TRUE
+	return FALSE
 
 /obj/singularity/proc/event()
 	var/numb = pick(1, 2, 3, 4, 5, 6)


### PR DESCRIPTION
## About the Pull Request

- Tweaked the containment check a little to be less ridiculous;
- Particle Accelerator will pause natural energy dissipation of the singularity.

## Why It's Good For The Game

- This makes sure the containment check is not super processing intensive and also does it right;
- Firing PA at 0 energy will keep singulo going. You could argue it makes singulo too trivial, but I'd rather not make singulo control something extremely annoying either.

## Did you test it?

Somewhat.

## Authorship

Me.

## Changelog

:cl:
tweak: Singularity will not lose energy even if Particle Accelerator has energy set to 0.
/:cl:
