### PR TITLE
Tiny fullscreen fix

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -449,19 +449,16 @@ client/verb/character_setup()
 
 	fullscreen = !fullscreen
 
-	if (fullscreen)
+	if(fullscreen)
 		winset(usr, "mainwindow", "titlebar=false")
 		winset(usr, "mainwindow", "can-resize=false")
 		winset(usr, "mainwindow", "is-maximized=false")
 		winset(usr, "mainwindow", "is-maximized=true")
-		winset(usr, "mainwindow", "statusbar=false")
 		winset(usr, "mainwindow", "menu=")
-//		winset(usr, "mainwindow.mainvsplit", "size=0x0")
 	else
 		winset(usr, "mainwindow", "is-maximized=false")
 		winset(usr, "mainwindow", "titlebar=true")
 		winset(usr, "mainwindow", "can-resize=true")
-		winset(usr, "mainwindow", "statusbar=true")
 		winset(usr, "mainwindow", "menu=menu")
 
 	fit_viewport()


### PR DESCRIPTION
## About the Pull Request

- Status bar is not removed in fullscreen. This has additional effect of fixing (?) the issue where fullscreen would constantly increase the size of the bottom bar by a few pixels every time it is used.

## Why It's Good For The Game

Better fullscreen.

## Did you test it?

Yes.
