### PR TITLE
Tegus are no longer dense

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/tegu.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/tegu.dm
@@ -14,6 +14,7 @@
 	health = 80
 	maxHealth = 80
 	movement_cooldown = 4
+	density = FALSE
 	pry_time = 7 SECONDS
 	pry_desc = "biting"
 	ai_holder_type = /datum/ai_holder/simple_animal/retaliate
@@ -22,4 +23,3 @@
 	name = "Atlas"
 	desc = "That's the captain's small, but mighty pet tegu. They may or may not have the blood of several crewmembers on them."
 	gender = MALE
-	ai_holder_type = /datum/ai_holder/simple_animal/retaliate/guard


### PR DESCRIPTION
## About the Pull Request

- Tegus are now not dense.
- Atlas doesn't have guard AI.

## Why It's Good For The Game

- Mostly to prevent Atlas from blocking passage in the Bridge.
- For same reasons.
