### PR TITLE
SCG simple mobs don't die to cold temps, removes unused variable

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/scg.dm
+++ b/code/modules/mob/living/simple_animal/hostile/scg.dm
@@ -18,6 +18,8 @@
 	natural_weapon = /obj/item/natural_weapon/punch
 	min_gas = list()
 	max_gas = list()
+	minbodytemp = 0
+	maxbodytemp = 3000
 	unsuitable_atmos_damage = 0
 	faction = "scg"
 	status_flags = CANPUSH

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -46,7 +46,6 @@
 	var/max_co2 = 5					// CO2 max
 	var/min_n2 = 0					// N2 min
 	var/max_n2 = 0					// N2 max
-	var/unsuitable_atoms_damage = 2	// This damage is taken when atmos doesn't fit all the requirements above
 
 	//Attack ranged settings
 	var/projectiletype				// The projectiles I shoot


### PR DESCRIPTION
## About the Pull Request

SCG explorer simple mobs now have minimum bodytemp set to 0 and max to 2000, preventing them from dying in space.
Remove "unsuitable_**atoms**_damage" variable from simple mobs.

## Why It's Good For The Game

Guys in space suits shouldn't be dying in space.
I think this variable was a typo...