### PR TITLE
Fixes missing arguments in ability master creation

### DIFF
--- a/code/_onclick/hud/ability_screen_objects.dm
+++ b/code/_onclick/hud/ability_screen_objects.dm
@@ -326,8 +326,9 @@
 		active_overlay = null
 	return ..()
 
-/obj/screen/movable/ability_master/proc/add_spell(var/datum/spell/spell)
-	if(!spell) return
+/obj/screen/movable/ability_master/proc/add_spell(datum/spell/spell)
+	if(!spell)
+		return
 
 	if(spell.spell_flags & NO_BUTTON) //no button to add if we don't get one
 		return

--- a/code/modules/spells/_spell_procs.dm
+++ b/code/modules/spells/_spell_procs.dm
@@ -46,7 +46,7 @@
 
 /mob/proc/add_spell(datum/spell/spell_to_add, spell_base = "wiz_spell_ready")
 	if(!ability_master)
-		ability_master = new()
+		ability_master = new(null, src)
 	spell_to_add.holder = src
 	if(mind)
 		if(!mind.learned_spells)


### PR DESCRIPTION
## About the Pull Request

`Runtime in ability_screen_objects.dm, line 21: ERROR: ability_master's New() was not given an owner argument. This is a bug.`
This fixes it.

## Why It's Good For The Game

Fix