### PR TITLE
Quickfix to shuttle power usage

### DIFF
--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -162,6 +162,14 @@
 	if(istype(old_location))
 		old_location.shuttle_departed(src)
 	destination.shuttle_arrived(src)
+	// Prevents power usage duplication
+	var/list/retally_areas
+	if(isarea(shuttle_area))
+		retally_areas = list(shuttle_area)
+	else if(islist(shuttle_area))
+		retally_areas = shuttle_area
+	for(var/area/A in retally_areas)
+		A.retally_power()
 	return TRUE
 
 //just moves the shuttle from A to B, if it can be moved


### PR DESCRIPTION
## About the Pull Request

For some ungodly reason shuttles multiply their power usage when moving. This is a quick/temporary fix.

## Why It's Good For The Game

Shuttles no longer consume 9 billions of watts.
