### PR TITLE
Minor floating chat tweaks

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -354,3 +354,9 @@
 	if(SEND_SIGNAL(src, COMSIG_ATOM_MOVABLE_DISPELL, dispell_strength) & COMPONENT_DISPELL_BLOCKED)
 		return FALSE
 	return TRUE
+
+/atom/movable/proc/GetOverheadTextXOffset()
+	return pixel_x
+
+/atom/movable/proc/GetOverheadTextYOffset()
+	return pixel_y

--- a/code/modules/mob/floating_message.dm
+++ b/code/modules/mob/floating_message.dm
@@ -59,20 +59,21 @@ var/global/list/floating_chat_colors = list()
 
 	for(var/client/C in show_to)
 		if(!C.mob.is_deaf() && C.get_preference_value(/datum/client_preference/floating_messages) == GLOB.PREF_SHOW)
-			if(C.mob.say_understands(null, language))
+			if(C.mob.say_understands(src, language))
 				C.images += understood
 			else
 				C.images += gibberish
 
 /proc/generate_floating_text(atom/movable/holder, message, style, size, duration, show_to)
 	var/image/I = image(null, get_atom_on_turf(holder))
-	I.layer=FLY_LAYER
+	I.plane = HUD_PLANE
+	I.layer = HUD_ABOVE_ITEM_LAYER
 	I.alpha = 0
 	I.maptext_width = CHAT_MESSAGE_WIDTH
 	I.maptext_height = CHAT_MESSAGE_HEIGHT
 	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
-	I.plane = EFFECTS_ABOVE_LIGHTING_PLANE
-	I.pixel_w = -round(I.maptext_width/2) + 16
+	I.pixel_w = -round(I.maptext_width/2) + 16 + holder.GetOverheadTextXOffset()
+	I.pixel_z = holder.GetOverheadTextYOffset()
 
 	style = "font-family: 'Small Fonts'; -dm-text-outline: 1px black; font-size: [size]px; line-height: 1.1; [style]"
 	I.maptext = "<center><span style=\"[style]\">[message]</span></center>"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1298,3 +1298,9 @@
 
 /mob/get_mass()
 	return mob_size
+
+/mob/GetOverheadTextXOffset()
+	return default_pixel_x
+
+/mob/GetOverheadTextYOffset()
+	return default_pixel_y


### PR DESCRIPTION
## About the Pull Request

- Floating messages are now displayed on HUD plane;
- *Probably* fixes weird stuff with chat text being different from floating one;
- The floating messages are now offset by the atom's pixel offsets.

## Why It's Good For The Game

- Makes them unaffected by certain things that could block the text, which isn't meant to be blocked;
- Idk? Fix? Hopefuly;
- Mostly affects large mobs, making it so text appears above them, not in them.

## Did you test it?

Yes.
