### PR TITLE
Replaces destroyed event with a signal on following

### DIFF
--- a/code/modules/mob/observer/following.dm
+++ b/code/modules/mob/observer/following.dm
@@ -8,7 +8,7 @@
 /mob/observer/proc/stop_following()
 	if(!following)
 		return
-	GLOB.destroyed_event.unregister(following, src)
+	UnregisterSignal(following, COMSIG_PARENT_QDELETING)
 	GLOB.moved_event.unregister(following, src)
 	GLOB.dir_set_event.unregister(following, src)
 	following = null
@@ -16,7 +16,7 @@
 /mob/observer/proc/start_following(var/atom/a)
 	stop_following()
 	following = a
-	GLOB.destroyed_event.register(a, src, .proc/stop_following)
+	RegisterSignal(a, COMSIG_PARENT_QDELETING, .proc/stop_following)
 	GLOB.moved_event.register(a, src, .proc/keep_following)
 	GLOB.dir_set_event.register(a, src, /atom/proc/recursive_dir_set)
 	keep_following(new_loc = get_turf(following))


### PR DESCRIPTION
## About the Pull Request

Replaced destroyed event with QDELETING signal when following mobs.

## Why It's Good For The Game

This fixes being sent to nullspace when atom you are following gets destroyed.

## Did you test it?

Yes.

## Authorship

Me....
