### PR TITLE
Fixes bluespace floor teleporting you even after its flooring is removed

### DIFF
--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -431,6 +431,9 @@
 /turf/simulated/floor/bluespace/Entered(mob/living/L)
 	. = ..()
 
+	if(!istype(flooring, initial_flooring))
+		return
+
 	if(istype(L) && prob(25))
 		L.visible_message(
 			SPAN_WARNING("\The [L] starts flickering in and out of existence as they step onto the bluespace!"),


### PR DESCRIPTION
## About the Pull Request

Title. When bluespace turf loses its bluespace flooring it will not teleport people.

## Why It's Good For The Game

Fix!
