### PR TITLE
Limb tweaks

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -84,8 +84,8 @@
 // that dealing just enough burn damage to kill the player will cause the given
 // proportion of their max blood volume to be lost
 // (e.g. 0.6 == 60% lost if 200 burn damage is taken).
-#define FLUIDLOSS_WIDE_BURN 0.6 //for burns from heat applied over a wider area, like from fire
-#define FLUIDLOSS_CONC_BURN 0.4 //for concentrated burns, like from lasers
+#define FLUIDLOSS_WIDE_BURN 0.2 //for burns from heat applied over a wider area, like from fire
+#define FLUIDLOSS_CONC_BURN 0.1 //for concentrated burns, like from lasers
 
 // Damage above this value must be repaired with surgery.
 #define ROBOLIMB_SELF_REPAIR_CAP 30

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -106,7 +106,8 @@
 		else if (E.is_dislocated())
 			stance_damage += 0.5
 
-		if(E) limb_pain = E.can_feel_pain()
+		if(E)
+			limb_pain = E.can_feel_pain()
 
 	// Canes and crutches help you stand (if the latter is ever added)
 	// One cane mitigates a broken leg+foot, or a missing foot.
@@ -195,9 +196,9 @@
 					to_chat(src, SPAN_WARNING("You lose your balance as [affected.name] [pick("malfunctions", "freezes","shudders")]!"))
 			else
 				return
-	Weaken(4)
+	Weaken(1)
 
-/mob/living/carbon/human/proc/grasp_damage_disarm(var/obj/item/organ/external/affected)
+/mob/living/carbon/human/proc/grasp_damage_disarm(obj/item/organ/external/affected)
 	var/disarm_slot
 	switch(affected.body_part)
 		if(HAND_LEFT, ARM_LEFT)
@@ -217,14 +218,13 @@
 		return
 
 	if(BP_IS_ROBOTIC(affected))
-		visible_message("<B>\The [src]</B> drops what they were holding, \his [affected.name] malfunctioning!")
+		visible_message(SPAN_WARNING("<b>\The [src]</b> drops what they were holding, \his [affected.name] malfunctioning!"))
 
 		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
 		spark_system.set_up(5, 0, src)
 		spark_system.attach(src)
 		spark_system.start()
-		spawn(10)
-			qdel(spark_system)
+		QDEL_IN(spark_system, 10)
 
 	else
 		var/grasp_name = affected.name
@@ -236,13 +236,13 @@
 			var/emote_scream = pick("screams in pain", "lets out a sharp cry", "cries out")
 			var/emote_scream_alt = pick("scream in pain", "let out a sharp cry", "cry out")
 			visible_message(
-				"<B>\The [src]</B> [emote_scream] and drops what they were holding in their [grasp_name]!",
+				SPAN_WARNING("<b>\The [src]</b> [emote_scream] and drops what they were holding in their [grasp_name]!"),
 				null,
-				"You hear someone [emote_scream_alt]!"
+				SPAN_WARNING("You hear someone [emote_scream_alt]!"),
 			)
 			custom_pain("The sharp pain in your [affected.name] forces you to drop [thing]!", 30)
 		else
-			visible_message("<B>\The [src]</B> drops what they were holding in their [grasp_name]!")
+			visible_message(SPAN_WARNING("<b>\The [src]</b> drops what they were holding in their [grasp_name]!"))
 
 /mob/living/carbon/human/proc/sync_organ_dna()
 	var/list/all_bits = internal_organs|organs

--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -25,6 +25,7 @@ var/datum/robolimb/basic_robolimb
 	var/list/restricted_to = list()
 	var/list/applies_to_part = list() //TODO.
 	var/list/allowed_bodytypes = list(SPECIES_HUMAN, SPECIES_IPC, SPECIES_SKRELL, SPECIES_UNATHI)
+	var/limb_malfunction_threshold = 20
 
 /datum/robolimb/bishop
 	company = "Bishop"

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -38,7 +38,6 @@ exactly 144 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 1 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 413 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 4 ".Replace( matches" '\.Replace(_char)?\(' -P
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P


### PR DESCRIPTION
## About the Pull Request

- Blood loss from burn damage is severely reduced;
- Robotic limbs have lesser chance to malfunction and malfunction threshold is increased twofold;
- Weakening from damaged feet/legs is reduced from 4 to 1.

## Why It's Good For The Game

- Hit once with a laser? Say goodbye to all your blood. It's just not fun, especially against rapid-firing lasers;
- 10 damage threshold was simply ridiculous, making robotic limbs drop everything every ~5 seconds;
- Less silly stuns. Random stuns are bad!
