### PR TITLE
Protolathe & circuit imprinter can multi-queue items

### DIFF
--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -21,7 +21,7 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 
 	idle_power_usage = 30
 	active_power_usage = 2500
-	
+
 	machine_name = "circuit imprinter"
 	machine_desc = "Creates circuit boards by etching raw sheets of material with sulphuric acid. Part of an R&D network."
 
@@ -146,14 +146,14 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 		return
 	queue.Cut(index, index + 1)
 
-/obj/machinery/r_n_d/circuit_imprinter/proc/canBuild(var/datum/design/D)
+/obj/machinery/r_n_d/circuit_imprinter/proc/canBuild(datum/design/D, amount = 1)
 	for(var/M in D.materials)
-		if(materials[M] <= D.materials[M] * mat_efficiency)
-			return 0
+		if(materials[M] <= D.materials[M] * mat_efficiency * amount)
+			return FALSE
 	for(var/C in D.chemicals)
-		if(!reagents.has_reagent(C, D.chemicals[C] * mat_efficiency))
-			return 0
-	return 1
+		if(!reagents.has_reagent(C, D.chemicals[C] * mat_efficiency * amount))
+			return FALSE
+	return TRUE
 
 /obj/machinery/r_n_d/circuit_imprinter/proc/build(var/datum/design/D)
 	var/power = active_power_usage

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -145,14 +145,14 @@
 		return
 	queue.Cut(index, index + 1)
 
-/obj/machinery/r_n_d/protolathe/proc/canBuild(var/datum/design/D)
+/obj/machinery/r_n_d/protolathe/proc/canBuild(datum/design/D, amount = 1)
 	for(var/M in D.materials)
-		if(materials[M] < D.materials[M])
-			return 0
+		if(materials[M] < D.materials[M] * mat_efficiency * amount)
+			return FALSE
 	for(var/C in D.chemicals)
-		if(!reagents.has_reagent(C, D.chemicals[C]))
-			return 0
-	return 1
+		if(!reagents.has_reagent(C, D.chemicals[C] * mat_efficiency * amount))
+			return FALSE
+	return TRUE
 
 /obj/machinery/r_n_d/protolathe/proc/build(var/datum/design/D)
 	var/power = active_power_usage

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -321,7 +321,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				being_built = D
 				break
 		if(being_built)
-			linked_lathe.addToQueue(being_built)
+			var/amount_to_print = text2num(href_list["build_amount"])
+			for(var/i = 1 to amount_to_print)
+				linked_lathe.addToQueue(being_built)
 		screen = 3.1
 
 	else if(href_list["imprint"]) //Causes the Circuit Imprinter to build something.
@@ -333,7 +335,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				being_built = D
 				break
 		if(being_built)
-			linked_imprinter.addToQueue(being_built)
+			var/amount_to_print = text2num(href_list["build_amount"])
+			for(var/i = 1 to amount_to_print)
+				linked_imprinter.addToQueue(being_built)
 		screen = 4.1
 
 	else if(href_list["disposeI"])  //Causes the circuit imprinter to dispose of a single reagent (all of it)
@@ -722,15 +726,20 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					continue
 				var/temp_dat
 				for(var/M in D.materials)
-					temp_dat += ", [D.materials[M]] [CallMaterialName(M)]"
+					temp_dat += ", [D.materials[M]*(linked_imprinter ? linked_imprinter.mat_efficiency : 1)] [CallMaterialName(M)]"
 				for(var/T in D.chemicals)
 					temp_dat += ", [D.chemicals[T]*(linked_imprinter ? linked_imprinter.mat_efficiency : 1)] [CallReagentName(T)]"
 				if(temp_dat)
 					temp_dat = " \[[copytext(temp_dat, 3)]\]"
 				if(linked_lathe.canBuild(D))
-					dat += "<LI><B><A href='?src=\ref[src];build=[D.id]'>[D.name]</A></B>[temp_dat]"
+					dat += "<LI><B><A href='?src=\ref[src];build=[D.id]&build_amount=1'>[D.name]</A></B>"
+					if(linked_lathe.canBuild(D, 5))
+						dat += " <A href='?src=\ref[src];build=[D.id]&build_amount=5'>x5</A>"
+					if(linked_lathe.canBuild(D, 10))
+						dat += " <A href='?src=\ref[src];build=[D.id]&build_amount=10'>x10</A>"
 				else
-					dat += "<LI><B>[D.name]</B>[temp_dat]"
+					dat += "<LI><B>[D.name]</B>"
+				dat += "[temp_dat]"
 			dat += "</UL>"
 
 		if(3.2) //Protolathe Material Storage Sub-menu
@@ -808,7 +817,11 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				if(temp_dat)
 					temp_dat = " \[[copytext(temp_dat,3)]\]"
 				if(linked_imprinter.canBuild(D))
-					dat += "<LI><B><A href='?src=\ref[src];imprint=[D.id]'>[D.name]</A></B>[temp_dat]"
+					dat += "<LI><B><A href='?src=\ref[src];imprint=[D.id]&build_amount=1'>[D.name]</A></B>[temp_dat]"
+					if(linked_imprinter.canBuild(D, 5))
+						dat += " <A href='?src=\ref[src];imprint=[D.id]&build_amount=5'>x5</A>"
+					if(linked_imprinter.canBuild(D, 10))
+						dat += " <A href='?src=\ref[src];imprint=[D.id]&build_amount=10'>x10</A>"
 				else
 					dat += "<LI><B>[D.name]</B>[temp_dat]"
 			dat += "</UL>"


### PR DESCRIPTION
## About the Pull Request

- Protolathe and Circuit Imprinter now can queue x5 and x10 designs with a single click;
- Fixed a tiny oversight where console wouldn't display protolathe's material efficiency.

## Why It's Good For The Game

- Quality of Life all around. No longer should you spam-click random shit;
- Fix.

## Did you test it?

I refuse.

## Authorship

Me.

## Changelog

:cl:
tweak: You can now queue 5 or 10 designs at once on the protolathe and circuit imprinter.
fix: R&D console now properly displays material cost for protolathe designs if it was upgraded.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
